### PR TITLE
adding analytics to ICAR's readthedocs page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,4 @@ pages:
 - Developing: developing.md
 - Errors: errors.md
 theme: readthedocs
+google_analytics: ['UA-108421993-4', 'icar.readthedocs.org']


### PR DESCRIPTION
This should be it.  Once you merge it, I'll test it...