### PR TITLE
online biascorrection

### DIFF
--- a/helpers/setup_next_run.py
+++ b/helpers/setup_next_run.py
@@ -22,28 +22,29 @@ def find_last_output(options_file):
     filelist=glob.glob(outputfile+"*00.nc")
     filelist.sort()
 
-    return filelist[-1], filelist[-2]
+    return filelist[-1], filelist[-2], outputfile
 
-def load_last_date(filename):
+def load_last_date(filename, prefix):
     """docstring for load_last_date"""
     time_data=mygis.read_nc(filename,"time").data
     last_hour=len(time_data)
     
-    year=filename.split("_")[-4]
-    month=filename.split("_")[-3]
-    day=filename.split("_")[-2]
-    hour=last_hour-1 # look back one time step incase it hadn't finished writing the last timestep
+    date_string = filename.replace(prefix,"")
+    year    = date_string.split("_")[-4]
+    month   = date_string.split("_")[-3]
+    day     = date_string.split("_")[-2]
+    hour    = last_hour-1 # look back one time step incase it hadn't finished writing the last timestep
     
     return "{0}, {1}, {2}, {3}, 0, 0".format(year,month,day,hour),hour
     
     
 def main(options_file, template_file):
     """docstring for main"""
-    restart_file,backup_file=find_last_output(options_file)
-    restart_date,hour=load_last_date(restart_file)
+    restart_file,backup_file,output_prefix=find_last_output(options_file)
+    restart_date,hour=load_last_date(restart_file, output_prefix)
     if hour<2:
         restart_file=backup_file
-        restart_date,hour=load_last_date(restart_file)
+        restart_date,hour=load_last_date(restart_file, output_prefix)
     
     print("Using restart file: "+restart_file)
     print("      restart date: "+restart_date)

--- a/io/output.f90
+++ b/io/output.f90
@@ -962,7 +962,7 @@ contains
         endif
         
         ! surface pressure
-        call check( nf90_put_var(ncid, varid(20), domain%psfc, start_two_D), trim(filename)//":ps" )
+        call check( nf90_put_var(ncid, varid(40), domain%psfc, start_two_D), trim(filename)//":ps" )
         
         ! Write precip variables (rain, snow, graupel, crain) adjusting for the internal precip bucket
         call tip_precip_to_buckets(domain)

--- a/io/output.f90
+++ b/io/output.f90
@@ -20,7 +20,7 @@ module output
     public :: write_domain, output_init
     
     integer, parameter :: ndims = 4     !> number of dimensions in output (x,y,z,t)
-    integer, parameter :: nvars = 39    !> current number of vars = 39
+    integer, parameter :: nvars = 41    !> current number of vars = 41
     !> This will be the netCDF ID for the file and data variable.
     integer :: ncid, temp_id
     !> dimension IDs
@@ -47,7 +47,7 @@ module output
     integer :: start_two_D(3)  = [1,1,1]
     integer :: start_scalar(1) = [1]
 
-    real, allocatable, dimension(:,:) :: last_rain
+    real, allocatable, dimension(:,:) :: last_rain, last_snow
     logical :: surface_io_only
     ! We are writing 3D data, a (ny x nz x nx) grid or (ny x nsoil x nx) grid
     integer :: nx,ny,nz,i,nsoil
@@ -93,6 +93,7 @@ contains
                     do while (domain%snow(i,j)>kPRECIP_BUCKET_SIZE)
                         domain%snow(i,j) = domain%snow(i,j)-kPRECIP_BUCKET_SIZE
                         domain%snow_bucket(i,j) = domain%snow_bucket(i,j)+1
+                        last_snow(i,j)=last_snow(i,j)-kPRECIP_BUCKET_SIZE
                     end do
                 endif
                 if (domain%graupel(i,j)>kPRECIP_BUCKET_SIZE) then
@@ -465,6 +466,14 @@ contains
             call check( nf90_put_att(ncid,temp_id,"units","m"))
             varid(20)=temp_id
         endif
+
+        ! surface pressure
+        call check( nf90_def_var(ncid, "ps", NF90_REAL, dimtwo_time, temp_id), trim(err)//"ps")
+        call check( nf90_put_att(ncid,temp_id,"standard_name","surface_air_pressure"))
+        call check( nf90_put_att(ncid,temp_id,"long_name","Surface Air Pressure"))
+        call check( nf90_put_att(ncid,temp_id,"units","Pa"))
+        varid(40)=temp_id
+
     
         ! surface precip fluxes
         call check( nf90_def_var(ncid, "rain", NF90_REAL, dimtwo_time, temp_id), trim(err)//"rain" )
@@ -475,10 +484,16 @@ contains
 
         call check( nf90_def_var(ncid, "rain_rate", NF90_REAL, dimtwo_time, temp_id), trim(err)//"rain_rate" )
         call check( nf90_put_att(ncid,temp_id,"standard_name","precipitation_amount"))
-        call check( nf90_put_att(ncid,temp_id,"long_name","Combined large scale and convective rain, snow and graupel"))
+        call check( nf90_put_att(ncid,temp_id,"long_name","Time step total combined rain, snow and graupel"))
         call check( nf90_put_att(ncid,temp_id,"units","kg m-2"))
         varid(32)=temp_id
     
+        call check( nf90_def_var(ncid, "snow_rate", NF90_REAL, dimtwo_time, temp_id), trim(err)//"snow_rate" )
+        call check( nf90_put_att(ncid,temp_id,"standard_name","snowfall_amount"))
+        call check( nf90_put_att(ncid,temp_id,"long_name","Time step total snowfall (liquid equivalent)"))
+        call check( nf90_put_att(ncid,temp_id,"units","kg m-2"))
+        varid(41)=temp_id
+
         call check( nf90_def_var(ncid, "snow", NF90_REAL, dimtwo_time, temp_id), trim(err)//"snow" )
         call check( nf90_put_att(ncid,temp_id,"standard_name","snowfall_amount"))
         call check( nf90_put_att(ncid,temp_id,"long_name","Combined large scale and convective snow (accumulated)"))
@@ -702,11 +717,15 @@ contains
         varid(13)=temp_id
         call check( nf90_inq_varid(ncid, "z",  temp_id), trim(err)//"z" )
         varid(20)=temp_id
+        call check( nf90_inq_varid(ncid, "ps",temp_id), trim(err)//"ps" )
+        varid(40)=temp_id
         ! surface precip fluxes
         call check( nf90_inq_varid(ncid, "rain",temp_id), trim(err)//"rain" )
         varid(14)=temp_id
         call check( nf90_inq_varid(ncid, "rain_rate",temp_id), trim(err)//"rain_rate" )
         varid(32)=temp_id
+        call check( nf90_inq_varid(ncid, "snow_rate",temp_id), trim(err)//"snow_rate" )
+        varid(41)=temp_id
         call check( nf90_inq_varid(ncid, "snow",temp_id), trim(err)//"snow" )
         varid(15)=temp_id
         
@@ -807,10 +826,13 @@ contains
         
         if (.not.allocated(last_rain)) then
             allocate(last_rain(nx,ny))
+            allocate(last_snow(nx,ny))
             if (options%restart) then
                 last_rain=domain%rain
+                last_snow=domain%snow
             else
                 last_rain=0
+                last_snow=0
             endif
         endif
     end subroutine output_init
@@ -914,27 +936,33 @@ contains
             elseif (options%physics%microphysics==kMP_WSM6) then
                 call check( nf90_put_var(ncid, varid(6),  reshape(domain%qgrau, output_shape, order=zlast), start_three_D),trim(filename)//":qgraupel" )
             endif
+            
+            ! for u add one to the x shape then revert
             output_shape(1)=output_shape(1)+1
             call check( nf90_put_var(ncid, varid(9),  reshape(domain%u,     output_shape, order=zlast), start_three_D),    trim(filename)//":u" )
             output_shape(1)=output_shape(1)-1
+            
+            ! for v add one to the y shape then revert
             output_shape(2)=output_shape(2)+1
             call check( nf90_put_var(ncid, varid(10), reshape(domain%v,     output_shape, order=zlast), start_three_D),    trim(filename)//":v" )
             output_shape(2)=output_shape(2)-1
+            
             call check( nf90_put_var(ncid, varid(11), reshape(domain%w_real,output_shape, order=zlast), start_three_D),    trim(filename)//":w" )
             call check( nf90_put_var(ncid, varid(12), reshape(domain%p,     output_shape, order=zlast), start_three_D),    trim(filename)//":p" )
             call check( nf90_put_var(ncid, varid(13), reshape(domain%th,    output_shape, order=zlast), start_three_D),    trim(filename)//":th" )
             call check( nf90_put_var(ncid, varid(21), reshape(domain%rho,   output_shape, order=zlast), start_three_D),    trim(filename)//":rho" )
+            
             if (options%physics%windtype==kWIND_LINEAR) then
                 call check( nf90_put_var(ncid, varid(33), reshape(domain%nsquared, output_shape, order=zlast), start_three_D), trim(filename)//":nsquared" )
             endif
         else
             call check( nf90_put_var(ncid, varid(1),  domain%qv(:,1,:), start_two_D),  trim(filename)//":qv" )
-!             call check( nf90_put_var(ncid, varid(9),  domain%u(:,1,:),  start_two_D),  trim(filename)//":u" )
-!             call check( nf90_put_var(ncid, varid(10), domain%v(:,1,:),  start_two_D),  trim(filename)//":v" )
             call check( nf90_put_var(ncid, varid(12), domain%p(:,1,:),  start_two_D),  trim(filename)//":p" )
             call check( nf90_put_var(ncid, varid(13), domain%th(:,1,:), start_two_D),  trim(filename)//":th" )
         endif
         
+        ! surface pressure
+        call check( nf90_put_var(ncid, varid(20), domain%psfc, start_two_D), trim(filename)//":ps" )
         
         ! Write precip variables (rain, snow, graupel, crain) adjusting for the internal precip bucket
         call tip_precip_to_buckets(domain)
@@ -945,6 +973,10 @@ contains
             call check( nf90_put_var(ncid, varid(32), &
                                      domain%rain-last_rain, &
                                      start_two_D), trim(filename)//":rainrate" )
+
+            call check( nf90_put_var(ncid, varid(41), &
+                                     domain%snow-last_snow, &
+                                     start_two_D), trim(filename)//":snowrate" )
         endif
         call check( nf90_put_var(ncid, varid(15), &
                                  domain%snow + domain%snow_bucket*kPRECIP_BUCKET_SIZE, &
@@ -999,6 +1031,7 @@ contains
         endif
         
         last_rain=domain%rain
+        last_snow=domain%snow
         ! Close the file, freeing all resources.
         call check( nf90_close(ncid), trim(filename) )
     end subroutine write_domain

--- a/main/boundary.f90
+++ b/main/boundary.f90
@@ -284,11 +284,11 @@ contains
         
         ! Variable specific options
         ! For wind variables run a first pass of smoothing over the low res data
-        ! if (((varname==options%vvar).or.(varname==options%uvar)).and.(.not.options%ideal)) then
-        !     call smooth_wind(inputdata,1,2)
+        if (((varname==options%vvar).or.(varname==options%uvar)).and.(.not.options%ideal)) then
+            call smooth_wind(inputdata,1,2)
             
         ! For Temperature, we may need to add an offset
-        if ((varname==options%tvar).and.(options%t_offset/=0)) then
+        elseif ((varname==options%tvar).and.(options%t_offset/=0)) then
             inputdata=inputdata+options%t_offset
         
         ! For pressure, we may need to add a base pressure offset read from pbvar

--- a/main/data_structures.f90
+++ b/main/data_structures.f90
@@ -447,6 +447,14 @@ module data_structures
 
 
     ! ------------------------------------------------
+    ! store Online Bias Correction options
+    ! ------------------------------------------------
+    type bias_options_type
+        character(len=MAXFILELENGTH):: filename             ! file containing bias correction data
+        character(len=MAXVARLENGTH) :: rain_fraction_var    ! name of variable containing the fraction to multiply rain by
+    end type bias_options_type
+    
+    ! ------------------------------------------------
     ! store Land Surface Model options
     ! ------------------------------------------------
     type lsm_options_type
@@ -484,7 +492,7 @@ module data_structures
                                         
         ! Filenames for files to read various physics options from
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, adv_options_filename, &
-                                        lsm_options_filename
+                                        lsm_options_filename, bias_options_filename
         character(len=MAXFILELENGTH) :: calendar
         
 
@@ -551,6 +559,9 @@ module data_structures
         
         logical :: use_lsm_options
         type(lsm_options_type) :: lsm_options
+
+        logical :: use_bias_correction
+        type(bias_options_type) :: bias_options
                     
         integer :: warning_level        ! level of warnings to issue when checking options settings 0-10.  
                                         ! 0  = Don't print anything

--- a/main/data_structures.f90
+++ b/main/data_structures.f90
@@ -66,8 +66,8 @@
 !! z        = model layer height (at mid point) [m]
 !! dz       = layer thickness                   [m]
 !!
-!! sintheta = sine of the angle between grid and geographic coords   []
-!! costheta = cosine of the angle between grid and geographic coords []
+!! sintheta = sine of the angle between grid and geographic coords   [-]
+!! costheta = cosine of the angle between grid and geographic coords [-]
 !! fzs      = buffered FFT(terrain) for linear wind calculations   
 !! </pre>
 !!
@@ -234,7 +234,7 @@ module data_structures
         ! these are needed to compute Brunt Vaisalla Frequency... 
         real, allocatable, dimension(:,:,:) :: th                   ! potential temperature         [K]
         real, allocatable, dimension(:,:,:) :: p                    ! pressure                      [Pa]
-        real, allocatable, dimension(:,:,:) :: pii                  ! exner function                []
+        real, allocatable, dimension(:,:,:) :: pii                  ! exner function                [-]
         real, allocatable, dimension(:,:,:) :: qv                   ! water vapor mixing ratio      [kg/kg]
         ! used to determine if moist or dry brunt vaisala frequency is used
         real, allocatable, dimension(:,:,:) :: cloud,ice,qsnow,qrain ! hydrometeor mixing ratios    [kg/kg]
@@ -276,28 +276,28 @@ module data_structures
         real, allocatable, dimension(:,:,:) :: mut          ! mass in a given cell ? (pbot-ptop) used in some physics schemes
         ! 3D soil field
         real, allocatable, dimension(:,:,:) :: soil_t       ! soil temperature (nx, nsoil, ny)  [K]
-        real, allocatable, dimension(:,:,:) :: soil_vwc     ! soil volumetric water content     []
+        real, allocatable, dimension(:,:,:) :: soil_vwc     ! soil volumetric water content     [-]
         
         ! 2D fields, primarily fluxes to/from the land surface
         ! surface pressure and model top pressure
         real, allocatable, dimension(:,:)   :: psfc, ptop
         ! precipitation fluxes
-        real, allocatable, dimension(:,:)   :: rain, crain, snow, graupel   ! accumulated : total precip, convective precip, snow, and graupel
-        real, allocatable, dimension(:,:)   :: current_rain, current_snow   ! current time step rain and snow
-        integer, allocatable, dimension(:,:):: rain_bucket,crain_bucket,snow_bucket,graupel_bucket  ! buckets to preserve accuracy in all variables
+        real,    allocatable, dimension(:,:):: rain, crain, snow, graupel   ! accumulated : total precip, convective precip, snow, and graupel
+        real,    allocatable, dimension(:,:):: current_rain, current_snow   ! current time step rain and snow
+        integer, allocatable, dimension(:,:):: rain_bucket, crain_bucket, snow_bucket, graupel_bucket  ! buckets to preserve accuracy in all variables
         
         ! radiative fluxes (and cloud fraction)
-        real, allocatable, dimension(:,:)   :: swdown       ! shortwave down at the surface
-        real, allocatable, dimension(:,:)   :: lwdown       ! longwave down at the surface
-        real, allocatable, dimension(:,:)   :: cloudfrac    ! total column cloud fraction
-        real, allocatable, dimension(:,:)   :: lwup         ! longwave up at/from the surface
+        real, allocatable, dimension(:,:)   :: swdown                       ! shortwave down at the surface         [W/m^2]
+        real, allocatable, dimension(:,:)   :: lwdown                       ! longwave down at the surface          [W/m^2]
+        real, allocatable, dimension(:,:)   :: cloudfrac                    ! total column cloud fraction           [-]
+        real, allocatable, dimension(:,:)   :: lwup                         ! longwave up at/from the surface       [W/m^2]
         
-        ! turbulent fluxes (and ground heat flux)
-        real, allocatable, dimension(:,:)   :: sensible_heat, latent_heat, ground_heat
+        ! turbulent and ground heat fluxes
+        real, allocatable, dimension(:,:)   :: sensible_heat, latent_heat, ground_heat       !  [W/m^2]
         
         ! domain parameters
-        real, allocatable, dimension(:,:)   :: landmask             ! store the land-sea mask
-        real, allocatable, dimension(:,:)   :: sintheta, costheta   ! rotations about the E-W, N-S grid
+        real, allocatable, dimension(:,:)   :: landmask             ! store the land-sea mask                       [-]
+        real, allocatable, dimension(:,:)   :: sintheta, costheta   ! rotations about the E-W, N-S grid             [-]
         real, allocatable, dimension(:)     :: ZNU, ZNW             ! = (p-p_top)/(psfc-ptop),  (p_inter-p_top)/(psfc-ptop)
         
         ! land surface state and parameters primarily used by Noah LSM
@@ -327,6 +327,9 @@ module data_structures
         double precision :: model_time
         integer :: current_month ! used to store the current month (should probably be fractional for interpolation...)
         
+        ! online bias correction data
+        real, allocatable, dimension(:,:,:) :: rain_fraction        ! seasonally varying fraction to multiple rain  [-]
+
         ! model specific fields
         real, allocatable, dimension(:,:,:) :: Um, Vm ! U and V on mass coordinates
         real, allocatable, dimension(:,:,:) :: T      ! real T (not potential)

--- a/main/data_structures.f90
+++ b/main/data_structures.f90
@@ -438,10 +438,11 @@ module data_structures
         
 
         ! various boolean options
+        logical :: debug                ! outputs a little more information at runtime (not much at present)
+        logical :: interactive          ! set to true if running at the commandline to see %complete printed
         logical :: ideal                ! this is an ideal simulation, forcing will be held constant
         logical :: readz                ! read atmospheric grid elevations from file
         logical :: readdz               ! read atm model layer thicknesses from namelist
-        logical :: debug                ! outputs a little more information at runtime (not much at present)
         logical :: external_winds       ! read a high res 3d wind field from an external file (e.g. a high res WRF run)
         logical :: mean_winds           ! use only a mean wind field across the entire model domain
         logical :: mean_fields          ! use only a mean forcing field across the model boundaries 

--- a/main/init.f90
+++ b/main/init.f90
@@ -18,7 +18,7 @@
 !! ----------------------------------------------------------------------------
 module init
     use data_structures
-    use io_routines,                only : io_read2d, io_read2di, io_read3d, &
+    use io_routines,                only : io_read, &
                                            io_write3d,io_write3di, io_write
     use geo,                        only : geo_LUT, geo_interp, geo_interp2d
     use vertical_interpolation,     only : vLUT, vinterp
@@ -57,6 +57,7 @@ contains
         write(*,*) "Initializing Boundaries"
         call init_bc(options,domain,boundary)
         write(*,*) ""
+        call setup_bias_correction(options,domain)
         write(*,'(/ A)') "Finished basic initialization"
         write(*,'(A /)') "---------------------------------------"
         
@@ -393,6 +394,16 @@ contains
         
     end subroutine copy_z
 
+    subroutine setup_bias_correction(options, domain)
+        implicit none
+        type(options_type), intent(in) :: options
+        type(domain_type), intent(inout):: domain
+        
+        if (options%use_bias_correction) then
+            call io_read(options%bias_options%filename, options%bias_options%rain_fraction_var, domain%rain_fraction)
+        endif
+    end subroutine setup_bias_correction
+
     subroutine init_domain_land(domain,options)
         implicit none
         type(options_type), intent(in) :: options
@@ -414,12 +425,12 @@ contains
         if (options%vegfrac_var.ne."") then
             ! if we are supposed to read a veg fraction for each month then it will be a 3D variable
             if (options%lsm_options%monthly_vegfrac) then
-                call io_read3d(options%init_conditions_file,options%vegfrac_var,temp_rdata,1)
+                call io_read(options%init_conditions_file,options%vegfrac_var,temp_rdata,1)
                 domain%vegfrac = temp_rdata(1+buffer:nx-buffer,1+buffer:ny-buffer,:)  ! subset the data by buffer grid cells
                 deallocate(temp_rdata)
             else
                 ! otherwise we just read a 2D variable and store it in the first time entry in the 3D vegfrac field
-                call io_read2d(options%init_conditions_file,options%vegfrac_var,temp_rdata_2d,1)
+                call io_read(options%init_conditions_file,options%vegfrac_var,temp_rdata_2d,1)
                 domain%vegfrac(:,:,1) = temp_rdata_2d(1+buffer:nx-buffer,1+buffer:ny-buffer)  ! subset the data by buffer grid cells
                 deallocate(temp_rdata_2d)
             endif
@@ -432,21 +443,21 @@ contains
 
         ! Veg TYPE = 2D integer
         if (options%vegtype_var.ne."") then
-            call io_read2di(options%init_conditions_file,options%vegtype_var,temp_idata,1)
+            call io_read(options%init_conditions_file,options%vegtype_var,temp_idata,1)
             domain%veg_type = temp_idata(1+buffer:nx-buffer,1+buffer:ny-buffer)  ! subset the data by buffer grid cells
             deallocate(temp_idata)
         endif
         
         ! Soil TYPE = 2D integer
         if (options%soiltype_var.ne."") then
-            call io_read2di(options%init_conditions_file,options%soiltype_var,temp_idata,1)
+            call io_read(options%init_conditions_file,options%soiltype_var,temp_idata,1)
             domain%soil_type = temp_idata(1+buffer:nx-buffer,1+buffer:ny-buffer)  ! subset the data by buffer grid cells
             deallocate(temp_idata)
         endif
         
         ! Soil Volumetric Water Content = 3D real
         if (options%soil_vwc_var.ne."") then
-            call io_read3d(options%init_conditions_file,options%soil_vwc_var,temp_rdata,1)  
+            call io_read(options%init_conditions_file,options%soil_vwc_var,temp_rdata,1)  
             domain%soil_vwc = reshape(temp_rdata(1+buffer:nx-buffer,1+buffer:ny-buffer,1:nz) &    ! subset the data by buffer grid cells
                                     ,[nx-buffer*2,nz,ny-buffer*2],order=[1,3,2])                ! and reshape to move the z axis to the middle
             deallocate(temp_rdata)
@@ -454,7 +465,7 @@ contains
         
         ! Soil Temperature = 3D real
         if (options%soil_t_var.ne."") then
-            call io_read3d(options%init_conditions_file,options%soil_t_var,temp_rdata,1)
+            call io_read(options%init_conditions_file,options%soil_t_var,temp_rdata,1)
             domain%soil_t = reshape(temp_rdata(1+buffer:nx-buffer,1+buffer:ny-buffer,1:nz) &  ! subset the data by buffer grid cells
                                     ,[nx-buffer*2,nz,ny-buffer*2],order=[1,3,2])            ! and reshape to move the z axis to the middle
             deallocate(temp_rdata)
@@ -462,7 +473,7 @@ contains
         
         ! Deep Soil Temperature = 2D real
         if (options%soil_deept_var.ne."") then
-            call io_read2d(options%init_conditions_file,options%soil_deept_var,temp_rdata_2d,1)
+            call io_read(options%init_conditions_file,options%soil_deept_var,temp_rdata_2d,1)
             domain%soil_tdeep = temp_rdata_2d(1+buffer:nx-buffer,1+buffer:ny-buffer)  ! subset the data by buffer grid cells
             where(domain%soil_tdeep<200) domain%soil_tdeep = 200 ! mitigates zeros that can cause problems
             if (options%soil_t_var=="") then
@@ -558,38 +569,38 @@ contains
         integer:: ny,nz,nx,i,buf
         
 !       these are the only required variables on a high-res grid, lat, lon, and terrain elevation
-        call io_read2d(options%init_conditions_file,options%hgt_hi,domain%terrain,1)
-        call io_read2d(options%init_conditions_file,options%lat_hi,domain%lat,1)
-        call io_read2d(options%init_conditions_file,options%lon_hi,domain%lon,1)
+        call io_read(options%init_conditions_file,options%hgt_hi,domain%terrain,1)
+        call io_read(options%init_conditions_file,options%lat_hi,domain%lat,1)
+        call io_read(options%init_conditions_file,options%lon_hi,domain%lon,1)
         call convert_longitudes(domain%lon)
         
         !  because u/vlat/lon_hi are optional, we calculated them by interplating from the mass lat/lon if necessary
         if (options%ulat_hi/="") then
-            call io_read2d(options%init_conditions_file,options%ulat_hi,domain%u_geo%lat,1)
+            call io_read(options%init_conditions_file,options%ulat_hi,domain%u_geo%lat,1)
         else
             call interpolate_in_x(domain%lat,domain%u_geo%lat)
         endif
         if (options%ulon_hi/="") then
-            call io_read2d(options%init_conditions_file,options%ulon_hi,domain%u_geo%lon,1)
+            call io_read(options%init_conditions_file,options%ulon_hi,domain%u_geo%lon,1)
         else
             call interpolate_in_x(domain%lon,domain%u_geo%lon)
         endif
         call convert_longitudes(domain%u_geo%lon)
         
         if (options%vlat_hi/="") then
-            call io_read2d(options%init_conditions_file,options%vlat_hi,domain%v_geo%lat,1)
+            call io_read(options%init_conditions_file,options%vlat_hi,domain%v_geo%lat,1)
         else
             call interpolate_in_y(domain%lat,domain%v_geo%lat)
         endif
         if (options%vlon_hi/="") then
-            call io_read2d(options%init_conditions_file,options%vlon_hi,domain%v_geo%lon,1)
+            call io_read(options%init_conditions_file,options%vlon_hi,domain%v_geo%lon,1)
         else
             call interpolate_in_y(domain%lon,domain%v_geo%lon)
         endif
         call convert_longitudes(domain%v_geo%lon)
         
         if (options%landvar/="") then
-            call io_read2d(options%init_conditions_file,options%landvar,domain%landmask,1)
+            call io_read(options%init_conditions_file,options%landvar,domain%landmask,1)
             where(domain%landmask==0) domain%landmask = kLC_WATER
         else
             nx = size(domain%lat,1)
@@ -615,7 +626,7 @@ contains
             
             stop("Reading Z from an external file is not currently supported, use a fixed dz")
             
-            call io_read3d(options%init_conditions_file,options%zvar, domain%z)
+            call io_read(options%init_conditions_file,options%zvar, domain%z)
             ! dz also has to be calculated from the 3d z file
             buf = options%buffer
             allocate(domain%dz(nx,nz,ny))
@@ -724,19 +735,19 @@ contains
         integer::nx,ny,nz,i
         
         ! these variables are required for any boundary/forcing file type
-        call io_read2d(options%boundary_files(1),options%latvar,boundary%lat)
-        call io_read2d(options%boundary_files(1),options%lonvar,boundary%lon)
+        call io_read(options%boundary_files(1),options%latvar,boundary%lat)
+        call io_read(options%boundary_files(1),options%lonvar,boundary%lon)
         call convert_longitudes(boundary%lon)
-        call io_read2d(options%boundary_files(1),options%ulat,boundary%u_geo%lat)
-        call io_read2d(options%boundary_files(1),options%ulon,boundary%u_geo%lon)
+        call io_read(options%boundary_files(1),options%ulat,boundary%u_geo%lat)
+        call io_read(options%boundary_files(1),options%ulon,boundary%u_geo%lon)
         call convert_longitudes(boundary%u_geo%lon)
-        call io_read2d(options%boundary_files(1),options%vlat,boundary%v_geo%lat)
-        call io_read2d(options%boundary_files(1),options%vlon,boundary%v_geo%lon)
+        call io_read(options%boundary_files(1),options%vlat,boundary%v_geo%lat)
+        call io_read(options%boundary_files(1),options%vlon,boundary%v_geo%lon)
         call convert_longitudes(boundary%v_geo%lon)
-        call io_read2d(options%boundary_files(1),options%hgtvar,boundary%terrain)
+        call io_read(options%boundary_files(1),options%hgtvar,boundary%terrain)
         
         ! read in the vertical coordinate
-        call io_read3d(options%boundary_files(1),options%zvar,zbase)
+        call io_read(options%boundary_files(1),options%zvar,zbase)
         if (options%debug) write(*,*) "Raw input forcing z min=",minval(zbase), " z max=", maxval(zbase)
         nx = size(zbase,1)
         ny = size(zbase,2)
@@ -746,7 +757,7 @@ contains
         deallocate(zbase)
 
         if (trim(options%zbvar)/="") then
-            call io_read3d(options%boundary_files(1),options%zbvar, zbase)
+            call io_read(options%boundary_files(1),options%zbvar, zbase)
             boundary%lowres_z = boundary%lowres_z + reshape(zbase,[nx,nz,ny],order=[1,3,2])
             if (options%debug) write(*,*) "Raw forcing z_base min=",minval(zbase), " max=", maxval(zbase)
             deallocate(zbase)
@@ -808,31 +819,31 @@ contains
         real, allocatable, dimension(:,:) :: lat,lon
         real, allocatable, dimension(:,:) :: temporary_terrain
         
-        call io_read2d(options%ext_wind_files(1),options%hgt_hi,bc%ext_winds%terrain,1)
-        call io_read2d(options%ext_wind_files(1),options%latvar,bc%ext_winds%lat)
-        call io_read2d(options%ext_wind_files(1),options%lonvar,bc%ext_winds%lon)
+        call io_read(options%ext_wind_files(1),options%hgt_hi,bc%ext_winds%terrain,1)
+        call io_read(options%ext_wind_files(1),options%latvar,bc%ext_winds%lat)
+        call io_read(options%ext_wind_files(1),options%lonvar,bc%ext_winds%lon)
         call convert_longitudes(bc%ext_winds%lon)
         
         ! ulat_hi and vlat_hi are optional, if they are not supplied interpolate the mass lat/lon grid
         if (options%ulat_hi/="") then
-            call io_read2d(options%ext_wind_files(1),options%ulat_hi,bc%ext_winds%u_geo%lat,1)
+            call io_read(options%ext_wind_files(1),options%ulat_hi,bc%ext_winds%u_geo%lat,1)
         else
             call interpolate_in_x(bc%ext_winds%lat,bc%ext_winds%u_geo%lat)
         endif
         if (options%ulon_hi/="") then
-            call io_read2d(options%ext_wind_files(1),options%ulon_hi,bc%ext_winds%u_geo%lon,1)
+            call io_read(options%ext_wind_files(1),options%ulon_hi,bc%ext_winds%u_geo%lon,1)
         else
             call interpolate_in_x(bc%ext_winds%lon,bc%ext_winds%u_geo%lon)
         endif
         call convert_longitudes(bc%ext_winds%u_geo%lon)
         
         if (options%vlat_hi/="") then
-            call io_read2d(options%ext_wind_files(1),options%vlat_hi,bc%ext_winds%v_geo%lat,1)
+            call io_read(options%ext_wind_files(1),options%vlat_hi,bc%ext_winds%v_geo%lat,1)
         else
             call interpolate_in_y(bc%ext_winds%lat,bc%ext_winds%v_geo%lat)
         endif
         if (options%vlon_hi/="") then
-            call io_read2d(options%ext_wind_files(1),options%vlon_hi,bc%ext_winds%v_geo%lon,1)
+            call io_read(options%ext_wind_files(1),options%vlon_hi,bc%ext_winds%v_geo%lon,1)
         else
             call interpolate_in_y(bc%ext_winds%lon,bc%ext_winds%v_geo%lon)
         endif

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -734,7 +734,7 @@ contains
         options%mp_options%Ef_sw_l = Ef_sw_l
 
         options%mp_options%update_interval = update_interval
-        if (top_mp_level < 0) then top_mp_level = options%nz + top_mp_level
+        if (top_mp_level < 0) top_mp_level = options%nz + top_mp_level
         options%mp_options%top_mp_level = top_mp_level
         options%mp_options%local_precip_fraction = local_precip_fraction
     end subroutine mp_parameters_namelist

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -34,16 +34,17 @@ contains
         options_filename=get_options_file()
         write(*,*) "Using options file = ", trim(options_filename)
         
-        call version_check(options_filename,options)
-        call physics_namelist(options_filename,options)
-        call var_namelist(options_filename,options)
-        call parameters_namelist(options_filename,options)
-        call model_levels_namelist(options_filename, options)
+        call version_check(         options_filename,   options)
+        call physics_namelist(      options_filename,   options)
+        call var_namelist(          options_filename,   options)
+        call parameters_namelist(   options_filename,   options)
+        call model_levels_namelist( options_filename,   options)
         
-        call lt_parameters_namelist(options%lt_options_filename, options)
-        call mp_parameters_namelist(options%mp_options_filename,options)
-        call adv_parameters_namelist(options%adv_options_filename,options)
-        call lsm_parameters_namelist(options%lsm_options_filename,options)
+        call lt_parameters_namelist(    options%lt_options_filename,    options)
+        call mp_parameters_namelist(    options%mp_options_filename,    options)
+        call adv_parameters_namelist(   options%adv_options_filename,   options)
+        call lsm_parameters_namelist(   options%lsm_options_filename,   options)
+        call bias_parameters_namelist(  options%bias_options_filename,  options)
 
         if (options%restart) then
             call init_restart_options(options_filename,options)
@@ -465,12 +466,13 @@ contains
         logical :: ideal, readz, readdz, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, &
-                   use_mp_options, use_lt_options, use_adv_options, use_lsm_options
+                   use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction
                    
         character(len=MAXFILELENGTH) :: date, calendar, start_date, forcing_start_date, end_date
         integer :: year, month, day, hour, minute, second
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, &
-                                        adv_options_filename, lsm_options_filename
+                                        adv_options_filename, lsm_options_filename, &
+                                        bias_options_filename
 
         namelist /parameters/ ntimesteps,outputinterval,inputinterval, surface_io_only, &
                               dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, &
@@ -479,10 +481,11 @@ contains
                               date, calendar, high_res_soil_state,rotation_scale_height,warning_level, &
                               use_agl_height, start_date, forcing_start_date, end_date, time_varying_z, &
                               cfl_reduction_factor, cfl_strictness, &
-                              mp_options_filename, use_mp_options, &    ! trude added
-                              lt_options_filename, use_lt_options, &
-                              lsm_options_filename, use_lsm_options, &
-                              adv_options_filename, use_adv_options
+                              mp_options_filename,      use_mp_options, &
+                              lt_options_filename,      use_lt_options, &
+                              lsm_options_filename,     use_lsm_options, &
+                              adv_options_filename,     use_adv_options, &
+                              bias_options_filename,    use_bias_correction
         
 !       default parameters
         surface_io_only=.False.
@@ -527,6 +530,9 @@ contains
 
         use_lsm_options=.False.
         lsm_options_filename = filename
+
+        use_bias_correction=.False.
+        bias_options_filename = filename
         
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=parameters)
@@ -640,6 +646,10 @@ contains
         options%use_lsm_options = use_lsm_options
         options%lsm_options_filename  = lsm_options_filename
 
+        options%use_bias_correction = use_bias_correction
+        options%bias_options_filename  = bias_options_filename
+
+        ! options are updated when complete
     end subroutine parameters_namelist
 
     subroutine mp_parameters_namelist(mp_filename,options)
@@ -958,6 +968,49 @@ contains
     end subroutine set_default_LU_categories
 
     
+    subroutine bias_parameters_namelist(filename, options)
+        implicit none
+        character(len=*),   intent(in)   :: filename
+        type(options_type), intent(inout):: options
+        
+        type(bias_options_type)     ::  bias_options
+        
+        integer :: name_unit
+
+        character(len=MAXFILELENGTH):: bias_correction_filename ! file containing bias correction data
+        character(len=MAXVARLENGTH) :: rain_fraction_var        ! name of variable containing the fraction to multiply rain by
+        
+        ! define the namelist
+        namelist /bias_parameters/ bias_correction_filename, rain_fraction_var
+        
+         ! because adv_options could be in a separate file
+         if (options%use_bias_correction) then
+             if (trim(filename)/=trim(get_options_file())) then
+                 call version_check(filename,options)
+             endif
+         endif
+        
+        
+        ! set default values
+        bias_correction_filename = options%init_conditions_file
+        rain_fraction_var        = "rain_fraction"
+        
+        ! read the namelist options
+        if (options%use_bias_correction) then
+            open(io_newunit(name_unit), file=filename)
+            read(name_unit,nml=bias_parameters)
+            close(name_unit)
+        endif
+        
+        ! store everything in the bias_options structure
+        bias_options%filename           = bias_correction_filename
+        bias_options%rain_fraction_var  = rain_fraction_var
+        
+        ! copy the data back into the global options data structure
+        options%bias_options = bias_options
+    end subroutine bias_parameters_namelist
+
+    
     subroutine lsm_parameters_namelist(filename, options)
         implicit none
         character(len=*), intent(in) :: filename
@@ -1183,8 +1236,6 @@ contains
             options%ext_wind_files=ext_wind_files
             deallocate(ext_wind_files)
         endif
-        
     end subroutine filename_namelist
-
 
 end module initialize_options

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -3,7 +3,7 @@
 !!  Also checks commandline arguments to an options filename
 !!
 !!  Entry point is init_options, everything else follows
-!!  
+!!
 !!
 !!  @author
 !!  Ethan Gutmann (gutmann@ucar.edu)
@@ -18,14 +18,14 @@ module initialize_options
     use string,                     only : str
 
     implicit none
-    
+
     private
     public :: init_options
 contains
-    
-    
+
+
     subroutine init_options(options)
-!       reads a series of options from a namelist file and stores them in the 
+!       reads a series of options from a namelist file and stores them in the
 !       options data structure
         implicit none
         type(options_type), intent(inout) :: options
@@ -33,13 +33,13 @@ contains
 
         options_filename=get_options_file()
         write(*,*) "Using options file = ", trim(options_filename)
-        
+
         call version_check(         options_filename,   options)
         call physics_namelist(      options_filename,   options)
         call var_namelist(          options_filename,   options)
         call parameters_namelist(   options_filename,   options)
         call model_levels_namelist( options_filename,   options)
-        
+
         call lt_parameters_namelist(    options%lt_options_filename,    options)
         call mp_parameters_namelist(    options%mp_options_filename,    options)
         call adv_parameters_namelist(   options%adv_options_filename,   options)
@@ -61,7 +61,7 @@ contains
         character(len=MAXFILELENGTH) ::options_file
         integer :: error
         logical :: file_exists
-    
+
         if (command_argument_count()>0) then
             call get_command_argument(1,options_file, status=error)
             if (error>0) then
@@ -91,7 +91,7 @@ contains
         type(options_type),intent(inout)::options
         character(len=MAXVARLENGTH) :: version,comment
         integer:: name_unit
-    
+
         namelist /model_version/ version,comment
         !default comment:
         comment="Model testing"
@@ -115,7 +115,7 @@ contains
         ! Minimal error checking on option settings
         implicit none
         type(options_type), intent(inout)::options
-    
+
         if (options%t_offset.eq.(-9999)) then
             if (options%warning_level>0) then
                 write(*,*) "WARNING, WARNING, WARNING"
@@ -124,7 +124,7 @@ contains
             endif
             options%t_offset = 0
         endif
-        
+
         if ((options%initial_mjd + options%ntimesteps/(86400.0/options%in_dt)) < options%start_mjd) then
             write(*,*) "ERROR: start date is more than ntimesteps past the forcing start"
             write(*,*) "Initial Modified Julian Day:",options%initial_mjd
@@ -133,7 +133,7 @@ contains
             write(*,*) "number of days to simulate:",options%ntimesteps/(86400.0/options%in_dt)
             stop "Start time is past stop time."
         endif
-            
+
 
         ! convection can modify wind field, and ideal doesn't rebalance winds every timestep
         if ((options%physics%convection.ne.0).and.(options%ideal)) then
@@ -171,8 +171,8 @@ contains
                 stop
             endif
         endif
-        
-        ! prior to v 0.9.3 this was assumed, so throw a warning now just in case. 
+
+        ! prior to v 0.9.3 this was assumed, so throw a warning now just in case.
         if ((options%z_is_geopotential .eqv. .False.).and.(options%zvar=="PH")) then
             if (options%warning_level>1) then
                 write(*,*) "WARNING WARNING WARNING"
@@ -193,15 +193,15 @@ contains
                 write(*,*) "WARNING WARNING WARNING"
             endif
         endif
-    
+
     end subroutine options_check
-    
+
     subroutine init_restart_options(filename, options)
         ! initialize the restart specifications
         ! read in the namelist, and calculate the restart_step if appropriate
         character(len=*),  intent(in)    :: filename    ! name of the file containing the restart namelist
         type(options_type),intent(inout) :: options     ! options data structure to store output
-        
+
         ! Local variables
         character(len=MAXFILELENGTH) :: restart_file    ! file name to read restart data from
         integer :: restart_step                         ! time step relative to the start of the restart file
@@ -209,25 +209,25 @@ contains
         integer :: name_unit                            ! logical unit number for namelist
         double precision :: restart_mjd                 ! restart date as a modified julian day
         real :: input_steps_per_day                     ! number of input time steps per day (for calculating restart_mjd)
-        
+
         namelist /restart_info/ restart_step, restart_file, restart_date
-        
+
         restart_date=[-999,-999,-999,-999,-999,-999]
         restart_step=-999
-        
+
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=restart_info)
         close(name_unit)
-        
+
         if (minval(restart_date)<0) then
             write(*,*) "------ Invalid restart_date ERROR ------"
             stop "restart_date must be specified in the namelist"
         endif
-        
+
         ! calculate the modified julian day for th restart date given
         restart_mjd = date_to_mjd(restart_date(1), restart_date(2), restart_date(3), &
                                   restart_date(4), restart_date(5), restart_date(6))
-        
+
         if (options%debug) then
             write(*,*) " ------------------ "
             write(*,*) "RESTART INFORMATION"
@@ -237,10 +237,10 @@ contains
             write(*,*) "forcing step",restart_step
             write(*,*) " ------------------ "
         endif
-        
+
         ! used in calculations below
         input_steps_per_day = 86400.0/options%in_dt
-        
+
         ! if the user did not specify the restart_step (and they really shouldn't)
         if (restart_step==-999) then
             ! +1e-4 prevents floating point rounding error from setting it back one day/hour/minute etc
@@ -248,70 +248,70 @@ contains
             restart_step=FLOOR((restart_mjd - options%initial_mjd + 1e-4) * input_steps_per_day) + 1
             if (options%debug) write(*,*) " updated forcing step",restart_step
         endif
-        
+
         ! save the parameters in the master options structure
         options%restart_step=restart_step
         options%restart_file=restart_file
         options%restart_date=restart_date
-        
+
         ! In case the supplied restart date doesn't line up with an input forcing step, recalculate
         ! The restart date (mjd) based off the nearest input step
         restart_mjd = options%initial_mjd + ((restart_step-1)/input_steps_per_day)
         if (options%debug) write(*,*) " updated mjd",restart_mjd
-        
+
         ! now find the closest previous output step to the current restart date
         options%restart_step_in_file = io_nearest_time_step(restart_file, restart_mjd)
         if (options%debug) write(*,*) " step in restart file",options%restart_step_in_file
-        
+
     end subroutine init_restart_options
-    
-    
+
+
 !   read physics options to use from a namelist file
     subroutine physics_namelist(filename,options)
         implicit none
         character(len=*),intent(in) :: filename
         type(options_type), intent(inout) :: options
         integer :: name_unit
-        
+
 !       variables to be used in the namelist
         integer::pbl,lsm,water,mp,rad,conv,adv,wind
 !       define the namelist
         namelist /physics/ pbl,lsm,water,mp,rad,conv,adv,wind
-        
+
 !       default values for physics options (advection+linear winds+simple_microphysics)
-        pbl = 0 ! 0 = no PBL, 
+        pbl = 0 ! 0 = no PBL,
                 ! 1 = Stupid PBL (only in LSM=1 module),
                 ! 2 = local PBL diffusion after Louis 1979
                 ! 3 = YSU PBL (not complete)
-                
-        lsm = 0 ! 0 = no LSM, 
-                ! 1 = Fluxes from GCM, 
+
+        lsm = 0 ! 0 = no LSM,
+                ! 1 = Fluxes from GCM,
                 ! 2 = simple LSM, (not complete)
                 ! 3 = Noah LSM
-                
-        water = 0 ! 0 = no open water fluxes, 
+
+        water = 0 ! 0 = no open water fluxes,
                 ! 1 = Fluxes from GCM, (needs lsm=1)
                 ! 2 = Simple fluxes (needs SST in forcing data)
-                
-        mp  = 1 ! 0 = no MP,  
-                ! 1 = Thompson et al (2008), 
+
+        mp  = 1 ! 0 = no MP,
+                ! 1 = Thompson et al (2008),
                 ! 2 = "Linear" microphysics
-        
-        rad = 0 ! 0 = no RAD, 
-                ! 1 = Surface fluxes from GCM, (radiative cooling ~1K/day in LSM=1 module), 
+
+        rad = 0 ! 0 = no RAD,
+                ! 1 = Surface fluxes from GCM, (radiative cooling ~1K/day in LSM=1 module),
                 ! 2 = cloud fraction based radiation + radiative cooling
-        
+
         conv= 0 ! 0 = no CONV,
                 ! 1 = Tiedke scheme
                 ! 2 = Kain-Fritsch scheme
-        
-        adv = 1 ! 0 = no ADV, 
+
+        adv = 1 ! 0 = no ADV,
                 ! 1 = upwind advection scheme
                 ! 2 = MPDATA
-        
-        wind= 1 ! 0 = no LT,  
+
+        wind= 1 ! 0 = no LT,
                 ! 1 = linear theory wind perturbations
-        
+
 !       read the namelist
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=physics)
@@ -326,9 +326,9 @@ contains
         options%physics%microphysics=mp
         options%physics%radiation=rad
         options%physics%windtype=wind
-        
+
     end subroutine physics_namelist
-    
+
     subroutine var_namelist(filename,options)
         implicit none
         character(len=*),intent(in) :: filename
@@ -340,14 +340,14 @@ contains
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
                                         swdown_var, lwdown_var, sst_var, rain_var
-                                        
+
         namelist /var_list/ pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                             landvar,latvar,lonvar,uvar,ulat,ulon,vvar,vlat,vlon,zvar,zbvar, &
                             hgt_hi,lat_hi,lon_hi,ulat_hi,ulon_hi,vlat_hi,vlon_hi,           &
                             soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                             vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
                             swdown_var, lwdown_var, sst_var, rain_var
-        
+
         hgtvar="HGT"
         latvar="XLAT"
         lonvar="XLONG"
@@ -388,7 +388,7 @@ contains
         linear_mask_var="data"
         nsq_calibration_var="data"
         rain_var=""
-        
+
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=var_list)
         close(name_unit)
@@ -419,7 +419,7 @@ contains
         ! vertical coordinate
         options%zvar=zvar
         options%zbvar=zbvar
-        ! 2D model variables (e.g. Land surface and PBL height)       
+        ! 2D model variables (e.g. Land surface and PBL height)
         options%shvar=shvar
         options%lhvar=lhvar
         options%pblhvar=pblhvar
@@ -429,7 +429,7 @@ contains
         ! Sea surface temperature
         options%sst_var = sst_var
         options%rain_var = rain_var
-        
+
         ! separate variable names for the high resolution domain
         options%hgt_hi=hgt_hi
         options%landvar=landvar
@@ -439,7 +439,7 @@ contains
         options%ulon_hi=ulon_hi
         options%vlat_hi=vlat_hi
         options%vlon_hi=vlon_hi
-        
+
         ! soil and vegetation parameters
         options%soiltype_var=soiltype_var
         options%soil_t_var=soil_t_var
@@ -447,17 +447,17 @@ contains
         options%soil_deept_var=soil_deept_var
         options%vegtype_var=vegtype_var
         options%vegfrac_var=vegfrac_var
-        
+
         options%linear_mask_var=linear_mask_var
         options%nsq_calibration_var=nsq_calibration_var
     end subroutine var_namelist
-    
+
     subroutine parameters_namelist(filename,options)
         implicit none
         character(len=*),intent(in) :: filename
         type(options_type), intent(inout) :: options
         integer :: name_unit
-        
+
         real    :: dx, dxlow, outputinterval, inputinterval, t_offset, smooth_wind_distance
         real    :: rotation_scale_height, cfl_reduction_factor
         integer :: ntimesteps
@@ -467,7 +467,7 @@ contains
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction
-                   
+
         character(len=MAXFILELENGTH) :: date, calendar, start_date, forcing_start_date, end_date
         integer :: year, month, day, hour, minute, second
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, &
@@ -486,7 +486,7 @@ contains
                               lsm_options_filename,     use_lsm_options, &
                               adv_options_filename,     use_adv_options, &
                               bias_options_filename,    use_bias_correction
-        
+
 !       default parameters
         surface_io_only=.False.
         mean_fields=.False.
@@ -518,11 +518,11 @@ contains
         time_varying_z=.False.
         cfl_reduction_factor = 0.9
         cfl_strictness = 3
-        
+
         ! flag set to read specific parameterization options
         use_mp_options=.False.
         mp_options_filename = filename
-        
+
         use_lt_options=.False.
         lt_options_filename = filename
 
@@ -534,11 +534,11 @@ contains
 
         use_bias_correction=.False.
         bias_options_filename = filename
-        
+
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=parameters)
         close(name_unit)
-        
+
         if (trim(forcing_start_date)=="") then
             if (trim(date)/="") then
                 forcing_start_date=date
@@ -553,15 +553,15 @@ contains
                 warning_level=5
             endif
         endif
-            
-        
+
+
         if (smooth_wind_distance.eq.(-9999)) then
             smooth_wind_distance=dxlow*2
             write(*,*) " Default smoothing distance = lowdx*2 = ", smooth_wind_distance
         endif
-        
+
         options%t_offset=t_offset
-        if (smooth_wind_distance<0) then 
+        if (smooth_wind_distance<0) then
             write(*,*) " Wind smoothing must be a positive number"
             write(*,*) " smooth_wind_distance = ",smooth_wind_distance
             if (warning_level>4) then
@@ -571,7 +571,7 @@ contains
             endif
         endif
         options%smooth_wind_distance=smooth_wind_distance
-        
+
         options%ntimesteps=ntimesteps
         options%in_dt=inputinterval
         options%out_dt=outputinterval
@@ -586,7 +586,7 @@ contains
             options%output_file_frequency="every step"
         endif
         options%surface_io_only = surface_io_only
-        
+
         call parse_date(date, year, month, day, hour, minute, second)
         options%calendar=calendar
         call time_init(calendar)
@@ -623,19 +623,19 @@ contains
         options%use_agl_height = use_agl_height
         options%z_is_geopotential = z_is_geopotential
         options%z_is_on_interface = z_is_on_interface
-        
+
         options%external_winds = external_winds
         options%ext_winds_nfiles = n_ext_winds
         options%restart = restart
-        
+
         options%nz = nz
-        
+
         options%high_res_soil_state = high_res_soil_state
         options%time_varying_z = time_varying_z
         options%cfl_reduction_factor = cfl_reduction_factor
         options%cfl_strictness = cfl_strictness
 
-        
+
         options%use_mp_options = use_mp_options
         options%mp_options_filename  = mp_options_filename   ! trude added
 
@@ -669,48 +669,48 @@ contains
 
         namelist /mp_parameters/ Nt_c,TNO, am_s, rho_g, av_s,bv_s,fv_s,av_g,bv_g,av_i,Ef_si,Ef_rs,Ef_rg,Ef_ri,&     ! trude added Nt_c, TNO
                               C_cubes,C_sqrd, mu_r, Ef_rw_l, Ef_sw_l, t_adjust, top_mp_level, local_precip_fraction, update_interval
-        
+
         ! because mp_options could be in a separate file (shoudl probably set all namelists up to have this option)
         if (options%use_mp_options) then
             if (trim(mp_filename)/=trim(get_options_file())) then
                 call version_check(mp_filename,options)
             endif
         endif
-        
+
         ! set default parameters
         Nt_c  = 100.e6      !  50, 100,500,1000
-        TNO   = 5.0         !  0.5, 5, 50 
-        am_s  = 0.069       ! 0.052 (Heymsfield), 0.02 (Mitchell), 0.01. 
-                            ! Note that these values are converted to mks units. Was given as cgs units in Morrison p3 code  
+        TNO   = 5.0         !  0.5, 5, 50
+        am_s  = 0.069       ! 0.052 (Heymsfield), 0.02 (Mitchell), 0.01.
+                            ! Note that these values are converted to mks units. Was given as cgs units in Morrison p3 code
         rho_g = 500.0       ! 800, 500, 200
         av_s  = 40.0        ! 11.72 (Locatelli and Hobbs)
         bv_s  = 0.55        ! 0.41
         fv_s  = 100.0       ! 0
-        av_g  = 442.0       ! 19.3   from "Cloud-Resolving Modelling of Convective Processes, by Gao and Li, 
+        av_g  = 442.0       ! 19.3   from "Cloud-Resolving Modelling of Convective Processes, by Gao and Li,
         bv_g  = 0.89        ! 0.37
         av_i  = 1847.5      ! 700 (Ikawa and Saito)
         Ef_si = 0.05
         Ef_rs = 0.95        ! 1
         Ef_rg = 0.75        ! 1
-        Ef_ri = 0.95        ! 1 
-        C_cubes = 0.5       ! 0.25 Based on Thesis paper "Validation and Improvements of Simulated 
+        Ef_ri = 0.95        ! 1
+        C_cubes = 0.5       ! 0.25 Based on Thesis paper "Validation and Improvements of Simulated
                             !      Cloud Microphysics and Orographic Precipitation over the Pacific Northwest"
         C_sqrd  = 0.3
         mu_r    = 0.        ! 1, 2, 5
         t_adjust= 0.0       ! -5, 10, 15
         Ef_rw_l = .False.   ! True sets ef_rw = 1, insted of max 0.95
         Ef_sw_l = .False.   ! True sets ef_rw = 1, insted of max 0.95
-        
+
         update_interval = 0 ! update every time step
         top_mp_level = 0    ! if <=0 just use the actual model top
-        local_precip_fraction = 1 ! if <1: the remaining fraction (e.g. 1-x) of precip gets distributed to the surrounding grid cells        
+        local_precip_fraction = 1 ! if <1: the remaining fraction (e.g. 1-x) of precip gets distributed to the surrounding grid cells
         ! read in the namelist
         if (options%use_mp_options) then
             open(io_newunit(name_unit), file=mp_filename)
             read(name_unit,nml=mp_parameters)
             close(name_unit)
         endif
-        
+
         ! store the data back into the mp_options datastructure
         options%mp_options%Nt_c = Nt_c
         options%mp_options%TNO = TNO
@@ -732,18 +732,19 @@ contains
         options%mp_options%C_sqrd = C_sqrd
         options%mp_options%Ef_rw_l = Ef_rw_l
         options%mp_options%Ef_sw_l = Ef_sw_l
-        
+
         options%mp_options%update_interval = update_interval
+        if (top_mp_level < 0) then top_mp_level = options%nz + top_mp_level
         options%mp_options%top_mp_level = top_mp_level
         options%mp_options%local_precip_fraction = local_precip_fraction
     end subroutine mp_parameters_namelist
-    
+
     subroutine lt_parameters_namelist(filename, options)
         implicit none
         character(len=*), intent(in) :: filename
         type(options_type), intent(inout)::options
         type(lt_options_type)::lt_options
-        
+
         integer :: name_unit
 
         integer :: vert_smooth
@@ -752,19 +753,19 @@ contains
         integer :: buffer                   ! number of grid cells to buffer around the domain MUST be >=1
         integer :: stability_window_size    ! window to average nsq over
         real :: max_stability               ! limits on the calculated Brunt Vaisala Frequency
-        real :: min_stability               ! these may need to be a little narrower. 
+        real :: min_stability               ! these may need to be a little narrower.
         real :: linear_contribution         ! multiplier on uhat,vhat before adding to u,v
         real :: linear_update_fraction      ! controls the rate at which the linearfield updates (should be calculated as f(in_dt))
-    
+
         real :: N_squared                   ! static Brunt Vaisala Frequency (N^2) to use
         logical :: remove_lowres_linear     ! attempt to remove the linear mountain wave from the forcing low res model
         real :: rm_N_squared                ! static Brunt Vaisala Frequency (N^2) to use in removing linear wind field
         real :: rm_linear_contribution      ! fractional contribution of linear perturbation to wind field to remove from the low-res field
-    
+
         logical :: spatial_linear_fields    ! use a spatially varying linear wind perturbation
         logical :: linear_mask              ! use a spatial mask for the linear wind field
         logical :: nsq_calibration          ! use a spatial mask to calibrate the nsquared (brunt vaisala frequency) field
-    
+
         ! Look up table generation parameters
         real :: dirmax, dirmin
         real :: spdmax, spdmin
@@ -774,7 +775,7 @@ contains
         logical :: read_LUT, write_LUT
         character(len=MAXFILELENGTH) :: u_LUT_Filename, v_LUT_Filename, LUT_Filename
         logical :: overwrite_lt_lut
-        
+
         ! define the namelist
         namelist /lt_parameters/ variable_N, smooth_nsq, buffer, stability_window_size, max_stability, min_stability, &
                                  linear_contribution, linear_update_fraction, N_squared, vert_smooth, &
@@ -782,15 +783,15 @@ contains
                                  spatial_linear_fields, linear_mask, nsq_calibration, &
                                  dirmax, dirmin, spdmax, spdmin, nsqmax, nsqmin, n_dir_values, n_nsq_values, n_spd_values, &
                                  read_LUT, write_LUT, u_LUT_Filename, v_LUT_Filename, overwrite_lt_lut, LUT_Filename
-        
+
          ! because lt_options could be in a separate file
          if (options%use_lt_options) then
              if (trim(filename)/=trim(get_options_file())) then
                  call version_check(filename,options)
              endif
          endif
-        
-        
+
+
         ! set default values
         variable_N = .True.
         smooth_nsq = .False.
@@ -798,19 +799,19 @@ contains
         stability_window_size = 2      ! window to average nsq over
         vert_smooth = 2
         max_stability = 6e-4           ! limits on the calculated Brunt Vaisala Frequency
-        min_stability = 1e-7           ! these may need to be a little narrower. 
-    
+        min_stability = 1e-7           ! these may need to be a little narrower.
+
         N_squared = 3e-5               ! static Brunt Vaisala Frequency (N^2) to use
         linear_contribution = 1        ! fractional contribution of linear perturbation to wind field (e.g. u_hat multiplied by this)
         remove_lowres_linear = .False. ! attempt to remove the linear mountain wave from the forcing low res model
         rm_N_squared = 3e-5            ! static Brunt Vaisala Frequency (N^2) to use in removing linear wind field
         rm_linear_contribution = 1     ! fractional contribution of linear perturbation to wind field to remove from the low-res field
-    
+
         linear_update_fraction = 0.2   ! fraction of linear perturbation to add each time step
         spatial_linear_fields = .True. ! use a spatially varying linear wind perturbation
         linear_mask = .False.          ! use a spatial mask for the linear wind field
         nsq_calibration = .False.      ! use a spatial mask to calibrate the nsquared (brunt vaisala frequency) field
-    
+
         ! look up table generation parameters
         dirmax = 2*pi
         dirmin = 0
@@ -821,21 +822,21 @@ contains
         n_dir_values = 24
         n_nsq_values = 5
         n_spd_values = 6
-        
+
         read_LUT = .False.
         write_LUT = .True.
         u_LUT_Filename = "MISSING"
         v_LUT_Filename = "MISSING"
         LUT_Filename   = "MISSING"
         overwrite_lt_lut = .True.
-        
+
         ! read the namelist options
         if (options%use_lt_options) then
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=lt_parameters)
             close(name_unit)
         endif
-        
+
         ! store everything in the lt_options structure
         lt_options%buffer = buffer
         lt_options%stability_window_size = stability_window_size
@@ -843,14 +844,14 @@ contains
         lt_options%min_stability = min_stability
         lt_options%variable_N = variable_N
         lt_options%smooth_nsq = smooth_nsq
-        
-        if (vert_smooth<0) then 
+
+        if (vert_smooth<0) then
             write(*,*) " Vertical smoothing must be a positive integer"
             write(*,*) " vert_smooth = ",vert_smooth
             stop
         endif
         lt_options%vert_smooth=vert_smooth
-        
+
         lt_options%N_squared = N_squared
         lt_options%linear_contribution = linear_contribution
         lt_options%remove_lowres_linear = remove_lowres_linear
@@ -878,13 +879,13 @@ contains
                 u_LUT_Filename=LUT_Filename
             endif
         endif
-        
+
         lt_options%u_LUT_Filename = u_LUT_Filename
         lt_options%v_LUT_Filename = v_LUT_Filename
         lt_options%overwrite_lt_lut = overwrite_lt_lut
-        
+
         ! copy the data back into the global options data structure
-        options%lt_options = lt_options        
+        options%lt_options = lt_options
     end subroutine lt_parameters_namelist
 
 
@@ -893,53 +894,53 @@ contains
         character(len=*), intent(in) :: filename
         type(options_type), intent(inout)::options
         type(adv_options_type)::adv_options
-        
+
         integer :: name_unit
 
         logical :: boundary_buffer          ! apply some smoothing to the x and y boundaries in MPDATA
         logical :: flux_corrected_transport ! use the flux corrected transport option in MPDATA
         integer :: mpdata_order             ! MPDATA order of correction (e.g. 1st=upwind, 2nd=classic, 3rd=better)
-        
+
         ! define the namelist
         namelist /adv_parameters/ boundary_buffer, flux_corrected_transport, mpdata_order
-        
+
          ! because adv_options could be in a separate file
          if (options%use_adv_options) then
              if (trim(filename)/=trim(get_options_file())) then
                  call version_check(filename,options)
              endif
          endif
-        
-        
+
+
         ! set default values
         boundary_buffer = .False.
-        flux_corrected_transport = .True. 
+        flux_corrected_transport = .True.
         mpdata_order = 2
-        
+
         ! read the namelist options
         if (options%use_adv_options) then
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=adv_parameters)
             close(name_unit)
         endif
-        
+
         ! store everything in the adv_options structure
         adv_options%boundary_buffer = boundary_buffer
         adv_options%flux_corrected_transport = flux_corrected_transport
         adv_options%mpdata_order = mpdata_order
-        
+
         ! copy the data back into the global options data structure
         options%adv_options = adv_options
     end subroutine adv_parameters_namelist
-    
-    
+
+
     subroutine set_default_LU_categories(urban_category, ice_category, water_category, LU_Categories)
         ! if various LU categories were not defined in the namelist (i.e. they == -1) then attempt
-        ! to define default values for them based on the LU_Categories variable supplied. 
+        ! to define default values for them based on the LU_Categories variable supplied.
         implicit none
         integer, intent(inout) :: urban_category, ice_category, water_category
         character(len=MAXVARLENGTH), intent(in) :: LU_Categories
-        
+
         if (trim(LU_Categories)=="MODIFIED_IGBP_MODIS_NOAH") then
             if (urban_category==-1) urban_category = 13
             if (ice_category==-1)   ice_category = 15
@@ -966,59 +967,59 @@ contains
             if (water_category==-1) water_category = 17 ! and 21
             print*, "WARNING: not handling all varients of categories (e.g. permanent_snow=15 is, but permanent_snow_ice=22 is not)"
         endif
-        
+
     end subroutine set_default_LU_categories
 
-    
+
     subroutine bias_parameters_namelist(filename, options)
         implicit none
         character(len=*),   intent(in)   :: filename
         type(options_type), intent(inout):: options
-        
+
         type(bias_options_type)     ::  bias_options
-        
+
         integer :: name_unit
 
         character(len=MAXFILELENGTH):: bias_correction_filename ! file containing bias correction data
         character(len=MAXVARLENGTH) :: rain_fraction_var        ! name of variable containing the fraction to multiply rain by
-        
+
         ! define the namelist
         namelist /bias_parameters/ bias_correction_filename, rain_fraction_var
-        
+
          ! because adv_options could be in a separate file
          if (options%use_bias_correction) then
              if (trim(filename)/=trim(get_options_file())) then
                  call version_check(filename,options)
              endif
          endif
-        
-        
+
+
         ! set default values
         bias_correction_filename = options%init_conditions_file
         rain_fraction_var        = "rain_fraction"
-        
+
         ! read the namelist options
         if (options%use_bias_correction) then
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=bias_parameters)
             close(name_unit)
         endif
-        
+
         ! store everything in the bias_options structure
         bias_options%filename           = bias_correction_filename
         bias_options%rain_fraction_var  = rain_fraction_var
-        
+
         ! copy the data back into the global options data structure
         options%bias_options = bias_options
     end subroutine bias_parameters_namelist
 
-    
+
     subroutine lsm_parameters_namelist(filename, options)
         implicit none
         character(len=*), intent(in) :: filename
         type(options_type), intent(inout)::options
         type(lsm_options_type)::lsm_options
-        
+
         integer :: name_unit
 
         character(len=MAXVARLENGTH) :: LU_Categories ! Category definitions (e.g. USGS, MODIFIED_IGBP_MODIS_NOAH)
@@ -1027,38 +1028,38 @@ contains
         integer :: urban_category                    ! index that defines the urban category in LU_Categories
         integer :: ice_category                      ! index that defines the ice category in LU_Categories
         integer :: water_category                    ! index that defines the water category in LU_Categories
-        
+
         ! define the namelist
         namelist /lsm_parameters/ LU_Categories, update_interval, monthly_vegfrac, &
                                   urban_category, ice_category, water_category
-        
+
          ! because adv_options could be in a separate file
          if (options%use_lsm_options) then
              if (trim(filename)/=trim(get_options_file())) then
                  call version_check(filename,options)
              endif
          endif
-        
-        
+
+
         ! set default values
         LU_Categories   = "MODIFIED_IGBP_MODIS_NOAH"
         update_interval = 300 ! 5 minutes
         monthly_vegfrac = .False.
-        
+
         ! default values for these will be set after reading LU_Categories
         urban_category  = -1
         ice_category    = -1
         water_category  = -1
-        
+
         ! read the namelist options
         if (options%use_lsm_options) then
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=lsm_parameters)
             close(name_unit)
         endif
-        
+
         call set_default_LU_categories(urban_category, ice_category, water_category, LU_Categories)
-        
+
         ! store everything in the lsm_options structure
         lsm_options%LU_Categories   = LU_Categories
         lsm_options%monthly_vegfrac = monthly_vegfrac
@@ -1066,7 +1067,7 @@ contains
         lsm_options%urban_category  = urban_category
         lsm_options%ice_category    = ice_category
         lsm_options%water_category  = water_category
-        
+
         ! copy the data back into the global options data structure
         options%lsm_options = lsm_options
     end subroutine lsm_parameters_namelist
@@ -1077,11 +1078,11 @@ contains
         implicit none
         character(len=*), intent(in) :: filename
         type(options_type), intent(inout) :: options
-        
+
         integer :: name_unit, this_level
         real, allocatable, dimension(:) :: dz_levels
         real, dimension(45) :: fulldz
-        
+
         namelist /z_info/ dz_levels
         this_level=1
 
@@ -1089,11 +1090,11 @@ contains
         if (options%readdz) then
             allocate(dz_levels(MAXLEVELS))
             dz_levels=-999
-            
+
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=z_info)
             close(name_unit)
-            
+
             ! if nz wasn't specified in the namelist, we assume a HUGE number of levels
             ! so now we have to figure out what the actual number of levels read was
             if (options%nz==MAXLEVELS) then
@@ -1106,7 +1107,7 @@ contains
                 options%nz=this_level
             endif
             allocate(options%dz_levels(options%nz))
-                    
+
             options%dz_levels(1:options%nz)=dz_levels(1:options%nz)
             deallocate(dz_levels)
         else
@@ -1122,15 +1123,15 @@ contains
             allocate(options%dz_levels(options%nz))
             options%dz_levels=fulldz(1:options%nz)
         endif
-        
+
     end subroutine model_levels_namelist
-    
+
     !> ----------------------------------------------------------------------------
     !!  Read in the name of the boundary condition files from a text file
     !!
     !!  @param      filename        The name of the text file to read
     !!  @param[out] forcing_files   An array to store the filenames in
-    !!  @retval     nfiles          The number of files read. 
+    !!  @retval     nfiles          The number of files read.
     !!
     !! ----------------------------------------------------------------------------
     function read_forcing_file_names(filename, forcing_files) result(nfiles)
@@ -1141,7 +1142,7 @@ contains
         integer :: file_unit
         integer :: i, error
         character(len=MAXFILELENGTH) :: temporary_file
-        
+
         open(unit=io_newunit(file_unit), file=filename)
         i=0
         error=0
@@ -1167,7 +1168,7 @@ contains
         endif
 
     end function read_forcing_file_names
-    
+
     subroutine filename_namelist(filename, options)
         ! read in filenames from up to two namelists
         ! init_conditions_file = high res grid data
@@ -1182,24 +1183,24 @@ contains
                                         linear_mask_file, nsq_calibration_file
         character(len=MAXFILELENGTH), allocatable :: boundary_files(:), ext_wind_files(:)
         integer :: name_unit, nfiles, i
-        
+
         ! set up namelist structures
         namelist /files_list/ init_conditions_file, output_file, boundary_files, forcing_file_list, &
                               linear_mask_file, nsq_calibration_file
         namelist /ext_winds_info/ ext_wind_files
-        
+
         linear_mask_file="MISSING"
         nsq_calibration_file="MISSING"
         allocate(boundary_files(MAX_NUMBER_FILES))
         boundary_files="MISSING"
         forcing_file_list="MISSING"
-        
+
         open(io_newunit(name_unit), file=filename)
         read(name_unit,nml=files_list)
         close(name_unit)
-        
+
         options%init_conditions_file=init_conditions_file
-        
+
         i=1
         do while (trim(boundary_files(i))/=trim("MISSING"))
             i=i+1
@@ -1212,11 +1213,11 @@ contains
                 stop "No boundary conditions files specified."
             endif
         endif
-        
+
         allocate(options%boundary_files(nfiles))
         options%boundary_files=boundary_files(1:nfiles)
         deallocate(boundary_files)
-        
+
         options%output_file=output_file
         if (trim(linear_mask_file)=="MISSING") then
             linear_mask_file = options%init_conditions_file
@@ -1226,14 +1227,14 @@ contains
             nsq_calibration_file = options%init_conditions_file
         endif
         options%nsq_calibration_file=nsq_calibration_file
-        
+
         if (options%external_winds) then
             allocate(ext_wind_files(options%ext_winds_nfiles))
-            
+
             open(io_newunit(name_unit), file=filename)
             read(name_unit,nml=ext_winds_info)
             close(name_unit)
-            
+
             allocate(options%ext_wind_files(options%ext_winds_nfiles))
             options%ext_wind_files=ext_wind_files
             deallocate(ext_wind_files)

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -463,7 +463,7 @@ contains
         integer :: ntimesteps
         double precision :: end_mjd
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
-        logical :: ideal, readz, readdz, debug, external_winds, surface_io_only, &
+        logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction
@@ -475,7 +475,7 @@ contains
                                         bias_options_filename
 
         namelist /parameters/ ntimesteps,outputinterval,inputinterval, surface_io_only, &
-                              dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, &
+                              dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, interactive, &
                               external_winds,buffer,n_ext_winds,advect_density,smooth_wind_distance, &
                               mean_winds,mean_fields,restart, z_is_geopotential, z_is_on_interface,&
                               date, calendar, high_res_soil_state,rotation_scale_height,warning_level, &
@@ -502,6 +502,7 @@ contains
         restart=.False.
         ideal=.False.
         debug=.False.
+        interactive=.False.
         warning_level=-9999
         readz=.False.
         readdz=.True.
@@ -616,6 +617,7 @@ contains
         options%mean_fields = mean_fields
         options%advect_density = advect_density
         options%debug = debug
+        options%interactive = interactive
         options%warning_level = warning_level
         options%rotation_scale_height = rotation_scale_height
         options%use_agl_height = use_agl_height

--- a/main/time_step.f90
+++ b/main/time_step.f90
@@ -447,7 +447,9 @@ contains
             endif
             ! set an upper bound on dt to keep microphysics and convection stable (?) not sure what time is required here. 
             dt = min(dt,120.0) !better min=180?
-            if (options%debug) write(*,"(A,f5.1,A,f5.1,A$)") char(13), 100-max(0.0,(end_time-model_time-dt)/options%in_dt*100)," %  dt=",dt,"s  "
+            if (options%interactive) then
+                write(*,"(A,f5.1,A,f5.1,A$)") char(13), 100-max(0.0,(end_time-model_time-dt)/options%in_dt*100)," %  dt=",dt,"s  "
+            endif
             ! Make sure we don't over step the forcing period
             if ((model_time + dt) > end_time) then
                 dt = end_time - model_time

--- a/physics/linear_winds.f90
+++ b/physics/linear_winds.f90
@@ -938,9 +938,11 @@ contains
                 ! set the domain wide U and V values to the current u and v values
                 ! this could use u/v_perturbation, but those would need to be put in a linearizable structure...
                 do k=1, n_spd_values
-                    !$omp critical (print_lock)
-                    write(*,"(A,f5.1,A$)") char(13), loops_completed/real(n_dir_values*n_spd_values)*100," %"
-                    !$omp end critical (print_lock)
+                    if (options%interactive) then
+                        !$omp critical (print_lock)
+                        write(*,"(A,f5.1,A$)") char(13), loops_completed/real(n_dir_values*n_spd_values)*100," %"
+                        !$omp end critical (print_lock)
+                    endif
                     do j=1, n_nsq_values
                         u = calc_u( dir_values(i), spd_values(k) )
                         v = calc_v( dir_values(i), spd_values(k) )

--- a/physics/linear_winds.f90
+++ b/physics/linear_winds.f90
@@ -48,7 +48,7 @@ module linear_theory_winds
     logical :: variable_N
     logical :: smooth_nsq
     real    :: N_squared
-    
+
     !! unfortunately these have to be allocated every call because we could be calling on both the high-res
     !! domain and the low res domain (to "remove" the linear winds)
     real,                       allocatable,    dimension(:,:)  :: k, l, kl, sig
@@ -101,7 +101,7 @@ module linear_theory_winds
     integer :: n_spd_values=10
 
     complex,parameter :: j= (0,1)
-    
+
     real, parameter :: SMALL_VALUE = 1e-15
 
 contains
@@ -265,8 +265,8 @@ contains
 
         if (variable_N) then
             do i=1,nz
-                top_layer    = max(i+stability_window_size, nz)
-                bottom_layer = min(i-stability_window_size,  i)
+                top_layer    = min(i+stability_window_size, nz)
+                bottom_layer = max(i-stability_window_size,  1)
 
                 dz     = sum(domain%z (:,top_layer,:)-domain%z (:,bottom_layer,:))/(nx*ny) ! distance between top layer and bottom layer
                 dtheta = sum(domain%th(:,top_layer,:)-domain%th(:,bottom_layer,:))/(nx*ny) ! average temperature change between layers
@@ -278,7 +278,7 @@ contains
             ! calculate the mean stability over the entire profile
             BV_freq=sum(vertical_N)/nz
             ! impose limits so the linear solution doesn't go crazy in really stable or unstable air
-            BV_freq=max(min(BV_freq, min_stability), max_stability)
+            BV_freq=min(max(BV_freq, min_stability), max_stability)
         else
             ! or just use the supplied BV frequency
             BV_freq=N_squared
@@ -301,17 +301,17 @@ contains
         real,                     intent(in)    :: z    ! elevation at which to compute the linear solution
         complex(C_DOUBLE_COMPLEX),intent(in)    :: fourier_terrain(:,:) ! FFT(terrain)
         type(linear_theory_type), intent(inout) :: lt_data
-        
-        
+
+
         integer :: nx, ny ! store the size of the grid
-        
+
         nx = size(fourier_terrain, 1)
         ny = size(fourier_terrain, 2)
-        
+
         lt_data%sig  = U * lt_data%k + V * lt_data%l
         ! prevent divide by zero
         where(lt_data%sig == 0) lt_data%sig = SMALL_VALUE
-        
+
         lt_data%denom = lt_data%sig**2 ! -f**2 ! to add coriolis
 
         lt_data%msq   = Nsq / lt_data%denom * lt_data%kl
@@ -329,7 +329,7 @@ contains
         !uhat = (0 - m) * ((sig * k) - (j * l * f)) * ineta / kl
         !vhat = (0 - m) * ((sig * l) + (j * k * f)) * ineta / kl
         ! removed coriolis term assumes the scale coriolis operates at is largely defined by the coarse model
-        ! if using e.g. a sounding or otherwise spatially constant u/v, then coriolis should be defined. 
+        ! if using e.g. a sounding or otherwise spatially constant u/v, then coriolis should be defined.
         lt_data%ineta = lt_data%ineta / (lt_data%kl / ((0 - lt_data%m) * lt_data%sig))
         lt_data%uhat  = lt_data%k * lt_data%ineta
         lt_data%vhat  = lt_data%l * lt_data%ineta
@@ -344,7 +344,7 @@ contains
 
         ! returns u_perturb and v_perturb
     end subroutine linear_perturbation
-    
+
     !>----------------------------------------------------------
     !! Compute linear wind perturbations to U and V and add them back to the domain
     !!
@@ -552,7 +552,7 @@ contains
                 !uhat = (0 - m) * ((sig * k) - (j * l * f)) * ineta / kl
                 !vhat = (0 - m) * ((sig * l) + (j * k * f)) * ineta / kl
                 ! removed coriolis term assumes the scale coriolis operates at is largely defined by the coarse model
-                ! if using e.g. a sounding or otherwise spatially constant u/v, then coriolis should be defined. 
+                ! if using e.g. a sounding or otherwise spatially constant u/v, then coriolis should be defined.
                 ineta = ineta / (kl / ((0 - m) * sig))
                 uhat(:,:,z) = k * ineta
                 vhat(:,:,z) = l * ineta
@@ -589,7 +589,7 @@ contains
                     i=ny
                     u_hat(1:nx-1,i,z) = (u_hat(1:nx-1,i,z) + u_hat(2:nx,i,z)) /2
                 endif
-                
+
                 ! If we are using density in the advection calculations, modify the linear perturbation
                 ! to get the vertical velocities closer to what they would be without density (boussinesq)
                 ! need to check if this makes the most sense when close to the surface
@@ -604,7 +604,7 @@ contains
                 !     v_hat(buffer:realnx+buffer,buffer:realny_v+buffer,z) = &
                 !         2*real(v_hat(buffer:realnx+buffer,buffer:realny_v+buffer,z))! / domain%rho(1:realnx,z,1:realny)
                 ! endif
-                
+
                 ! If we are removing linear winds from a low res field, subtract u_hat v_hat instead
                 ! real(real()) extracts real component of complex, then converts to a real data type (may not be necessary except for IO?)
                 if (reverse) then
@@ -729,12 +729,12 @@ contains
         type(linear_theory_type), intent(inout) :: lt_data
         integer, intent(in) :: nx, ny
         real,    intent(in) :: dx
-        
+
         integer(C_SIZE_T) :: n_elements
         real :: gain, offset
         integer :: i
 
-        
+
         allocate(lt_data%k(nx,ny))
         allocate(lt_data%l(nx,ny))
         allocate(lt_data%kl(nx,ny))
@@ -771,7 +771,7 @@ contains
         ! finally compute the kl combination array
         lt_data%kl = lt_data%k**2 + lt_data%l**2
         WHERE (lt_data%kl == 0.0) lt_data%kl = SMALL_VALUE
-        
+
         ! using fftw_alloc routines to ensure better allignment for vectorization may not be threadsafe
         n_elements = nx * ny
         !$omp critical (fftw_lock)
@@ -780,7 +780,7 @@ contains
         lt_data%vh_aligned_data = fftw_alloc_complex(n_elements)
         lt_data%vp_aligned_data = fftw_alloc_complex(n_elements)
         !$omp end critical (fftw_lock)
-        
+
         call c_f_pointer(lt_data%uh_aligned_data,   lt_data%uhat,       [nx,ny])
         call c_f_pointer(lt_data%up_aligned_data,   lt_data%u_perturb,  [nx,ny])
         call c_f_pointer(lt_data%vh_aligned_data,   lt_data%vhat,       [nx,ny])
@@ -792,14 +792,14 @@ contains
         lt_data%vplan = fftw_plan_dft_2d(ny,nx, lt_data%vhat, lt_data%v_perturb, FFTW_BACKWARD, FFTW_MEASURE) ! alternatives to MEASURE are PATIENT, or ESTIMATE
         !$omp end critical (fftw_lock)
 
-        
+
     end subroutine initialize_linear_theory_data
 
 
     subroutine destroy_linear_theory_data(lt_data)
         implicit none
         type(linear_theory_type), intent(inout) :: lt_data
-        
+
         if (allocated(lt_data%k))       deallocate(lt_data%k)
         if (allocated(lt_data%l))       deallocate(lt_data%l)
         if (allocated(lt_data%kl))      deallocate(lt_data%kl)
@@ -816,7 +816,7 @@ contains
         call fftw_free(lt_data%vh_aligned_data)
         call fftw_free(lt_data%vp_aligned_data)
         !$omp end critical (fftw_lock)
-        
+
         NULLIFY(lt_data%uhat)
         NULLIFY(lt_data%u_perturb)
         NULLIFY(lt_data%vhat)
@@ -838,7 +838,7 @@ contains
         class(linearizable_type),intent(inout)::domain
         type(options_type), intent(in) :: options
         logical, intent(in) :: reverse
-        
+
         ! local variables used to calculate the LUT
         real :: u,v, layer_height
         integer :: nx,ny,nz, i,j,k,z, nxu,nyv, error
@@ -853,15 +853,15 @@ contains
 
         nxu = size(domain%u,1)
         nyv = size(domain%v,3)
-        
+
         fftnx = size(domain%fzs,1)
         fftny = size(domain%fzs,2)
-        ! note: 
+        ! note:
         ! buffer = (fftnx - nx)/2
 
         ! default assumes no errors in reading the LUT
         error = 0
-        
+
         ! store to make it easy to check dim sizes in read_LUT
         LUT_dims(:,1) = [nxu,nz,ny]
         LUT_dims(:,2) = [nx,nz,nyv]
@@ -893,7 +893,7 @@ contains
             allocate(rev_v_LUT(n_spd_values,n_dir_values,n_nsq_values,nx,nz,nyv))
             u_LUT=>rev_u_LUT
             v_LUT=>rev_v_LUT
-        else 
+        else
             ! this is the more common forward transform
             if (.not.options%lt_options%read_LUT) then
                 allocate(hi_u_LUT(n_spd_values,n_dir_values,n_nsq_values,nxu,nz,ny))
@@ -929,7 +929,7 @@ contains
             !$omp parallel default(shared) &
             !$omp private(i,j,k,z, u,v, layer_height)
             ! $omp private(lt_data_m)
-            
+
             ! initialization has to happen in each thread so each thread has its own copy
             ! lt_data_m is a threadprivate variable, within initialization, there are omp critical sections for fftw calls
             call initialize_linear_theory_data(lt_data_m, fftnx, fftny, domain%dx)
@@ -961,7 +961,7 @@ contains
                                 u_LUT(k,i,j,2:nx,z, :  ) = real( real(                                  &
                                         ( lt_data_m%u_perturb(1+buffer:nx+buffer-1,   1+buffer:ny+buffer) &
                                         + lt_data_m%u_perturb(2+buffer:nx+buffer,     1+buffer:ny+buffer)) )) / 2
-                                                         
+
                                 v_LUT(k,i,j, :,  z,2:ny) = real( real(                                      &
                                         ( lt_data_m%v_perturb(1+buffer:nx+buffer,     1+buffer:ny+buffer-1)   &
                                         + lt_data_m%v_perturb(1+buffer:nx+buffer,     2+buffer:ny+buffer)) )) / 2
@@ -987,7 +987,7 @@ contains
             write(*,"(A,f5.1,A$)") char(13), loops_completed/real(n_dir_values*n_spd_values)*100," %"
             write(*,*) char(10),"--------  Linear wind look up table generation complete ---------"
         endif
-        
+
         if ((options%lt_options%write_LUT).and.(.not.reverse)) then
             if ((options%lt_options%read_LUT) .and. (error == 0)) then
                 print*, "Not writing Linear Theory LUT to file because LUT was read from file"
@@ -1048,7 +1048,7 @@ contains
         logical, intent(in) :: reverse
         integer, intent(in) :: vsmooth
         integer, intent(in) :: winsz
-        
+
         integer :: nx,nxu, ny,nyv, nz, i,j,k, smoothz
         integer :: uk, vi !store a separate value of i for v and of k for u to we can handle nx+1, ny+1
         integer :: step, dpos, npos, spos, nexts, nextd, nextn
@@ -1086,12 +1086,12 @@ contains
         do k=1,ny
             do j=1,nz
                 do i=1,nx
-                    
+
                     ! look up vsmooth gridcells up to nz at the maximum
                     top = min(j+vsmooth, nz)
                     ! if (top-j)/=vsmooth, then look down enough layers to make the window vsmooth in size
                     bottom = max(1, j - (vsmooth - (top-j)) )
-                    
+
                     if (.not.reverse) then
                         domain%nsquared(i,j,k) = calc_stability(domain%th(i,bottom,k), domain%th(i,top,k),  &
                                                                 domain%pii(i,bottom,k),domain%pii(i,top,k), &
@@ -1101,9 +1101,9 @@ contains
                                                                 +domain%qrain(i,j,k)+domain%qsnow(i,j,k))
                         domain%nsquared(i,j,k) = max(min(domain%nsquared(i,j,k) * nsq_calibration(i,k), max_stability), min_stability)
                     else
-                        ! Low-res boundary condition variables will be in a different array format.  It should be 
+                        ! Low-res boundary condition variables will be in a different array format.  It should be
                         ! easy enough to call calc_stability after e.g. transposing z and y dimension, but some
-                        ! e.g. pii will not be set in the forcing data, so this may need a little thought. 
+                        ! e.g. pii will not be set in the forcing data, so this may need a little thought.
                         domain%nsquared(i,j,k) = 3e-6
                     endif
                 end do
@@ -1111,7 +1111,7 @@ contains
 
             if (smooth_nsq) then
                 do j=1,nz
-                    ! compute window as above. 
+                    ! compute window as above.
                     top = min(j+vsmooth,nz)
                     bottom = max(1, j - (vsmooth - (top-j)) )
 
@@ -1133,7 +1133,7 @@ contains
                 do i=1, nxu
                     uk = min(k,ny)
                     vi = min(i,nx)
-                    
+
                     !   First find the bounds of the region to average over
                     west  = max(i - winsz, 1)
                     east  = min(i + winsz,nx)
@@ -1151,7 +1151,7 @@ contains
                         v = domain%v(vi,j,k)
                     endif
                     n = n * ((top-bottom)+1)
-                    
+
                     ! Calculate the direction of the current grid cell wind
                     dpos = 1
                     curdir = calc_direction( u, v )
@@ -1183,13 +1183,13 @@ contains
                             npos = step
                         endif
                     end do
-                    
+
                     ! Calculate the weights and the "next" u/v position
                     ! "next" usually = pos+1 but for edge cases next = 1 or n
                     dweight = calc_weight(dir_values, dpos, nextd, curdir)
                     sweight = calc_weight(spd_values, spos, nexts, curspd)
                     nweight = calc_weight(nsq_values, npos, nextn, curnsq)
-                    
+
                     ! perform linear interpolation between LUT values
                     if (k<=ny) then
                         wind_first =      nweight  * (dweight * u_LUT(spos, dpos,npos, i,j,k) + (1-dweight) * u_LUT(spos, nextd,npos, i,j,k))   &
@@ -1344,11 +1344,11 @@ contains
                 write(*,*) "  from file: " // trim(options%linear_mask_file)
                 write(*,*) "  with var: "  // trim(options%linear_mask_var)
                 call io_read2d(options%linear_mask_file, options%linear_mask_var, domain%linear_mask)
-                
+
                 linear_mask = domain%linear_mask * linear_contribution
             endif
 
-            ! Stupidly simple adjustment to the linear wind field to account for using density. 
+            ! Stupidly simple adjustment to the linear wind field to account for using density.
             ! If we are using density in the advection calculations, modify the linear perturbation
             ! to get the vertical velocities closer to what they would be without density (boussinesq)
             ! need to check if this makes the most sense when close to the surface
@@ -1368,7 +1368,7 @@ contains
                 write(*,*) "  with var: "  // trim(options%nsq_calibration_var)
                 call io_read2d(options%nsq_calibration_file, options%nsq_calibration_var, domain%nsq_calibration)
                 nsq_calibration = domain%nsq_calibration
-                
+
                 where(nsq_calibration<1) nsq_calibration = 1 + 1/( (1-1/nsq_calibration)/100 )
                 where(nsq_calibration>1) nsq_calibration = 1 + (nsq_calibration-1)/100
             endif
@@ -1402,7 +1402,7 @@ contains
 
                 write(*,*) "Generating a spatially variable linear perturbation look up table"
                 call initialize_spatial_winds(domain, options, reverse)
-                
+
             endif
         endif
 
@@ -1410,7 +1410,7 @@ contains
     end subroutine setup_linwinds
 
     !>----------------------------------------------------------
-    !! Initialize and/or apply linear wind solution. 
+    !! Initialize and/or apply linear wind solution.
     !!
     !! Called from ICAR to update the U and V wind fields based on linear theory (W is calculated to balance U/V)
     !!
@@ -1431,13 +1431,13 @@ contains
         else
             rev=.False.
         endif
-        
+
         if (present(useDensity)) then
             useD=useDensity
         else
             useD=.False.
         endif
-        
+
         ! this is a little trickier, because it does have to be domain dependant... could at least be stored in the domain though...
         if (rev) then
             linear_contribution = options%lt_options%rm_linear_contribution

--- a/physics/linear_winds.f90
+++ b/physics/linear_winds.f90
@@ -1047,7 +1047,7 @@ contains
         integer, intent(in) :: vsmooth
         integer, intent(in) :: winsz
         
-        integer :: nx,ny,nz,i,j,k, smoothz
+        integer :: nx,nxu, ny,nyv, nz, i,j,k, smoothz
         integer :: uk, vi !store a separate value of i for v and of k for u to we can handle nx+1, ny+1
         integer :: step, dpos, npos, spos, nexts, nextd, nextn
         integer :: north, south, east, west, top, bottom, n
@@ -1057,6 +1057,8 @@ contains
         nx=size(domain%lat,1)
         ny=size(domain%lat,2)
         nz=size(domain%u,2)
+        nxu=size(domain%u,1)
+        nyv=size(domain%v,3)
 
         if (reverse) then
             u_LUT=>rev_u_LUT
@@ -1071,7 +1073,7 @@ contains
         endif
 
         if (reverse) print*, "WARNING using fixed nsq for linear wind removal: 3e-6"
-        !$omp parallel firstprivate(nx,ny,nz, reverse, vsmooth, winsz), default(none), &
+        !$omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz), default(none), &
         !$omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom), &
         !$omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v), &
         !$omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
@@ -1124,9 +1126,9 @@ contains
         !$omp end do
         !$omp barrier
         !$omp do
-        do k=1, ny+1
+        do k=1, nyv
             do j=1, nz
-                do i=1, nx+1
+                do i=1, nxu
                     uk = min(k,ny)
                     vi = min(i,nx)
                     

--- a/physics/linear_winds.f90
+++ b/physics/linear_winds.f90
@@ -1202,9 +1202,9 @@ contains
                                     + linear_update_fraction * (sweight*wind_first + (1-sweight)*wind_second)
 
                         if (reverse) then
-                            domain%u(i,j,k) = domain%u(i,j,k) - u_perturbation(i,j,k)
+                            domain%u(i,j,k) = domain%u(i,j,k) - u_perturbation(i,j,k) * linear_contribution
                         else
-                            domain%u(i,j,k) = domain%u(i,j,k) + u_perturbation(i,j,k)
+                            domain%u(i,j,k) = domain%u(i,j,k) + u_perturbation(i,j,k) * linear_mask(min(nx,i),min(ny,k))
                         endif
                     endif
                     if (i<=nx) then

--- a/physics/mp_driver.f90
+++ b/physics/mp_driver.f90
@@ -33,6 +33,7 @@ module microphysics
     use module_mp_wsm6,             only: wsm6, wsm6init
     use module_mp_simple,           only: mp_simple_driver
     use mod_wrf_constants !,          only: rhoair0, rhowater, rhosnow, cliq, cpv
+    use time,                       only: calc_year_fraction
     implicit none
 
     ! permit the microphysics to update on a longer time step than the advection
@@ -102,6 +103,7 @@ contains
     !!
     !!----------------------------------------------------------
     subroutine distribute_precip(current_precip, last_precip, local_fraction, precip_delta)
+        implicit none
         real, dimension(:,:), intent(inout) :: current_precip, last_precip
         real, intent(in) :: local_fraction
         logical, intent(in) :: precip_delta
@@ -116,14 +118,14 @@ contains
         if (precip_delta) then
             do j=2,ny-1
                 do i=2,nx-1
-                    this_precip(i,j) = current_precip(i,j)-last_precip(i,j)
+                    this_precip(i,j)    = current_precip(i,j)-last_precip(i,j)
                     current_precip(i,j) = last_precip(i,j)
                 end do
             end do
         else
             do j=2,ny-1
                 do i=2,nx-1
-                    this_precip(i,j) = last_precip(i,j)
+                    this_precip(i,j)    = last_precip(i,j)
                     current_precip(i,j) = current_precip(i,j)-last_precip(i,j)
                 end do
             end do
@@ -141,6 +143,51 @@ contains
         end do
                 
     end subroutine distribute_precip
+    
+    subroutine apply_rain_fraction(current_date, rain_fraction, current_precip, last_precip, precip_delta)
+        implicit none
+        double precision                        :: current_date
+        real, dimension(:,:,:), intent(in)      :: rain_fraction
+        real, dimension(:,:),   intent(inout)   :: current_precip, last_precip
+        logical,                intent(in)      :: precip_delta
+        ! relies on module variable this_precip as a temporary array
+        
+        integer :: i,j, nx,ny
+        integer :: x,y, point
+        integer :: n_correction_points, correction_step
+        real    :: year_fraction
+        
+        nx=size(current_precip,1)
+        ny=size(current_precip,2)
+        
+        n_correction_points = size(rain_fraction,3)
+        year_fraction = calc_year_fraction(current_date)
+        correction_step = nint(n_correction_points * year_fraction)
+        
+        if (precip_delta) then
+            do j=2,ny-1
+                do i=2,nx-1
+                    this_precip(i,j)    = current_precip(i,j)-last_precip(i,j)
+                    current_precip(i,j) = last_precip(i,j)
+                end do
+            end do
+        else
+            do j=2,ny-1
+                do i=2,nx-1
+                    this_precip(i,j)    = last_precip(i,j)
+                    current_precip(i,j) = current_precip(i,j)-last_precip(i,j)
+                end do
+            end do
+        endif
+        
+        do j=2,ny-1
+            do i=2,nx-1
+                current_precip(i,j) = current_precip(i,j)+this_precip(i,j)*rain_fraction(i,j,correction_step)
+            end do
+        end do
+                
+    end subroutine apply_rain_fraction
+
     
     !>----------------------------------------------------------
     !! Microphysical driver
@@ -299,6 +346,11 @@ contains
                                ,its,ite, jts,jte, kts,kte                        &
                                                                                  )
 
+            endif
+            
+            if (options%use_bias_correction) then
+                call apply_rain_fraction(model_time/86400.0+50000, domain%rain_fraction, domain%rain, last_rain, precip_delta)
+                call apply_rain_fraction(model_time/86400.0+50000, domain%rain_fraction, domain%snow, last_snow, precip_delta)
             endif
             
             if (options%mp_options%local_precip_fraction<1) then

--- a/physics/mp_driver.f90
+++ b/physics/mp_driver.f90
@@ -162,7 +162,8 @@ contains
         
         n_correction_points = size(rain_fraction,3)
         year_fraction = calc_year_fraction(current_date)
-        correction_step = nint(n_correction_points * year_fraction)
+        correction_step = min(  floor(n_correction_points * year_fraction)+1, &
+                                n_correction_points)
         
         if (precip_delta) then
             do j=2,ny-1
@@ -273,7 +274,7 @@ contains
             
             ! If we are going to distribute the current precip over a few grid cells, we need to keep track of
             ! the last_precip so we know how much fell
-            if (options%mp_options%local_precip_fraction<1) then
+            if ((options%mp_options%local_precip_fraction<1).or.(options%use_bias_correction)) then
                 last_rain=domain%rain
                 last_snow=domain%snow
             endif

--- a/physics/ra_simple.f90
+++ b/physics/ra_simple.f90
@@ -1,16 +1,16 @@
 !>----------------------------------------------------------
 !! Very simple radiation code modeled after the description in Finch and Best(2004?)
-!! of Reiff et al. 1984 shortwave and Idso and Jackson (1969) longwave. 
-!! 
-!! Clearsky Shortwave radiation is calculated as a function of day of year and time of day. 
+!! of Reiff et al. 1984 shortwave and Idso and Jackson (1969) longwave.
+!!
+!! Clearsky Shortwave radiation is calculated as a function of day of year and time of day.
 !! Cloudy Shortwave is calculated as clearsky SW * f(cloud cover) [0.25-1]
-!! 
+!!
 !! Cloud cover is calculated as in Xu and Randal (1996) as f(surface_RH, qc+qs+qr)
-!! 
+!!
 !! Clearsky Longwave radiation is calculated as f(Tair)
 !! Cloudy longwave is scaled up by a f(cloud cover) [1-1.2]
 !!
-!! The entry point to the code is ra_simple. 
+!! The entry point to the code is ra_simple.
 !!
 !! <pre>
 !! Call tree graph :
@@ -18,13 +18,13 @@
 !!  [cloudfrac->],
 !!  [shortwave->],
 !!  [longwave->]
-!! 
+!!
 !! High level routine descriptions / purpose
 !!   ra_simple          - loops over X,Y grid cells, calls cloudfrac, shortwave,longwave on columns
 !!   cloudfrac           - calculates the cloud fraction following Xu and Randall (1996)
 !!   shortwave           - calculates shortwave at the surface following Reiff et al (1984)
 !!   longwave               - calculates longwave at the surface following Idso and Jackson (1969)
-!! 
+!!
 !! Driver inputs: p,th,pii,rho,qv,qc,qr,qs,rain,snow,dt,dz,nx,ny,nz
 !!   p   = pressure                      - 3D - input  - Pa     - (nx,nz,ny)
 !!   th  = potential temperature         - 3D - in/out - K      - (nx,nz,ny)
@@ -57,21 +57,21 @@ contains
         type(domain_type), intent(in) :: domain
         type(options_type),intent(in)    :: options
         integer :: nx,ny
-        
+
         nx=size(domain%lat,1)
         ny=size(domain%lat,2)
         allocate(cos_lat_m(nx,ny))
         allocate(sin_lat_m(nx,ny))
-        
+
         cos_lat_m=cos(domain%lat/360.0 * 2*pi)
         sin_lat_m=sin(domain%lat/360.0 * 2*pi)
-        
+
     end subroutine ra_simple_init
 
 !   day_of_year=calc_day_of_year(date)
 !   time_of_day=calc_time_of_day(date)
 
-    
+
     function relative_humidity(t,qv,p,j,nx)
         implicit none
         real,dimension(nx) :: relative_humidity
@@ -79,7 +79,7 @@ contains
         real,intent(in),dimension(:,:,:)::qv,p
         integer,intent(in)::j,nx
         real,dimension(nx) :: mr, e, es
-        
+
         ! convert sensible humidity to mixing ratio
         mr=qv(:,1,j)/(1-qv(:,1,j))
         ! convert mixing ratio to vapor pressure
@@ -93,25 +93,25 @@ contains
         where(relative_humidity>(1-MINIMUM_RH)) relative_humidity=1-MINIMUM_RH
         where(relative_humidity<MINIMUM_RH) relative_humidity=MINIMUM_RH
     end function relative_humidity
-    
+
     function shortwave(day_frac, cloud_cover, solar_elevation,nx)
 !       compute shortwave down at the surface based on solar elevation, fractional day of the year, and cloud fraction
 !       based on Reiff et al. (1984)
         implicit none
         real, dimension(nx) :: shortwave
         real, intent(in), dimension(nx) :: day_frac, cloud_cover, solar_elevation
-        
+
         real, dimension(nx) :: sin_solar_elev
         integer, intent(in) :: nx
-        
+
         sin_solar_elev = sin(solar_elevation)
         shortwave=So * (1+0.035*cos(day_frac * 2*pi)) * sin_solar_elev * (0.48+0.29*sin_solar_elev)
-        
+
         ! note it is cloud_cover**3.4 in Reiff, but this makes almost no difference and integer powers are fast
         shortwave=shortwave * (1 - (0.75 * (cloud_cover**3)) )
-        
+
     end function shortwave
-    
+
     function longwave(T_air, cloud_cover,nx)
 !       compute longwave down at the surface based on air temperature and cloud fraction
 !       based on Idso and Jackson (1969)
@@ -120,13 +120,13 @@ contains
         real, intent(in), dimension(nx) :: T_air,cloud_cover
         real, dimension(nx) :: effective_emissivity
         integer, intent(in) :: nx
-        
+
         effective_emissivity = 1 - 0.261 * exp((-7.77e-4) * (273.16-T_air)**2)
         longwave = effective_emissivity * stefan_boltzmann * T_air**4
-        
+
         longwave = longwave * (1+0.2*cloud_cover)
     end function longwave
-    
+
     function cloudfrac(rh,qc,nx)
 !       Calculate the cloud fraction based on cloud water content (qc) and relative humidity
 !       based on equations from Xu and Randal (1996)
@@ -135,20 +135,20 @@ contains
         real,intent(in),dimension(nx)::rh,qc
         integer, intent(in) :: nx
         real,dimension(nx)::temporary
-        
+
         temporary=((1-rh)*qc)**0.25
         where(temporary >1) temporary=1
         where(temporary <0.0001) temporary=0.0001
-        
+
         cloudfrac=qc-qcmin
         where(cloudfrac<0) cloudfrac=0
-        
+
         cloudfrac=(rh**0.25) * (1-exp((-2000*(cloudfrac)) / temporary))
         where(cloudfrac<0) cloudfrac=0
         where(cloudfrac>1) cloudfrac=1
-        
+
     end function
-    
+
     function calc_solar_elevation(date,lon,j,nx,day_frac)
         implicit none
         real, dimension(nx) :: calc_solar_elevation
@@ -156,26 +156,34 @@ contains
         real, dimension(:,:), intent(in) :: lon
         integer,intent(in) :: j, nx
         real, dimension(:), intent(out) :: day_frac
-        
+
         integer :: i
         real, dimension(nx) :: declination,day_of_year,hour_angle
-        
+
         do i=1,nx
             day_of_year(i) = floor(calc_day_of_year(date + lon(i,j)/360.0))
             hour_angle(i) = 2*pi* mod(date+0.5 + lon(i,j)/360.0,1.0)
         end do
         day_frac=day_of_year/365.25
-        
+
         ! fast approximation see : http://en.wikipedia.org/wiki/Position_of_the_Sun
         declination = (-0.4091) * cos(2.0*pi/365.0*(day_of_year+10))
-        calc_solar_elevation = sin_lat_m(:,j) * sin(declination) + & 
+        calc_solar_elevation = sin_lat_m(:,j) * sin(declination) + &
                                cos_lat_m(:,j) * cos(declination) * cos(hour_angle)
+
+        ! due to float precision errors, it is possible to exceed (-1 - 1) in which case asin will break
+        where(calc_solar_elevation < -1)
+            calc_solar_elevation = -1
+        elsewhere(calc_solar_elevation > 1)
+            calc_solar_elevation = 1
+        endwhere
+
         calc_solar_elevation = asin(calc_solar_elevation)
 
         ! if the sun is below the horizon just set elevation to 0
         where(calc_solar_elevation<0) calc_solar_elevation=0
     end function calc_solar_elevation
-    
+
     subroutine ra_simple(theta,pii,qv,qc,qs,qr,p,swdown,lwdown,cloud_cover,lat,lon,date,options,dt)
         implicit none
         real,dimension(:,:,:), intent(inout) :: theta
@@ -188,49 +196,49 @@ contains
         real :: coolingrate
         integer :: nx,ny,j,k,nz
         real, allocatable, dimension(:) :: rh,T_air,solar_elevation, hydrometeors,day_frac
-        
-        
+
+
         !$omp parallel private(nx,ny,nz,j,rh,T_air,solar_elevation,hydrometeors,day_frac,coolingrate) &
         !$omp shared(theta,pii,qv,p,qc,qs,qr,date,lon,cloud_cover,swdown,lwdown)
         nx=size(lat,1)
         ny=size(lat,2)
         nz=size(qv,2)
-        
+
         allocate(rh(nx))
         allocate(T_air(nx))
         allocate(solar_elevation(nx))
         allocate(hydrometeors(nx))
         allocate(day_frac(nx))
-        
+
         ! 1.5K/day radiative cooling rate (300 = W/m^2 at 270K)
-        coolingrate=1.5*(dt/86400.0) *stefan_boltzmann / 300.0 
-        
-        
+        coolingrate=1.5*(dt/86400.0) *stefan_boltzmann / 300.0
+
+
         !$omp do
         do j=2,ny-1
-            
+
             T_air=theta(:,1,j)*pii(:,1,j)
             rh=relative_humidity(T_air,qv,p,j,nx)
-            
+
             hydrometeors=qc(:,1,j)+qs(:,1,j)+qr(:,1,j)
             do k=2,nz
                 hydrometeors=hydrometeors+qc(:,k,j)+qs(:,k,j)+qr(:,k,j)
             end do
             where(hydrometeors<0) hydrometeors = 0
-            
+
             solar_elevation=calc_solar_elevation(date,lon,j,nx,day_frac)
-            
+
             cloud_cover(:,j) = cloudfrac(rh,hydrometeors,nx)
             swdown(:,j) = shortwave(day_frac,cloud_cover(:,j),solar_elevation,nx)
             lwdown(:,j) = longwave(T_air,cloud_cover(:,j),nx)
             ! apply a simple radiative cooling to the atmosphere
             theta(2:nx-1,:,j)=theta(2:nx-1,:,j) - (((theta(2:nx-1,:,j)*pii(2:nx-1,:,j))**4) * coolingrate)
-            
+
         end do
         !$omp end do
-        
+
         deallocate(rh,T_air,solar_elevation, hydrometeors, day_frac)
         !$omp end parallel
-        
+
     end subroutine ra_simple
 end module module_ra_simple

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -153,6 +153,9 @@
     !   Doesn't do much at the moment, increases output print at runtime
     debug = true,
     warning_level = 4, ! 0-10 increases the level of errors it warns about and quits over (slightly)
+    
+    ! controls printing of % completed for longer processes.  Nice to see if it is running in a console, not nice to see in a log file. 
+    interactive=False
 
     !   If the following are true, their respective namelists (below) will also be read in. 
     !   Read parameters for advection

--- a/utilities/debug_utils.f90
+++ b/utilities/debug_utils.f90
@@ -10,8 +10,8 @@ contains
         type(domain_type),  intent(inout)   :: domain
         character(len=*),   intent(in)      :: error_msg
         
-        call check_var(domain%th,       name="th",      msg=error_msg, less_than    =100.0)
-        call check_var(domain%th,       name="th",      msg=error_msg, greater_than =600.0)
+        call check_var(domain%th,       name="th",      msg=error_msg, less_than    =100.0,fix=.True.)
+        call check_var(domain%th,       name="th",      msg=error_msg, greater_than =600.0,fix=.True.)
         call check_var(domain%qv,       name="qv",      msg=error_msg, less_than    =0.0, fix=.True.)
         call check_var(domain%cloud,    name="cloud",   msg=error_msg, less_than    =0.0, fix=.True.)
         call check_var(domain%ice,      name="ice",     msg=error_msg, less_than    =0.0, fix=.True.)

--- a/utilities/time.f90
+++ b/utilities/time.f90
@@ -16,7 +16,7 @@ module time
     integer :: calendar
     integer, dimension(13) :: month_start
     private
-    public :: time_init, date_to_mjd, calendar_date, calc_day_of_year, parse_date
+    public :: time_init, date_to_mjd, calendar_date, calc_day_of_year, parse_date, calc_year_fraction
     public :: calendar
     public :: GREGORIAN, NOLEAP, THREESIXTY, YEAR_ZERO
 contains
@@ -161,6 +161,26 @@ contains
             calc_day_of_year = mod(mjd,360.0)
         endif
     end function calc_day_of_year
+
+
+    function calc_year_fraction(mjd)
+        implicit none
+        real :: calc_year_fraction
+        double precision, intent(in) :: mjd
+        double precision :: year_start
+        
+        integer :: year, month, day, hour, minute, second
+
+        if (calendar==GREGORIAN) then
+            call calendar_date(mjd,year, month, day, hour, minute, second)
+            year_start = date_to_mjd(year, 1,1,0,0,0)
+            calc_year_fraction = (mjd - year_start) / (date_to_mjd(year+1, 1,1,0,0,0) - year_start)
+        else if (calendar==NOLEAP) then
+            calc_year_fraction = calc_day_of_year(mjd) / 365.0
+        else if (calendar==THREESIXTY) then
+            calc_year_fraction = calc_day_of_year(mjd) / 360.0
+        endif
+    end function calc_year_fraction
 
     ! convert an input date string in the form YYYY/MM/DD or YYYY/MM/DD hh:mm:ss
     ! into integer variables


### PR DESCRIPTION
Adds capability to bias correct (microphysics only) precipitation at runtime ("online").  

Adds ability to turn % completed printing on / off with interactive = true/false in the parameters namelist

Adds surface pressure and ~hourly snowfall amounts to output files

Permits negative values to be specified for top_mp_level in which case top_mp_level will be specified as nz + top_mp_level

Various bug fixes