### PR TITLE
Update icar_git_workflow.md

### DIFF
--- a/docs/howto/icar_git_workflow.md
+++ b/docs/howto/icar_git_workflow.md
@@ -67,7 +67,7 @@ The process would be as follows:
 
  * Add the main ICAR repo as the upstream remote, so you can easily merge changes that are made in the main ICAR repo into your own local repo
 
-        git add remote upstream ssh://git@github.com:NCAR/icar.git
+        git  remote add upstream ssh://git@github.com:NCAR/icar.git
 
  * Checkout the `develop` branch
 


### PR DESCRIPTION
Just notice that 
git  add remote  upstream ssh://git@github.com:NCAR/icar.git 
should be replaced by 
git  remote add upstream ssh://git@github.com:NCAR/icar.git
