### PR TITLE
Immaterial blank-space fixes to source for compiling with gfortran v6…

### DIFF
--- a/main/init.f90
+++ b/main/init.f90
@@ -376,14 +376,14 @@ contains
         allocate(output%z(nxo,nzo,nyo))
         if (interpolate_dim==1) then
             if ((nxo/=(nxi+1)).or.(nyo/=nyi).or.(nzo/=nzi)) then
-                stop("Error copying z levels from mass grid to U grid, dimensions don't match")
+                stop ("Error copying z levels from mass grid to U grid, dimensions don't match")
             endif
             output%z(2:nxo-1,:,:) = (input%z(1:nxi-1,:,:) + input%z(2:nxi,:,:))/2
             output%z(1,:,:) = input%z(1,:,:)
             output%z(nxo,:,:) = input%z(nxi,:,:)
         else if (interpolate_dim==3) then
             if ((nyo/=(nyi+1)).or.(nxo/=nxi).or.(nzo/=nzi)) then
-                stop("Error copying z levels from mass grid to V grid, dimensions don't match")
+                stop ("Error copying z levels from mass grid to V grid, dimensions don't match")
             endif
             output%z(:,:,2:nyo-1) = (input%z(:,:,1:nyi-1) + input%z(:,:,2:nyi))/2
             output%z(:,:,1) = input%z(:,:,1)
@@ -624,7 +624,7 @@ contains
         ! if a 3d grid was also specified, then read those data in
         if ((options%readz).and.(options%ideal).and.(options%zvar.ne."")) then
             
-            stop("Reading Z from an external file is not currently supported, use a fixed dz")
+            stop ("Reading Z from an external file is not currently supported, use a fixed dz")
             
             call io_read(options%init_conditions_file,options%zvar, domain%z)
             ! dz also has to be calculated from the 3d z file

--- a/main/init_options.f90
+++ b/main/init_options.f90
@@ -69,7 +69,7 @@ contains
             elseif (error==-1) then
                 write(*,*) "Options filename = ", trim(options_file), " ...<cutoff>"
                 write(*,*) "Maximum filename length = ", MAXFILELENGTH
-                stop("ERROR: options filename too long")
+                stop ("ERROR: options filename too long")
             endif
         else
             options_file="icar_options.nml"

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@
 #			clean: 		removes objects and module files
 #			allclean: 	makes clean and removes executables
 #			cleanall: 	alias for allclean
-#			tests: 		makes various unit tests (not all work)
+#			test: 		makes various unit tests (not all work)
 #			icar: 		makes the primary model
 #			doc: 		make doxygen documentation in docs/html (requires doxygen)
 #
@@ -35,6 +35,7 @@
 # Dependencies: fftw, netcdf
 #	FFTW is available here: http://www.fftw.org/
 #		FFTW is a C library with fortran headers
+# JPH version 3 needed.
 #	netcdf is available here: http://www.unidata.ucar.edu/software/netcdf/
 #		netcdf is a fortran library and must be compiled with the same fortran
 #		compiler you are using to be compatible
@@ -60,10 +61,14 @@ F90=gfortran
 RM=/bin/rm
 CP=/bin/cp
 DOXYGEN=doxygen
-FFTW_PATH=/usr/local
+##JPH change default fftw path
+FFTW_PATH = ${FFTW}
+##FFTW_PATH=/usr/local
 LIBFFT = ${FFTW_PATH}/lib
 INCFFT = ${FFTW_PATH}/include
-NCDF_PATH = /usr/local
+##JPH change default netcdf path
+NCDF_PATH = ${NETCDF}
+##NCDF_PATH = #/usr/local 
 LIBNETCDF = -L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
 INCNETCDF = -I$(NCDF_PATH)/include
 
@@ -475,7 +480,7 @@ $(BUILD)vinterp.o: $(UTIL)vinterp.f90 $(BUILD)data_structures.o
 ###################################################################
 
 $(BUILD)mp_driver.o:$(PHYS)mp_driver.f90 $(BUILD)mp_thompson.o $(BUILD)mp_simple.o \
-					$(BUILD)mp_morrison.o $(BUILD)data_structures.o $(BUILD)mp_wsm6.o
+					$(BUILD)mp_morrison.o $(BUILD)data_structures.o $(BUILD)mp_wsm6.o $(BUILD)time.o
 	${F90} ${FFLAGS} $(PHYS)mp_driver.f90 -o $(BUILD)mp_driver.o
 
 $(BUILD)mp_morrison.o:$(PHYS)mp_morrison.f90 $(BUILD)data_structures.o

--- a/physics/cu_kf.f90
+++ b/physics/cu_kf.f90
@@ -1886,7 +1886,7 @@ CONTAINS
         ERR2=(QFNL-QINIT)*100./QINIT                                  
 !     WRITE(98,1110)QINIT,QFNL,ERR2                                  
 !        IF(ABS(ERR2).GT.0.05)STOP 'QVERR'                           
-        IF(ABS(ERR2).GT.0.05) stop( 'module_cu_kf.F: QVERR' )
+        IF(ABS(ERR2).GT.0.05) stop ( 'module_cu_kf.F: QVERR' )
         RELERR=ERR2*QINIT/(PPTFLX*TIMEC+1.E-10)                   
 !     WRITE(98,1120)RELERR                                       
 !     WRITE(98,*)'TDER, CPR, USR, TRPPT =',                     

--- a/physics/lsm_driver.f90
+++ b/physics/lsm_driver.f90
@@ -391,7 +391,7 @@ contains
         
         if (options%physics%landsurface==kLSM_SIMPLE) then
             write(*,*) "    Simple LSM (may not work?)"
-            stop("Simple LSM not settup, choose a different LSM options")
+            stop ("Simple LSM not settup, choose a different LSM options")
             call lsm_simple_init(domain,options)
         endif
         ! Noah Land Surface Model

--- a/physics/pbl_driver.f90
+++ b/physics/pbl_driver.f90
@@ -93,7 +93,7 @@ contains
         endif
         
         if (options%physics%boundarylayer==kPBL_YSU) then
-            stop( "YSU PBL not implemented yet")
+            stop ( "YSU PBL not implemented yet")
 !             call ysu(domain%Um, domain%Vm,   domain%th, domain%t,               &
 !                      domain%qv, domain%cloud,domain%ice,                        &
 !                      domain%p,domain%p_inter,domain%pii,                        &


### PR DESCRIPTION
….3.0 on Mac OSX, slight generalization of makefile, fixed one dependency in makefile.

Minor fixes to source files to include extra space after 'stop' command to result in successful build on Mac OSX with gfortran/gcc v6.3.0. Generalized makefile to remove hard-coded paths to /usr/local. Now requires environment variables NETCDF and FFTW. Added dependency time.o to mp_driver list.