### PR TITLE
Minor update to geo_reader and adds a wrf2icar helper script

### DIFF
--- a/helpers/wrf2icar.sh
+++ b/helpers/wrf2icar.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# Script to remove bottom level in selected variables in met_em files
+# also rotates wind field to be earth relative instead of grid relative as in met files
+#
+# Original from Marie Pontoppidan 29/11/2017
+# Converted to shell script Ethan Gutmann 26 Jan. 2018
+
+if [ "$#" -lt 2 ]; then
+  echo "">&2
+  echo "Usage: $0 input_directory output_directory [prefix] [output_file] [temp_prefix]">&2
+  echo ""                                                                               >&2
+  echo "        If output_file is specified, prefix must be too."                       >&2
+  echo "        If temp_prefix is specified, output_file must be too."                  >&2
+  echo "        Prefix defaults to 'wrfout'"                                            >&2
+  echo "        temp_prefix defaults to 'temp_'"                                        >&2
+  echo "        If output_file is specified, all outputs are ncrcated into it."         >&2
+  exit 1
+fi
+
+if ! [ -d "$1" ]; then
+  echo "$1 is not a directory" >&2
+  exit 1
+fi
+
+input_dir=$1
+output_dir=$2
+
+if [ "$#" -ge 3 ]; then
+    prefix=$3
+else
+    prefix='wrfout'
+fi
+
+if [ "$#" -eq 5 ]; then
+    TEMP=$5
+else
+    TEMP='temp_'
+fi
+
+if [ ${prefix::6} == 'met_em' ]; then
+    varlist_3d="PRES,TT,RH,GHT"
+    varlist_2d="ALBEDO12M,XLAT_M,XLONG_M,GREENFRAC,HGT_M,LANDMASK,ST,SM,TAVGSFC,SKINTEMP,SOILTEMP"
+    uvar="UU"
+    vvar="VV"
+    general_3d="TT"
+    vertical_dim="num_metgrid_levels"
+elif [ ${prefix::6} == 'wrfout' ]; then
+    varlist_3d="P,PB,T,QVAPOR,PH,PHB"
+    varlist_2d="XLAT,XLONG,HGT,LANDMASK,TSLB,SMOIS,TSK,SWDOWN,GLW,PREC_ACC_C"
+    uvar="U"
+    vvar="V"
+    general_3d="T"
+    vertical_dim="bottom_top"
+fi
+
+sinalpha=SINALPHA
+cosalpha=COSALPHA
+
+echo $varlist_3d
+echo $varlist_2d
+echo ${general_3d},${uvar},${vvar},${cosalpha},${sinalpha}
+
+mkdir -p $output_dir
+
+for f in ${input_dir}/${prefix}*; do
+    filename=`basename $f`
+    output_file=${output_dir}/${filename}
+    echo $filename $output_file
+
+    # One of the primary reasons for this script is to rotate the wind field into earth-relative coordinates
+    # instead of having them as model grid relative.
+    # First make a file that only has the necessary variables in it
+    ncks -v ${general_3d},${uvar},${vvar},${cosalpha},${sinalpha} $f ${TEMP}general.nc
+
+    # Create a U wind variable on the mass grid
+    ncap2 -A -s "UU_M=${general_3d}" ${TEMP}general.nc
+    # Compute U on the mass grid destaggered from the wind grid
+    ncap2 -A -s "UU_M(:,:,:,:)=(${uvar}(:,:,:,0:-2)+${uvar}(:,:,:,1:))/2" ${TEMP}general.nc 2>/dev/null
+
+    # Now repeat for V
+    # Create a V wind variable on the mass grid
+    ncap2 -A -s "VV_M=${general_3d}" ${TEMP}general.nc
+    # Compute V on the mass grid destaggered from the wind grid
+    ncap2 -A -s "VV_M(:,:,:,:)=(${vvar}(:,:,0:-2,:)+${vvar}(:,:,1:,:))/2" ${TEMP}general.nc 2>/dev/null
+
+    # Now perform the rotation, recompute
+    ncap2 -s "UU_M=UU_M*${cosalpha}-VV_M*${sinalpha}" ${TEMP}general.nc ${TEMP}uvfinal.nc
+    ncap2 -A -s "VV_M=VV_M*${cosalpha}+UU_M*${sinalpha}" ${TEMP}general.nc ${TEMP}uvfinal.nc
+
+    if [ ${prefix::6} == 'met_em' ]; then
+        ncks -d $vertical_dim,1,-1 -v UU_M,VV_M ${TEMP}uvfinal.nc ${TEMP}new.nc
+        ncks -d $vertical_dim,1,-1 -v $varlist_3d $f ${TEMP}lev.nc
+    else
+        ncks -v UU_M,VV_M ${TEMP}uvfinal.nc ${TEMP}new.nc
+        ncks -v $varlist_3d $f ${TEMP}lev.nc
+    fi
+    ncks -v $varlist_2d $f $output_file
+    ncks -A ${TEMP}new.nc $output_file
+    ncks -A ${TEMP}lev.nc $output_file
+
+    rm ${TEMP}*
+
+    ncatted -a units,UU_M,m,c,"m s-1" $output_file
+    ncatted -a units,VV_M,m,c,"m s-1" $output_file
+    ncatted -a description,UU_M,m,c,"earth-rotated wind" $output_file
+    ncatted -a description,VV_M,m,c,"earth-rotated wind" $output_file
+
+    if [ ${prefix::6} == 'met_em' ]; then
+        ncatted -a scale_factor,RH,c,f,0.01 $output_file
+    fi
+
+    # For WRF output files we handle a number of issues to make the files smaller and more intuitive
+    # Note that ICAR can actually handle all of these internally, so this is not strictly necessary
+    if [ ${prefix::6} == 'wrfout' ]; then
+
+        # First, combine the P and PB (perturbation and base pressure) to save space
+        ncap2 -A -s "P=P+PB" $output_file
+        ncatted -a description,P,m,c,"pressure" $output_file
+
+        # Second, combine the PH and PHB (perturbation and base geopotential) to save space and convert to height
+        ncap2 -A -s "PH=(PH+PHB)/9.81" $output_file
+        ncatted -a description,PH,m,c,"height" $output_file
+        ncatted -a units,PH,m,c,"m" $output_file
+
+        # Third, add 300 to T (because WRF output files have 300 subtracted)
+        ncap2 -A -s "T=T+300" $output_file
+
+        # Fourth, remove the now unnecessary PB and PHB variables
+        ncks -x -v PB,PHB $output_file ${output_file}.temp
+        mv ${output_file}.temp $output_file
+
+        # Finally, we get rid of the time dimension to XLAT and XLONG to save more space
+        # Create a new file without lat and long (which otherwise have a time dimension)
+        ncks -x -v XLAT,XLONG $output_file ${output_file}.temp
+        # Put lat and long WITHOUT a time dimension into a temp file
+        ncwa -d Time,0 -a Time -v XLAT,XLONG $output_file ${output_file}.temp2
+        # then recombine lat/lon back into the main file so there is no time dimension to them
+        mv ${output_file}.temp $output_file
+        ncks -A ${output_file}.temp2 $output_file
+        rm ${output_file}.temp2
+
+    fi
+done
+
+
+if [ "$#" -ge 4 ]; then
+    echo "Concatenating all files together."
+    ncrcat ${output_dir}/${prefix}* $4
+fi

--- a/src/tests/test_point_in_on.f90
+++ b/src/tests/test_point_in_on.f90
@@ -4,8 +4,9 @@ program test_point_in_on
     implicit none
 
     real :: x,y
-    real :: poly(2,4), large_poly(2,8)
+    real :: poly(2,4), large_poly(2,8), triangle(2,3)
     real :: x0,y0,x1,y1
+    integer :: i,j
 
     logical :: passing
     passing=.True.
@@ -28,6 +29,27 @@ program test_point_in_on
     endif
 
 
+    x = 35.4495850
+    y = 34.0271034
+    print*, "Testing problem grid cell from a simulation."
+    print*, "[",x,",", y,"]"
+    print*, ""
+
+    ! These are the coordinates of the bounding box of grid cells for which find_surrounding was failing before
+    ! poly(1,:) = [35.40149, 35.46729, 35.40778, 35.47363]
+    ! poly(2,:) = [33.99421, 33.98899, 34.04877, 34.04354]
+
+    triangle(1,:) = [35.4077759, 35.4736328, 35.4375458]
+    triangle(2,:) = [34.0487747, 34.0435371, 34.0188789]
+
+    passing = passing.and.test_poly(x,y,triangle,.True.)
+
+    ! Note that this will actually fail because the precision is "too" high,
+    ! but if the points are in a different order it will fail for the other viable set as well! 1e-7 is too high a precision for lat/lon as single precision reals
+    !
+    ! print*, point_in_poly(x,y,triangle, precision=1e-7)
+    ! result = .False. ^^^^
+
     poly(1,:) = [0,0,1,1]
     poly(2,:) = [0,1,1,0]
 
@@ -36,7 +58,6 @@ program test_point_in_on
 
     x=1.01; y=0.5
     passing = passing.and.test_poly(x,y,poly,.False.)
-
 
     poly(1,:) = [0.5,0.0,0.5,1.0]
     poly(2,:) = [0.0,0.5,1.0,0.5]

--- a/src/utilities/geo_reader.f90
+++ b/src/utilities/geo_reader.f90
@@ -141,7 +141,7 @@ contains
 
         w3 = 1 - w1 - w2
 
-        if (minval([w1,w2,w3]) < -1e-4) then
+        if (minval([w1,w2,w3]) < -1e-3) then
             write(*,*) "ERROR: Point not located in bounding triangle"
             write(*,*) xi, yi
             write(*,*) "Triangle vertices"
@@ -157,7 +157,7 @@ contains
         endif
         w1=max(0.,w1); w2=max(0.,w2); w3=max(0.,w3);
 
-        if (abs((w1+w2+w3)-1)>1e-4) then
+        if (abs((w1+w2+w3)-1)>1e-3) then
             write(*,*) "Error, w1+w2+w3 != 1"
             write(*,*) w1,w2,w3
             write(*,*) "Point"
@@ -511,7 +511,7 @@ contains
         real :: internal_precision
         double precision :: slope, offset
 
-        internal_precision = 1e-7
+        internal_precision = 1e-5
         if (present(precision)) internal_precision = precision
 
         online=.False.
@@ -613,7 +613,7 @@ contains
         real :: x0,y0,x1,y1
         double precision :: slope, x_line
 
-        internal_precision = 1e-7
+        internal_precision = 1e-5
         if (present(precision)) internal_precision = precision
         n = size(poly,2)
 


### PR DESCRIPTION
Relaxes precision on geo_reader's point in poly test so a point only has to fall within one meter of a polygon to count as being "in" the polygon.  This was causing problems with an edge case in which the point fell on a line, but due to numerical precision issues (order of operations dependent) it didn't appear to be in the polygons on either side of the line.  

Also adds a wrf2icar script that can be used to convert WRF output (or metgrid output) files into icar input files.  Note this script depends on NCO, has hardcoded variable names (WRF's current standard names).  This could be cleaned up, but it meant to provide a starting point for any other interested parties. 