### PR TITLE
bug fixes + mp update_interval works

### DIFF
--- a/io/lt_lut_io.f90
+++ b/io/lt_lut_io.f90
@@ -312,9 +312,10 @@ contains
             ncid=-1
             varid=-1
             ! Open the file. NF90_NOCLOBBER tells netCDF we want append to existing files
+            !   nf90_64bit_offset tells netCDF that this may be a really LARGE file and it needs to support >2GB
             if (present(open_new_file)) then
                 if (open_new_file) then
-                    call check( nf90_create(filename, NF90_CLOBBER, ncid), filename)
+                    call check( nf90_create(filename, or(NF90_CLOBBER,nf90_64bit_offset), ncid), filename)
                 endif
             endif
             if (ncid==-1) then
@@ -335,7 +336,7 @@ contains
             endif
 
             ! End define mode. This tells netCDF we are done defining metadata.
-            call check( nf90_enddef(ncid) )
+            call check( nf90_enddef(ncid), "enddef file:"//trim(filename) )
             ! write the actual data to the file
             if (error == 0) then
                 call check( nf90_put_var(ncid, varid, data_out), trim(filename)//":"//trim(varname))
@@ -393,7 +394,7 @@ contains
             ! Open the file. NF90_NOCLOBBER tells netCDF we want append to existing files
             if (present(open_new_file)) then
                 if (open_new_file) then
-                    call check( nf90_create(filename, NF90_CLOBBER, ncid), filename)
+                    call check( nf90_create(filename, or(NF90_CLOBBER,nf90_64bit_offset), ncid), filename)
                 endif
             endif
             if (ncid==-1) then

--- a/main/data_structures.f90
+++ b/main/data_structures.f90
@@ -388,7 +388,7 @@ module data_structures
         real :: t_adjust
         logical :: Ef_rw_l, EF_sw_l
         
-        real :: update_interval
+        integer :: update_interval ! maximum number of seconds between updates
         integer :: top_mp_level ! top model level to process in the microphysics
         real :: local_precip_fraction
     end type mp_options_type

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -629,7 +629,7 @@ contains
         logical :: Ef_rw_l, EF_sw_l
         integer :: top_mp_level
         real :: local_precip_fraction
-        real :: update_interval
+        integer :: update_interval
 
         namelist /mp_parameters/ Nt_c,TNO, am_s, rho_g, av_s,bv_s,fv_s,av_g,bv_g,av_i,Ef_si,Ef_rs,Ef_rg,Ef_ri,&     ! trude added Nt_c, TNO
                               C_cubes,C_sqrd, mu_r, Ef_rw_l, Ef_sw_l, t_adjust, top_mp_level, local_precip_fraction, update_interval

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -135,23 +135,51 @@ contains
 
         ! convection can modify wind field, and ideal doesn't rebalance winds every timestep
         if ((options%physics%convection.ne.0).and.(options%ideal)) then
-            if (options%warning_level>1) then
+            if (options%warning_level>3) then
                 write(*,*) "WARNING WARNING WARNING"
                 write(*,*) "WARNING, Running convection in ideal mode may be bad..."
                 write(*,*) "WARNING WARNING WARNING"
             endif
             if (options%warning_level==10) then
+                write(*,*) "Set warning_level<10 to continue"
                 stop
             endif
         endif
-        if ((options%physics%landsurface>0).and.(options%physics%boundarylayer==0)) then
-            if (options%warning_level>0) then
+        ! if using a real LSM, feedback will probably keep hot-air from getting even hotter, so not likely a problem
+        if ((options%physics%landsurface>1).and.(options%physics%boundarylayer==0)) then
+            if (options%warning_level>2) then
                 write(*,*) "WARNING WARNING WARNING"
                 write(*,*) "WARNING, Running LSM without PBL may overheat the surface and CRASH the model. "
                 write(*,*) "WARNING WARNING WARNING"
             endif
+            if (options%warning_level>=7) then
+                write(*,*) "Set warning_level<7 to continue"
+                stop
+            endif
+        endif
+        ! if using perscribed LSM fluxes, no feedbacks are present, so the surface layer is likely to overheat.
+        if ((options%physics%landsurface==1).and.(options%physics%boundarylayer==0)) then
+            if (options%warning_level>0) then
+                write(*,*) "WARNING WARNING WARNING"
+                write(*,*) "WARNING, Running prescribed LSM fluxes without a PBL overheat the surface and CRASH. "
+                write(*,*) "WARNING WARNING WARNING"
+            endif
             if (options%warning_level>=5) then
                 write(*,*) "Set warning_level<5 to continue"
+                stop
+            endif
+        endif
+        
+        ! prior to v 0.9.3 this was assumed, so throw a warning now just in case. 
+        if ((options%z_is_geopotential==.False.).and.(options%zvar=="PH")) then
+            if (options%warning_level>1) then
+                write(*,*) "WARNING WARNING WARNING"
+                write(*,*) "WARNING z variable is no longer assumed to be geopotential height when it is 'PH'."
+                write(*,*) "WARNING To treat z as geopotential, set z_is_geopotential=True in the namelist. "
+                write(*,*) "WARNING WARNING WARNING"
+            endif
+            if (options%warning_level>=7) then
+                write(*,*) "Set warning_level<7 to continue"
                 stop
             endif
         endif

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -171,7 +171,7 @@ contains
         endif
         
         ! prior to v 0.9.3 this was assumed, so throw a warning now just in case. 
-        if ((options%z_is_geopotential==.False.).and.(options%zvar=="PH")) then
+        if ((options%z_is_geopotential .eqv. .False.).and.(options%zvar=="PH")) then
             if (options%warning_level>1) then
                 write(*,*) "WARNING WARNING WARNING"
                 write(*,*) "WARNING z variable is no longer assumed to be geopotential height when it is 'PH'."

--- a/main/time_step.f90
+++ b/main/time_step.f90
@@ -358,7 +358,7 @@ contains
             model_time=model_time+dt
             if (dt>1e-5) then
                 call advect(domain,options,dt)
-                call mp(domain,options,dt)
+                call mp(domain,options,dt, model_time)
                 call rad(domain,options,model_time/86400.0+50000, dt)
                 call lsm(domain,options,dt,model_time)
                 call pbl(domain,options,dt)

--- a/physics/linear_winds.f90
+++ b/physics/linear_winds.f90
@@ -753,7 +753,7 @@ contains
         deallocate(savedU,savedV)
 
         if (options%lt_options%write_LUT) then
-            if (options%lt_options%read_LUT) then
+            if ((options%lt_options%read_LUT) .and. (error == 0)) then
                 print*, "Not writing Linear Theory LUT to file because LUT was read from file"
             else
                 print*, "Writing u-LUT to file: ", trim(options%lt_options%u_LUT_Filename)

--- a/physics/mp_driver.f90
+++ b/physics/mp_driver.f90
@@ -27,21 +27,21 @@
 !!----------------------------------------------------------
 module microphysics
     use data_structures
-    use module_mp_thompson, only: mp_gt_driver,thompson_init
-    use module_mp_simple, only:mp_simple_driver
+    use module_mp_thompson, only:   mp_gt_driver, thompson_init
+    use module_mp_simple,   only:   mp_simple_driver
     implicit none
-!   these are now defined in data_structures.f90
-!   real, parameter :: LH_vaporization=2260000.0 ! J/kg
-!   real, parameter :: R=287.058 ! J/(kg K) specific gas constant for air
-!   real, parameter :: cp = 1012.0 ! specific heat capacity of moist STP air? J/kg/K
-!   real, parameter :: g=9.81 ! gravity m/s^2
 
+    ! permit the microphysics to update on a longer time step than the advection
+    integer :: update_interval
+    real*8 :: last_model_time
+    ! temporary variables
     real,allocatable,dimension(:,:) :: SR, last_rain, last_snow, this_precip
     integer, parameter :: npoints=8
     real,    dimension(npoints) :: dist_fraction = [ 0.1,0.15,0.1, 0.15,0.15, 0.1,0.15,0.1]
     integer, dimension(npoints) :: x_list = [ -1,0,1, -1,1, -1,0,1]
     integer, dimension(npoints) :: y_list = [ 1,1,1, 0,0, -1,-1,-1]
 contains
+    
     subroutine mp_init(options)
         implicit none
         type(options_type), intent(in)::options
@@ -51,7 +51,9 @@ contains
             write(*,*) "    Thompson Microphysics"
             call thompson_init(options%mp_options)
         endif
-        
+
+        update_interval = options%mp_options%update_interval
+        last_model_time = -999
     end subroutine mp_init
     
     subroutine distribute_precip(current_precip, last_precip, local_fraction)
@@ -82,15 +84,15 @@ contains
             end do
         end do
                 
-        
-        
     end subroutine distribute_precip
     
-    subroutine mp(domain,options,dt_in)
+    subroutine mp(domain,options,dt_in, model_time)
         implicit none
         type(domain_type),intent(inout)::domain
         type(options_type),intent(in)::options
         real,intent(in)::dt_in
+        double precision, intent(in) :: model_time
+        real :: mp_dt
         integer ::ids,ide,jds,jde,kds,kde,itimestep=1
         integer ::its,ite,jts,jte,kts,kte, nx,ny
         
@@ -102,6 +104,11 @@ contains
         jds=1
         jde=size(domain%qv,3)
         ny=jde
+
+        ! if this is the first time mp is called, set last time such that mp will update
+        if (last_model_time==-999) then
+            last_model_time = (model_time-max(real(update_interval),dt_in))
+        endif
         
         ! snow rain ratio
         if (.not.allocated(SR)) then
@@ -123,44 +130,62 @@ contains
             allocate(this_precip(nx,ny))
             this_precip=0
         endif
-        
-        if (options%physics%microphysics==kMP_THOMPSON) then
-            kts=kds
-            kte=kde
-            if (options%mp_options%top_mp_level>0) then
-                kte=min(kte, options%mp_options%top_mp_level)
+
+        ! only run the microphysics if the next time step would put it over the update_interval time
+        if (((model_time+dt_in)-last_model_time)>=update_interval) then
+            ! calculate the actual time step for the microphysics
+            mp_dt = model_time-last_model_time
+            ! reset the counter so we know that *this* is the last time we've run the microphysics
+            last_model_time = model_time
+            
+            ! If we are going to distribute the current precip over a few grid cells, we need to keep track of
+            ! the last_precip so we know how much fell
+            if (options%mp_options%local_precip_fraction<1) then
+                last_rain=domain%rain
+                last_snow=domain%snow
             endif
-            if (options%ideal) then
-                ! for ideal runs process the boundaries as well to be consistent with WRF
-                its=ids;ite=ide
-                jts=jds;jte=jde
-            else
-                its=ids+1;ite=ide-1
-                jts=jds+1;jte=jde-1
+            
+            ! run the thompson microphysics
+            if (options%physics%microphysics==kMP_THOMPSON) then
+                kts=kds
+                kte=kde
+                ! set the current tile to the top layer to process microphysics for
+                if (options%mp_options%top_mp_level>0) then
+                    kte=min(kte, options%mp_options%top_mp_level)
+                endif
+                if (options%ideal) then
+                    ! for ideal runs process the boundaries as well to be consistent with WRF
+                    its=ids;ite=ide
+                    jts=jds;jte=jde
+                else
+                    its=ids+1;ite=ide-1
+                    jts=jds+1;jte=jde-1
+                endif
+                ! call the thompson microphysics
+                call mp_gt_driver(domain%qv, domain%cloud, domain%qrain, domain%ice, &
+                                domain%qsnow, domain%qgrau, domain%nice, domain%nrain, &
+                                domain%th, domain%pii, domain%p, domain%dz_inter, mp_dt, itimestep, &
+                                domain%rain, last_rain, &       ! last_rain is not used in thompson
+                                domain%snow, last_snow, &       ! last_snow is not used in thompson
+                                domain%graupel, this_precip, &  ! this_precip is not used in thompson
+                                SR, &
+                                ids,ide, jds,jde, kds,kde, &    ! domain dims
+                                ids,ide, jds,jde, kds,kde, &    ! memory dims
+                                its,ite, jts,jte, kts,kte)      ! tile dims
+                                
+            elseif (options%physics%microphysics==kMP_SB04) then
+                ! call the simple microphysics routine of SB04
+                call mp_simple_driver(domain%p,domain%th,domain%pii,domain%rho,domain%qv,domain%cloud, &
+                                domain%qrain,domain%qsnow,domain%rain,domain%snow,&
+                                mp_dt,domain%dz,ide,jde,kde)
             endif
-            last_rain=domain%rain
-            last_snow=domain%snow
-            call mp_gt_driver(domain%qv, domain%cloud, domain%qrain, domain%ice, &
-                            domain%qsnow, domain%qgrau, domain%nice, domain%nrain, &
-                            domain%th, domain%pii, domain%p, domain%dz_inter, dt_in, itimestep, &
-                            domain%rain, domain%rain, &
-                            domain%snow, domain%snow, &
-                            domain%graupel, domain%graupel, &
-                            SR, &
-                            ids,ide, jds,jde, kds,kde, &    ! domain dims
-                            ids,ide, jds,jde, kds,kde, &    ! memory dims
-                            its,ite, jts,jte, kts,kte)      ! tile dims
-        elseif (options%physics%microphysics==kMP_SB04) then
-            call mp_simple_driver(domain%p,domain%th,domain%pii,domain%rho,domain%qv,domain%cloud, &
-                            domain%qrain,domain%qsnow,domain%rain,domain%snow,&
-                            dt_in,domain%dz,ide,jde,kde)
+            
+            if (options%mp_options%local_precip_fraction<1) then
+                call distribute_precip(domain%rain, last_rain, options%mp_options%local_precip_fraction)
+                call distribute_precip(domain%snow, last_snow, options%mp_options%local_precip_fraction)
+            endif
         endif
         
-        if (options%mp_options%local_precip_fraction<1) then
-            call distribute_precip(domain%rain, last_rain, options%mp_options%local_precip_fraction)
-            call distribute_precip(domain%snow, last_snow, options%mp_options%local_precip_fraction)
-        endif
-                        
     end subroutine mp
     
     subroutine mp_finish()

--- a/physics/mp_thompson.f90
+++ b/physics/mp_thompson.f90
@@ -996,9 +996,13 @@
 !                         ' at i,j,k=', i,j,k
              ! CALL wrf_debug(150, mp_debug)
 !             endif
-            if (qv1d(k) .lt. 0.0) then
+            if (qv1d(k) .lt. 1.E-7) then
              if (k.lt.kte-2 .and. k.gt.kts+1) then
                 qv(i,k,j) = 0.5*(qv(i,k-1,j) + qv(i,k+1,j))
+                ! note, if qv(i,k+1,j) < 0 then qv(i,k,j) could still be < 0
+                if (qv1d(k) .lt. 1.E-7) then
+                    qv(i,k,j) = 1.E-7
+                endif
              else
                 qv(i,k,j) = 1.E-7
              endif


### PR DESCRIPTION
- namelist mp_parameters now support option update_interval and this code works
    - microphysics will only be updated as close to a maximum time interval (update_interval) as possible
- Changed lt_lut_io to create 64-bit offset files so it can write variables greater than 2GB in size. 
- Added check for z_is_geopotential=False and zvar="PH" (will print warning)
- fixed gfortran bug (can't use == to compare logicals)
- will now write the lt_lut if write=true and read=true when there is an error reading. 
- added more doxygen headers, added a better check for qv<0 in mp_thompson
