### PR TITLE
made lt_lut files NF90_NETCDF4 to support >4GB variable

### DIFF
--- a/io/lt_lut_io.f90
+++ b/io/lt_lut_io.f90
@@ -312,10 +312,10 @@ contains
             ncid=-1
             varid=-1
             ! Open the file. NF90_NOCLOBBER tells netCDF we want append to existing files
-            !   nf90_64bit_offset tells netCDF that this may be a really LARGE file and it needs to support >2GB
+            !   NF90_NETCDF4 tells netCDF that this may be a really LARGE file and it needs to support >4GB/variable
             if (present(open_new_file)) then
                 if (open_new_file) then
-                    call check( nf90_create(filename, or(NF90_CLOBBER,nf90_64bit_offset), ncid), filename)
+                    call check( nf90_create(filename, or(NF90_CLOBBER,NF90_NETCDF4), ncid), filename)
                 endif
             endif
             if (ncid==-1) then
@@ -392,9 +392,10 @@ contains
             ncid=-1
             varid=-1
             ! Open the file. NF90_NOCLOBBER tells netCDF we want append to existing files
+            ! NF90_NETCDF4 is necessary to support variables >4GB in size
             if (present(open_new_file)) then
                 if (open_new_file) then
-                    call check( nf90_create(filename, or(NF90_CLOBBER,nf90_64bit_offset), ncid), filename)
+                    call check( nf90_create(filename, or(NF90_CLOBBER,NF90_NETCDF4), ncid), filename)
                 endif
             endif
             if (ncid==-1) then


### PR DESCRIPTION
Previous change to 64-bit offset files only supported >2GB variables, but LUTs can be larger still! 
Now requiring LUTs to be NetCDF4 files (requires HDF5 support) at some point I probably need to add a line that tests for HDF5 support and simply doesn't read (or write) LUTs if it is not available. 