### PR TITLE
Merge various bug fixes and updates, adds humidity and temperature options

### DIFF
--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -127,6 +127,9 @@
     !   If the temperature field in the forcing data is not potential temperature, then set this flag to False
     ! t_is_potential = .True.
 
+    !   If the water vapor field in the forcing data is specific humidity instead of mixing ratio, then set this flag to true.
+    ! qv_is_spec_humidity = .False.
+
     !   Distance to smooth winds over [m] ~100000 is reasonable
     !   larger values result in less large scale convergence/divergence in the flow field
     !   smaller value result in more and can destroy orographic precip and result in odd spatial coherence

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -100,6 +100,7 @@
     !   if it is supplied it must be less than or equal to the number of levels specified below
     !   but it can be used to subset the number of levels used.
     nz = 15, ! []
+
     !   Set this to true of the zvar in the input data is actually in units of geopotential height (m/s^2)
     z_is_geopotential = False,
     !   Set this to true of the zvar in the input data is specified on model interfaces (as WRF geopotential height is)
@@ -122,6 +123,9 @@
     !   If the forcing data come from WRF, the temperature data probably have an offset applied
     !   t_offset will be added to the forcing temperature data.  Defaults to 0
     ! t_offset = 300, ! [K]
+
+    !   If the temperature field in the forcing data is not potential temperature, then set this flag to False
+    ! t_is_potential = .True.
 
     !   Distance to smooth winds over [m] ~100000 is reasonable
     !   larger values result in less large scale convergence/divergence in the flow field

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -129,6 +129,8 @@
 
     !   If the water vapor field in the forcing data is specific humidity instead of mixing ratio, then set this flag to true.
     ! qv_is_spec_humidity = .False.
+    !   If the water vapor field in the forcing data is relative humidity instead of mixing ratio, then set this flag to true.
+    ! qv_is_relative_humidity = .False.
 
     !   Distance to smooth winds over [m] ~100000 is reasonable
     !   larger values result in less large scale convergence/divergence in the flow field

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -38,6 +38,7 @@ module boundary_conditions
     use output,                 only : write_domain, output_init
     use string,                 only : str
     use array_utilities,        only : smooth_array
+    use mod_atm_utilities,      only : rh_to_mr
 
     implicit none
     private
@@ -917,7 +918,11 @@ contains
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options)
             if (options%qv_is_spec_humidity) then
-                bc%next_domain%qv = bc%next_domain%qv / (1 - bc%next_domain%qv)
+                domain%qv = domain%qv / (1 - domain%qv)
+            endif
+
+            if (options%qv_is_relative_humidity) then
+                domain%qv = rh_to_mr(domain%qv, domain%th * domain%pii, domain%p)
             endif
 
             if (trim(options%qcvar)/="") then
@@ -1348,6 +1353,10 @@ contains
         if (options%qv_is_spec_humidity) then
             bc%next_domain%qv = bc%next_domain%qv / (1 - bc%next_domain%qv)
         endif
+        if (options%qv_is_relative_humidity) then
+            bc%next_domain%qv = rh_to_mr(bc%next_domain%qv, bc%next_domain%th * bc%next_domain%pii, bc%next_domain%p)
+        endif
+
 
         if (trim(options%qcvar)/="") then
             call read_var(bc%next_domain%cloud,   file_list(curfile), options%qcvar,  &

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -900,12 +900,20 @@ contains
                 call smooth_array(domain%u,smoothing_window,3)
                 call smooth_array(domain%v,smoothing_window,3)
             endif
+
             call read_var(domain%p,    file_list(curfile),   options%pvar,   &
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options,   bc%lowres_z,domain%z, interp_vertical=.True.)
+
             call read_var(domain%th,   file_list(curfile),   options%tvar,   &
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options)
+
+            if (.not.options%t_is_potential) then
+                domain%pii = (domain%p/100000.0)**(Rd/cp)
+                domain%th = domain%th / domain%pii
+            endif
+
             call read_var(domain%qv,   file_list(curfile),   options%qvvar,  &
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options)
@@ -1315,7 +1323,6 @@ contains
                       bc%geolut, bc%vert_lut, curstep, use_interior,              &
                       options, time_varying_zlut=newbc%vert_lut, interp_vertical=.True. )
         ! for pressure update we need real temperature, not potential t to compute an exner function
-        ! bc%next_domain%pii=(bc%next_domain%p/100000.0)**(Rd/cp)
         ! now update pressure using the high res T field
         call update_pressure(bc%next_domain%p,bc%lowres_z,domain%z)!,  &
                             !  lowresT = bc%next_domain%th * bc%next_domain%pii, &
@@ -1325,6 +1332,12 @@ contains
         call read_var(bc%next_domain%th,      file_list(curfile), options%tvar,   &
                       bc%geolut, bc%vert_lut, curstep, use_boundary,              &
                       options, time_varying_zlut=newbc%vert_lut)
+
+        if (.not.options%t_is_potential) then
+            bc%next_domain%pii = (bc%next_domain%p/100000.0)**(Rd/cp)
+            bc%next_domain%th = bc%next_domain%th / bc%next_domain%pii
+        endif
+
 
         call read_var(bc%next_domain%qv,      file_list(curfile), options%qvvar,  &
                       bc%geolut, bc%vert_lut, curstep, use_boundary,              &
@@ -1392,8 +1405,8 @@ contains
         bc%next_domain%cloud=domain%cloud + domain%ice + domain%qrain + domain%qsnow
 
         ! these are required by update_winds for most options
-        bc%next_domain%pii=(bc%next_domain%p/100000.0)**(Rd/cp)
-        bc%next_domain%rho=bc%next_domain%p/(Rd*domain%th*bc%next_domain%pii) ! kg/m^3
+        bc%next_domain%pii = (bc%next_domain%p / 100000.0)** (Rd / cp)
+        bc%next_domain%rho = bc%next_domain%p / (Rd * domain%th * bc%next_domain%pii) ! kg/m^3
 
 
         call update_winds(bc%next_domain,options)

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -908,7 +908,6 @@ contains
             call read_var(domain%th,   file_list(curfile),   options%tvar,   &
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options)
-
             if (.not.options%t_is_potential) then
                 domain%pii = (domain%p/100000.0)**(Rd/cp)
                 domain%th = domain%th / domain%pii
@@ -917,6 +916,10 @@ contains
             call read_var(domain%qv,   file_list(curfile),   options%qvvar,  &
                             bc%geolut, bc%vert_lut, curstep, boundary_value, &
                             options)
+            if (options%qv_is_spec_humidity) then
+                bc%next_domain%qv = bc%next_domain%qv / (1 - bc%next_domain%qv)
+            endif
+
             if (trim(options%qcvar)/="") then
                 call read_var(domain%cloud,file_list(curfile),   options%qcvar,  &
                                 bc%geolut, bc%vert_lut, curstep, boundary_value, &
@@ -1338,10 +1341,13 @@ contains
             bc%next_domain%th = bc%next_domain%th / bc%next_domain%pii
         endif
 
-
         call read_var(bc%next_domain%qv,      file_list(curfile), options%qvvar,  &
                       bc%geolut, bc%vert_lut, curstep, use_boundary,              &
                       options, time_varying_zlut=newbc%vert_lut)
+
+        if (options%qv_is_spec_humidity) then
+            bc%next_domain%qv = bc%next_domain%qv / (1 - bc%next_domain%qv)
+        endif
 
         if (trim(options%qcvar)/="") then
             call read_var(bc%next_domain%cloud,   file_list(curfile), options%qcvar,  &

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -479,6 +479,7 @@ module data_structures
         logical :: mean_winds           ! use only a mean wind field across the entire model domain
         logical :: mean_fields          ! use only a mean forcing field across the model boundaries
         logical :: restart              ! this is a restart run, read model conditions from a restart file
+        logical :: t_is_potential       ! if true the input temperature is interpreted as potential temperature
         logical :: z_is_geopotential    ! if true the z variable is interpreted as geopotential height
         logical :: z_is_on_interface    ! if true the z variable is interpreted as residing at model level interfaces
         logical :: advect_density       ! properly incorporate density into the advection calculations.

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -479,6 +479,7 @@ module data_structures
         logical :: mean_winds           ! use only a mean wind field across the entire model domain
         logical :: mean_fields          ! use only a mean forcing field across the model boundaries
         logical :: restart              ! this is a restart run, read model conditions from a restart file
+        logical :: qv_is_relative_humidity! if true the input water vapor is assumed to be relative humidity instead of mixing ratio
         logical :: qv_is_spec_humidity  ! if true the input water vapor is assumed to be specific humidity instead of mixing ratio
         logical :: t_is_potential       ! if true the input temperature is interpreted as potential temperature
         logical :: z_is_geopotential    ! if true the z variable is interpreted as geopotential height

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -479,6 +479,7 @@ module data_structures
         logical :: mean_winds           ! use only a mean wind field across the entire model domain
         logical :: mean_fields          ! use only a mean forcing field across the model boundaries
         logical :: restart              ! this is a restart run, read model conditions from a restart file
+        logical :: qv_is_spec_humidity  ! if true the input water vapor is assumed to be specific humidity instead of mixing ratio
         logical :: t_is_potential       ! if true the input temperature is interpreted as potential temperature
         logical :: z_is_geopotential    ! if true the z variable is interpreted as geopotential height
         logical :: z_is_on_interface    ! if true the z variable is interpreted as residing at model level interfaces

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -474,7 +474,7 @@ contains
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
         logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
-                   high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, &
+                   high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, qv_is_spec_humidity, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction, &
                    use_block_options
 
@@ -488,7 +488,7 @@ contains
                               dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, interactive, &
                               external_winds,buffer,n_ext_winds,advect_density,smooth_wind_distance, &
                               mean_winds,mean_fields,restart, z_is_geopotential, z_is_on_interface,&
-                              date, calendar, high_res_soil_state,warning_level, t_is_potential, &
+                              date, calendar, high_res_soil_state,warning_level, t_is_potential, qv_is_spec_humidity,  &
                               use_agl_height, start_date, forcing_start_date, end_date, time_varying_z, &
                               cfl_reduction_factor, cfl_strictness,         &
                               mp_options_filename,      use_mp_options,     &
@@ -508,6 +508,7 @@ contains
         buffer=0
         advect_density=.False.
         t_is_potential=.True.
+        qv_is_spec_humidity=.False.
         z_is_geopotential=.False.
         z_is_on_interface=.False.
         dxlow=100000
@@ -639,6 +640,7 @@ contains
         options%warning_level = warning_level
         options%use_agl_height = use_agl_height
         options%t_is_potential = t_is_potential
+        options%qv_is_spec_humidity = qv_is_spec_humidity
         options%z_is_geopotential = z_is_geopotential
         options%z_is_on_interface = z_is_on_interface
 

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -600,7 +600,7 @@ contains
         if (outputinterval>=43200) then
             options%output_file_frequency="monthly"
         ! if outputing at half-hour or longer intervals, create daily files
-        else if (outputinterval>=1800) then
+        else if (outputinterval>=300) then
             options%output_file_frequency="daily"
         ! otherwise create a new output file every timestep
         else

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -475,6 +475,7 @@ contains
         logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, qv_is_spec_humidity, &
+                   qv_is_relative_humidity, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction, &
                    use_block_options
 
@@ -488,7 +489,8 @@ contains
                               dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, interactive, &
                               external_winds,buffer,n_ext_winds,advect_density,smooth_wind_distance, &
                               mean_winds,mean_fields,restart, z_is_geopotential, z_is_on_interface,&
-                              date, calendar, high_res_soil_state,warning_level, t_is_potential, qv_is_spec_humidity,  &
+                              date, calendar, high_res_soil_state,warning_level, t_is_potential,  &
+                              qv_is_relative_humidity, qv_is_spec_humidity,  &
                               use_agl_height, start_date, forcing_start_date, end_date, time_varying_z, &
                               cfl_reduction_factor, cfl_strictness,         &
                               mp_options_filename,      use_mp_options,     &
@@ -509,6 +511,7 @@ contains
         advect_density=.False.
         t_is_potential=.True.
         qv_is_spec_humidity=.False.
+        qv_is_relative_humidity=.False.
         z_is_geopotential=.False.
         z_is_on_interface=.False.
         dxlow=100000
@@ -640,6 +643,7 @@ contains
         options%warning_level = warning_level
         options%use_agl_height = use_agl_height
         options%t_is_potential = t_is_potential
+        options%qv_is_relative_humidity = qv_is_relative_humidity
         options%qv_is_spec_humidity = qv_is_spec_humidity
         options%z_is_geopotential = z_is_geopotential
         options%z_is_on_interface = z_is_on_interface

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -1200,6 +1200,12 @@ contains
             allocate(options%dz_levels(options%nz))
 
             options%dz_levels(1:options%nz)=dz_levels(1:options%nz)
+
+            if (minval(options%dz_levels)<1) then
+                print*, "NB: gfortran doesn't read namelist arrays on multiple lines (check dz_levels)"
+                stop "ERROR: model levels must be > 1m vertical"
+            endif
+
             deallocate(dz_levels)
         else
         ! if we are not reading dz from the namelist, use default values from a WRF run
@@ -1212,7 +1218,7 @@ contains
                options%nz=45
            endif
             allocate(options%dz_levels(options%nz))
-            options%dz_levels=fulldz(1:options%nz)
+            options%dz_levels = fulldz(1:options%nz)
         endif
 
     end subroutine model_levels_namelist

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -474,7 +474,7 @@ contains
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
         logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
-                   high_res_soil_state, use_agl_height, time_varying_z, &
+                   high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction, &
                    use_block_options
 
@@ -488,7 +488,7 @@ contains
                               dx,dxlow,ideal,readz,readdz,nz,t_offset,debug, interactive, &
                               external_winds,buffer,n_ext_winds,advect_density,smooth_wind_distance, &
                               mean_winds,mean_fields,restart, z_is_geopotential, z_is_on_interface,&
-                              date, calendar, high_res_soil_state,warning_level, &
+                              date, calendar, high_res_soil_state,warning_level, t_is_potential, &
                               use_agl_height, start_date, forcing_start_date, end_date, time_varying_z, &
                               cfl_reduction_factor, cfl_strictness,         &
                               mp_options_filename,      use_mp_options,     &
@@ -507,6 +507,7 @@ contains
         t_offset=(-9999)
         buffer=0
         advect_density=.False.
+        t_is_potential=.True.
         z_is_geopotential=.False.
         z_is_on_interface=.False.
         dxlow=100000
@@ -637,6 +638,7 @@ contains
         options%interactive = interactive
         options%warning_level = warning_level
         options%use_agl_height = use_agl_height
+        options%t_is_potential = t_is_potential
         options%z_is_geopotential = z_is_geopotential
         options%z_is_on_interface = z_is_on_interface
 

--- a/src/makefile
+++ b/src/makefile
@@ -510,7 +510,7 @@ $(BUILD)cu_kf.o:$(PHYS)cu_kf.f90
 $(BUILD)ra_driver.o:$(PHYS)ra_driver.f90 $(BUILD)ra_simple.o $(BUILD)data_structures.o
 	${F90} ${FFLAGS} $(PHYS)ra_driver.f90 -o $(BUILD)ra_driver.o
 
-$(BUILD)ra_simple.o:$(PHYS)ra_simple.f90 $(BUILD)data_structures.o $(BUILD)time.o
+$(BUILD)ra_simple.o:$(PHYS)ra_simple.f90 $(BUILD)data_structures.o $(BUILD)time.o $(BUILD)atm_utilities.o
 	${F90} ${FFLAGS} $(PHYS)ra_simple.f90 -o $(BUILD)ra_simple.o
 
 ###################################################################

--- a/src/physics/ra_simple.f90
+++ b/src/physics/ra_simple.f90
@@ -20,10 +20,10 @@
 !!  [longwave->]
 !!
 !! High level routine descriptions / purpose
-!!   ra_simple          - loops over X,Y grid cells, calls cloudfrac, shortwave,longwave on columns
+!!   ra_simple           - loops over X,Y grid cells, calls cloudfrac, shortwave,longwave on columns
 !!   cloudfrac           - calculates the cloud fraction following Xu and Randall (1996)
 !!   shortwave           - calculates shortwave at the surface following Reiff et al (1984)
-!!   longwave               - calculates longwave at the surface following Idso and Jackson (1969)
+!!   longwave            - calculates longwave at the surface following Idso and Jackson (1969)
 !!
 !! Driver inputs: p,th,pii,rho,qv,qc,qr,qs,rain,snow,dt,dz,nx,ny,nz
 !!   p   = pressure                      - 3D - input  - Pa     - (nx,nz,ny)
@@ -34,8 +34,8 @@
 !!   qc  = cloud water content           - 3D - input  - kg/kg  - (nx,nz,ny)
 !!   qr  = rain water content            - 3D - input  - kg/kg  - (nx,nz,ny)
 !!   qs  = snow water content            - 3D - input  - kg/kg  - (nx,nz,ny)
-!!   swdown = shortwave down at surface - 2D - output - W/m^2   - (nx,ny)
-!!   lwdown = longwave down at surface  - 2D - output - W/m^2   - (nx,ny)
+!!   swdown = shortwave down at surface  - 2D - output - W/m^2  - (nx,ny)
+!!   lwdown = longwave down at surface   - 2D - output - W/m^2  - (nx,ny)
 !!   dt = time step                      - 0D - input  - seconds    - scalar
 !! </pre>
 !!

--- a/src/physics/ra_simple.f90
+++ b/src/physics/ra_simple.f90
@@ -81,7 +81,7 @@ contains
         integer,intent(in) :: nx
         real,               dimension(nx) :: mr, e, es
 
-        ! convert sensible humidity to mixing ratio
+        ! convert specific humidity to mixing ratio
         mr = qv / (1-qv)
         ! convert mixing ratio to vapor pressure
         e = mr * p / (0.62197+mr)

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -23,6 +23,36 @@ module mod_atm_utilities
 
 contains
 
+
+    !>----------------------------------------------------------
+    !! Convert relative humidity, temperature, and pressure to water vapor mixing ratio
+    !!
+    !! Input temperature is real temperature in Kelvin  [K]
+    !! Input relative humidity is fractional            [0-1]
+    !! Input pressure s in Pascals                      [Pa]
+    !! Output mixing ratio is in kg / kg                [kg/kg]
+    !!
+    !!----------------------------------------------------------
+    pure elemental function rh_to_mr(input_rh, t, p) result(mr)
+        implicit none
+        real, intent(in) :: input_rh, t, p
+        real :: mr
+        real :: es, e, rh
+
+        rh = min(1.0, max(0.0, input_rh))
+
+        ! saturated vapor pressure
+        ! convert temperature to saturated vapor pressure (in Pa)
+        es = 611.2 * exp(17.67 * (t - 273.15) / (t - 29.65))
+
+        ! convert relative humidity to vapor pressure
+        e = rh / es
+
+        ! finally convert vapor pressure to mixing ratio
+        mr = 0.62197 * e / (p - e)
+    end function
+
+
     !>----------------------------------------------------------
     !! Calculate direction [0-2*pi) from u and v wind speeds
     !!
@@ -54,7 +84,7 @@ contains
     !! Calculate the strength of the u wind field given a direction [0-2*pi] and magnitude
     !!
     !!----------------------------------------------------------
-    pure function calc_speed(u, v) result(speed)
+    pure elemental function calc_speed(u, v) result(speed)
         implicit none
         real, intent(in) :: u,v
         real :: speed
@@ -66,7 +96,7 @@ contains
     !! Calculate the strength of the u wind field given a direction [0-2*pi] and magnitude
     !!
     !!----------------------------------------------------------
-    pure function calc_u(direction, magnitude) result(u)
+    pure elemental function calc_u(direction, magnitude) result(u)
         implicit none
         real, intent(in) :: direction, magnitude
         real :: u
@@ -78,7 +108,7 @@ contains
     !! Calculate the strength of the v wind field given a direction [0-2*pi] and magnitude
     !!
     !!----------------------------------------------------------
-    pure function calc_v(direction, magnitude) result(v)
+    pure elemental function calc_v(direction, magnitude) result(v)
         implicit none
         real, intent(in) :: direction, magnitude
         real :: v
@@ -94,7 +124,7 @@ contains
     !! from http://glossary.ametsoc.org/wiki/Saturation-adiabatic_lapse_rate
     !!
     !!----------------------------------------------------------
-    pure function calc_sat_lapse_rate(T,mr) result(sat_lapse)
+    pure elemental function calc_sat_lapse_rate(T,mr) result(sat_lapse)
         implicit none
         real, intent(in) :: T,mr  ! inputs T in K and mr in kg/kg
         real :: L
@@ -110,7 +140,7 @@ contains
     !! formula from Durran and Klemp, 1982 after Lalas and Einaudi 1974
     !!
     !!----------------------------------------------------------
-    pure function calc_moist_stability(t_top, t_bot, z_top, z_bot, qv_top, qv_bot, qc) result(BV_freq)
+    pure elemental function calc_moist_stability(t_top, t_bot, z_top, z_bot, qv_top, qv_bot, qc) result(BV_freq)
         implicit none
         real, intent(in) :: t_top, t_bot, z_top, z_bot, qv_top, qv_bot, qc
         real :: t,qv, dz, sat_lapse
@@ -129,7 +159,7 @@ contains
     !! Calculate the dry brunt vaisala frequency (Nd^2)
     !!
     !!----------------------------------------------------------
-    pure function calc_dry_stability(th_top, th_bot, z_top, z_bot) result(BV_freq)
+    pure elemental function calc_dry_stability(th_top, th_bot, z_top, z_bot) result(BV_freq)
         implicit none
         real, intent(in) :: th_top, th_bot, z_top, z_bot
         real :: BV_freq

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -54,6 +54,39 @@ contains
 
 
     !>----------------------------------------------------------
+    !! Convert temperature, specific humidity, and pressure to relative humidity
+    !!
+    !! Input temperature is real temperature in Kelvin  [K]
+    !! Input specific humidity is in kg / kg            [kg/kg]
+    !! Input pressure s in Pascals                      [Pa]
+    !! Output relative humidity is fractional           [0-1]
+    !!
+    !!----------------------------------------------------------
+    pure elemental function relative_humidity(t,qv,p)
+        implicit none
+        real               :: relative_humidity
+        real,   intent(in) :: t
+        real,   intent(in) :: qv, p
+        real               :: mr, e, es
+
+        ! convert specific humidity to mixing ratio
+        mr = qv / (1-qv)
+        ! convert mixing ratio to vapor pressure
+        e = mr * p / (0.62197+mr)
+        ! convert temperature to saturated vapor pressure
+        es = 611.2 * exp(17.67 * (t - 273.15) / (t - 29.65))
+        ! finally return relative humidity
+        relative_humidity = e / es
+
+        ! because it is an approximation things could go awry and rh outside or reasonable bounds could break something else.
+        ! alternatively air could be supersaturated (esp. on boundary cells) but cloud fraction calculations will break.
+        relative_humidity = min(1.0, max(0.0, relative_humidity))
+
+    end function relative_humidity
+
+
+
+    !>----------------------------------------------------------
     !! Calculate direction [0-2*pi) from u and v wind speeds
     !!
     !!----------------------------------------------------------

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -46,7 +46,7 @@ contains
         es = 611.2 * exp(17.67 * (t - 273.15) / (t - 29.65))
 
         ! convert relative humidity to vapor pressure
-        e = rh / es
+        e = rh * es
 
         ! finally convert vapor pressure to mixing ratio
         mr = 0.62197 * e / (p - e)

--- a/src/utilities/geo_reader.f90
+++ b/src/utilities/geo_reader.f90
@@ -110,6 +110,7 @@ contains
         real,intent(in)::yi,y(4),xi,x(4)
         real::x0,y0
         real, dimension(4) ::tri_weights
+        real :: test_poly(2,3)
 
         real :: w1,w2,w3,denom
 
@@ -148,6 +149,10 @@ contains
             write(*,*) x2, y2
             write(*,*) x3, y3
             write(*,*) w1, w2, w3
+            test_poly(:,1) = [x1,y1]
+            test_poly(:,2) = [x2,y2]
+            test_poly(:,3) = [x3,y3]
+            write(*,*) "Point in poly returns:",point_in_poly(xi, yi, test_poly)
             stop "Triangulation is broken"
         endif
         w1=max(0.,w1); w2=max(0.,w2); w3=max(0.,w3);
@@ -608,7 +613,7 @@ contains
         real :: x0,y0,x1,y1
         double precision :: slope, x_line
 
-        internal_precision = 1e-5
+        internal_precision = 1e-7
         if (present(precision)) internal_precision = precision
         n = size(poly,2)
 


### PR DESCRIPTION
Now permits input humidity to be relative, specific, or mixing ratio. 
Also permits input temperature to be real instead of potential. 

Fixes possible bug in georeader if a point was too close to a line (precision issues), may need to think about this more generally still. 

Finally checks to see that dz levels were read in correctly from the namelist (e.g. there are no negative dz values specified).  Before a namelist that worked with ifort would cause random seeming errors with gfortran because of how the two compilers treat reading in arrays from namelists. 