### PR TITLE
Additional microphysics fields for initialisation and domain boundaries

### DIFF
--- a/ci/icar_install_utils
+++ b/ci/icar_install_utils
@@ -31,9 +31,9 @@ function install_szip {
 function install_hdf5 {
     echo install_hdf5
     cd $WORKDIR
-    wget --no-check-certificate -q https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.1.tar.gz
-    tar -xzf hdf5-1.10.1.tar.gz
-    cd hdf5-1.10.1
+    wget --no-check-certificate -q https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.gz
+    tar -xzf hdf5-1.10.5.tar.gz
+    cd hdf5-1.10.5
     ./configure --prefix=$INSTALLDIR &> config.log
     (make | awk 'NR%100 == 0')
     make install
@@ -43,9 +43,9 @@ function install_hdf5 {
 function install_netcdf_c {
     echo install_netcdf_c
     cd $WORKDIR
-    wget --no-check-certificate -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.tar.gz
-    tar -xzf netcdf-4.4.1.tar.gz
-    cd netcdf-4.4.1
+    wget --no-check-certificate -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.6.1.tar.gz
+    tar -xzf netcdf-4.6.1.tar.gz
+    cd netcdf-4.6.1
     ./configure --prefix=$INSTALLDIR &> config.log
     make &> make.log
     make install
@@ -55,9 +55,9 @@ function install_netcdf_c {
 function install_netcdf_fortran {
     echo install_netcdf_fortran
     cd $WORKDIR
-    wget --no-check-certificate -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.4.4.tar.gz
-    tar -xzf netcdf-fortran-4.4.4.tar.gz
-    cd netcdf-fortran-4.4.4
+    wget --no-check-certificate -q ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.4.5.tar.gz
+    tar -xzf netcdf-fortran-4.4.5.tar.gz
+    cd netcdf-fortran-4.4.5
     ./configure --prefix=$INSTALLDIR &> config.log
     make &> make.log
     make install

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,42 +1,54 @@
 ##Common errors
 
 1) **Segmentation fault**:
-    Possibly due to your shell's stacksize limit (particularly with ifort). 
-    
-To *fix* it try the following: 
+    Possibly due to your shell's stacksize limit (particularly with ifort).
+
+To *fix* it try the following:
 
     in bash:
         ulimit -s unlimited
-    in csh: 
+    in csh:
         unlimit stacksize
 
-    **NB**: Some systems have a hard limit of 64MB (ulimit -s 65532), this *may* be enough depending on domain size. 
+    **NB**: Some systems have a hard limit of 64MB (ulimit -s 65532), this *may* be enough depending on domain size.
     Reference: https://software.intel.com/en-us/articles/determining-root-cause-of-sigsegv-or-sigbus-errors
 
 2) **Common output file errors**
-    If there are existing outputfiles with a different grid (e.g. number of levels, number of latitudes), ICAR will try to write to the existing file and will stop because the dimensions don't match. If you get an error such as : 
-    
+    If there are existing outputfiles with a different grid (e.g. number of levels, number of latitudes), ICAR will try to write to the existing file and will stop because the dimensions don't match. If you get an error such as :
+
     NetCDF: Variable not found
     setup_varids: Searching for variable in existing file:nsq
-    
-Then ICAR is trying to write a variable (in this case nsq, the Brunt-Vaisala frequency) to the output file, but this variable does not exist is pre-existing output files.  If you get an error such as : 
+
+Then ICAR is trying to write a variable (in this case nsq, the Brunt-Vaisala frequency) to the output file, but this variable does not exist is pre-existing output files.  If you get an error such as :
 
     NetCDF: Start+count exceeds dimension bound
     output/icar_1990_01_01_00-00.nc:qv
 
-Then the dimensions of the model domain have changed since the last run, and it is not possible to write the output to the existing files. 
+Then the dimensions of the model domain have changed since the last run, and it is not possible to write the output to the existing files.
 
 In both cases, the solution is to delete (or move) the existing output files, or to modify your options file so that the output will be consistent with existing files.  
 
-    
+
 3) **dz_levels namelist error**
     "Fortran runtime error: Bad data for namelist object dz_levels"
 
-    If compiled with gfortran, the namelist format for arrays has to be slightly different than is supplied in the run directory. An easy fix is to put the dz_levels array all onto one line. 
-    
-    
+    If compiled with gfortran, the namelist format for arrays has to be slightly different than is supplied in the run directory. An easy fix is to put the dz_levels array all onto one line.
+
+
 4) **other namelist error**
     If a newer namelist is used with an older version of code, you may get errors telling you that a given variable is not supported.  You can probably remove that line from the namelist and it will run correctly, though you should think about the variable that is being removed to decide what it means.  
 
 5) **Floating Point errors**
-    Check your input data.  For example, if you are supplying Shortwave or longwave down at the surface, but those terms are 0, the LSM can cool off and the surface layer becomes too stable. This causes the surface fluxes to become numerically unstable, and eventually the system breaks. 
+    Check your input data.  For example, if you are supplying Shortwave or longwave down at the surface, but those terms are 0, the LSM can cool off and the surface layer becomes too stable. This causes the surface fluxes to become numerically unstable, and eventually the system breaks.
+
+6) **NetCDF related build error**
+    If the NetCDF library supplied does not support the full NetCDF4 file format (based on HDF5) you will get the following error.  Note that using version 4 of the netcdf library does not imply full support for version 4 of the netcdf file format...
+
+    `Error: Symbol ‘nf90_netcdf4’ at (1) has no IMPLICIT type`
+
+    There are two options :
+        1) The better option is to recompile the netcdf library, being sure that you first compile HDF5 and link the netcdf library to it.  You should be able to run
+            `nc-config --has-nc4`
+            and have it output “yes”
+
+        2) You can edit the ICAR source code to not require netCDF4 support.  This might be easier, but it will mean that ICAR ca not save very large files (which is useful for the linear wind look up table).  To do this, simply change `or(NF90_CLOBBER,NF90_NETCDF4)` to `NF90_CLOBBER` in `io/lt_lut_io.f90`

--- a/helpers/erai/config.py
+++ b/helpers/erai/config.py
@@ -64,7 +64,7 @@ def parse():
     parser.add_argument('lat_s',    nargs="?",     action='store',  help="southern latitude boundary",         default="20")
     parser.add_argument('lon_e',    nargs="?",     action='store',  help="eastern longitude boundary",         default="-50")
     parser.add_argument('lon_w',    nargs="?",     action='store',  help="western longitude boundary",         default="-140")
-    parser.add_argument('dir',      nargs="?",     action='store',  help="ERAi file location",                 default="/glade/p/rda/data/ds627.0/")
+    parser.add_argument('dir',      nargs="?",     action='store',  help="ERAi file location",                 default="/glade/collections/rda/data/ds627.0/")
     parser.add_argument('atmdir',   nargs="?",     action='store',  help="ERAi atmospheric data file location",default="ei.oper.an.ml/_Y__M_/")
     parser.add_argument('sfcdir',   nargs="?",     action='store',  help="ERAi surface data file location",    default="ei.oper.fc.sfc/_Y__M_/")
     parser.add_argument('atmfile',  nargs="?",     action='store',  help="ERAi primary atmospheric file",      default="ei.oper.an.ml.regn128sc._Y__M__D__h_")

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -26,6 +26,7 @@
     ! For a FASTER run (simpler physics), set mp=2
     ! If surface air temperature is important use pbl=2 lsm=3 rad=2 water=2 this requires Noah LSM data
     ! N/A = Not Available or Not fully implemented
+    ! Warning, convection can be unstable.
     ! wishlist = No Code Present yet
 
     pbl = 0,  ! 1=legacy (deprecated)      2=Simple (Local HP96)        3=YSU             (N/A)
@@ -99,6 +100,7 @@
     !   this is now optional, if not supplied, ICAR will determine it from the number of levels specified
     !   if it is supplied it must be less than or equal to the number of levels specified below
     !   but it can be used to subset the number of levels used.
+    !   WARNING : ICAR can be surprisingly sensitive to this parameter
     nz = 15, ! []
 
     !   Set this to true of the zvar in the input data is actually in units of geopotential height (m/s^2)
@@ -163,7 +165,7 @@
     debug = true,
     warning_level = 4, ! 0-10 increases the level of errors it warns about and quits over (slightly)
 
-    ! controls printing of % completed for longer processes.  Nice to see if it is running in a console, not nice to see in a log file.
+    ! controls printing of % completed for longer processes.  Nice if it is running in a console, not nice in a log file.
     interactive=False
 
     !   If the following are true, their respective namelists (below) will also be read in.
@@ -201,6 +203,8 @@
     zbvar   = "PHB",        ! base height state         [m or m/s^2] OPTIONAL
     sst_var = "TSK"         ! Water surface temperature [K]          OPTIONAL (used with water=2)
 
+    ! WARNING, if U and V are "grid relative" (e.g. output from WRF) and on a skewed grid, this will cause problems
+    ! run the helpers/wrf2icar.sh script first to rotate the wind field to be east-west, north-south relative
     ! variables on the ew staggered (U) grid
     uvar    = "U",          ! East-West wind speed      [m/s]
     ulat    = "XLAT_U",     ! latitude                  [degrees]
@@ -254,7 +258,7 @@
 !   Optionally specified Microphysics parameters (mostly for Thompson)
 !---------------------------------------------------------
 &mp_parameters
-    update_interval = 60 ! maximum update interval allowed
+    update_interval = 0  ! maximum update interval allowed
                          ! MP only updated when this interval will be exceeded in the next step
 
     Nt_c  = 100.e6      !  50, 100,500,1000
@@ -280,7 +284,7 @@
     Ef_rw_l = .False.   ! True sets ef_rw = 1, insted of max 0.95
     Ef_sw_l = .False.   ! True sets ef_rw = 1, insted of max 0.95
 
-    top_mp_level = 0    ! if <=0 just use the actual model top
+    top_mp_level = 0    ! if <=0 stop that many levels below the model top
     local_precip_fraction = 1.0 ! Fraction of micrphysics derived precipitation to deposit in the local grid cell
                                 ! the remaining precip is distributed to the surrounding grid cells.
 /
@@ -306,7 +310,7 @@
 !   Optionally specified land surface model parameters (mostly for Noah)
 !---------------------------------------------------------
 &lsm_parameters
-    update_interval = 600             ! Int : Seconds to wait before updating land surface fluxes again (default=300)
+    update_interval = 300             ! Int : Seconds to wait before updating land surface fluxes again (default=300)
 
     LU_Categories = "MODIFIED_IGBP_MODIS_NOAH"   ! Land Use Category definitions
                                     ! Note, this must match a category in VEGPARM.TBL and correspond to
@@ -326,9 +330,9 @@
 !   Optionally specified Linear Theory parameters
 !---------------------------------------------------------
 &lt_parameters
-    buffer = 50                     ! The number of grid cells of buffer to use around the topography for the fft calculations
-    stability_window_size = 10      ! The number of grid cells in all directions to average Nsq over for variable_N
-    vert_smooth = 10,               ! The number of vertical levels to look up and down when calculating brunt vaisalla frequency
+    buffer = 200                    ! The number of grid cells of buffer to use around the topography for the fft calculations
+    stability_window_size = 20      ! The number of grid cells in all directions to average Nsq over for variable_N
+    vert_smooth = 20,               ! The number of vertical levels to look up and down when calculating brunt vaisalla frequency
     smooth_nsq = .True.,            ! set to true to provide additional vertical smoothing of Nsq within spatial_linear_winds
     max_stability = 6e-4            ! The maximum Brunt-Vaisalla frequency to allow
     min_stability = 1e-7            ! The minimum Brunt-Vaisalla frequency to allow

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -2,7 +2,7 @@
 !   Model and run meta-data
 !---------------------------------------------------------
 &model_version
-    version = "0.9.5",                    ! This must match the version of the compiled code
+    version = "1.0.1",                    ! This must match the version of the compiled code
     comment = "Add your comment here"     ! This will be stored in output files
 /
 

--- a/run/short_icar_options.nml
+++ b/run/short_icar_options.nml
@@ -13,6 +13,7 @@
     ! Common precipitation downscaling run use pbl=0 lsm=0 mp=1 rad=0 conv=0 adv=1 wind=1
     ! For a FASTER run (simpler physics), set mp=2
     ! If surface air temperature is important use pbl=2 lsm=3 rad=2 water=2 this requires Noah LSM data
+    ! Warning, convection can be unstable
     ! N/A = Not Available or Not fully implemented
     ! wishlist = No Code Present yet
 
@@ -91,6 +92,7 @@
     !   this is now optional, if not supplied, ICAR will determine it from the number of levels specified
     !   if it is supplied it must be less than or equal to the number of levels specified below
     !   but it can be used to subset the number of levels used.
+    !   WARNING : ICAR can be surprisingly sensitive to this parameter
     nz = 15, ! []
     !   Set this to true if the zvar in the input data is actually in units of geopotential height (m/s^2)
     z_is_geopotential = True,
@@ -131,6 +133,8 @@
     lonvar  = "XLONG",      ! longitude                 [degrees]
     sst_var = "TSK"         ! Water surface temperature [K]
 
+    ! WARNING, if U and V are "grid relative" (e.g. output from WRF) and on a skewed grid, this will cause problems
+    ! run the helpers/wrf2icar.sh script first to rotate the wind field to be east-west, north-south relative
     ! variables on the ew staggered (U) grid
     uvar    = "U",          ! East-West wind speed      [m/s]
     ulat    = "XLAT_U",     ! latitude                  [degrees]
@@ -145,6 +149,8 @@
     lat_hi  = "XLAT_M",     ! latitude (mass grid)      [degrees]
     lon_hi  = "XLONG_M",    ! longitude (mass grid)     [degrees]
     hgt_hi  = "HGT_M"       ! surface elevation         [m]
+
+    ! To use the Noah LSM additional fields must be specified on the high-res grid, see complete_icar_options.nml
 
     ! only required for some physics code (Noah LSM, water, Tiedke, KF(?))
     landvar = "LANDMASK",   ! land-water mask (as in WRF) 1=land, 0 or 2=water

--- a/run/short_icar_options.nml
+++ b/run/short_icar_options.nml
@@ -2,7 +2,7 @@
 !   Model and run meta-data
 !---------------------------------------------------------
 &model_version
-    version = "0.9.5",                    ! This must match the version of the compiled code
+    version = "1.0.1",                    ! This must match the version of the compiled code
     comment = "Add your comment here"     ! This will be stored in output files
 /
 

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -1,7 +1,7 @@
 module icar_constants
 
     implicit none
-    character(len=5) :: kVERSION_STRING = "0.9.5"
+    character(len=5) :: kVERSION_STRING = "1.0.1"
 
 ! ------------------------------------------------
 ! Model constants (string lengths)

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -942,6 +942,53 @@ contains
                 domain%ice=0
             endif
 
+            ! jh - added qr, qs, qg, ni and nr as optional fields BEGIN
+            if (trim(options%qrvar)/="") then
+                call read_var(domain%qrain,  file_list(curfile),   options%qrvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Rain specified"
+                domain%qrain=0
+            endif
+
+            if (trim(options%qsvar)/="") then
+                call read_var(domain%qsnow,  file_list(curfile),   options%qsvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Snow specified"
+                domain%qsnow=0
+            endif
+            
+            if (trim(options%qgvar)/="") then
+                call read_var(domain%qgrau,  file_list(curfile),   options%qgvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Graupel specified"
+                domain%qgrau=0
+            endif
+            
+            if (trim(options%qnivar)/="") then
+                call read_var(domain%nice,  file_list(curfile),   options%qnivar,  &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value, &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Ice number density specified"
+                domain%nice=0
+            endif
+            
+            if (trim(options%qnrvar)/="") then
+                call read_var(domain%nrain,  file_list(curfile),   options%qnrvar,  &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value, &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Rain number density specified"
+                domain%nrain=0
+            endif
+            ! jh - added qr, qs, qg, ni and nr as optional fields END
+
             if (options%physics%landsurface==kLSM_BASIC) then
                 call read_2dvar(domain%sensible_heat,file_list(curfile),options%shvar,  bc%geolut,curstep)
                 call read_2dvar(domain%latent_heat,  file_list(curfile),options%lhvar,  bc%geolut,curstep)
@@ -1368,6 +1415,38 @@ contains
                           bc%geolut, bc%vert_lut, curstep, use_boundary,              &
                           options, time_varying_zlut=newbc%vert_lut)
         endif
+        
+        ! jh - added qr, qs, qg, ni and nr as optional fields BEGIN
+        if (trim(options%qrvar)/="") then
+            call read_var(bc%next_domain%qrain,  file_list(curfile),   options%qrvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+
+        if (trim(options%qsvar)/="") then
+            call read_var(bc%next_domain%qsnow,  file_list(curfile),   options%qsvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qgvar)/="") then
+            call read_var(bc%next_domain%qgrau,  file_list(curfile),   options%qgvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qnivar)/="") then
+            call read_var(bc%next_domain%nice,  file_list(curfile),   options%qnivar,  &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary, &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qnrvar)/="") then
+            call read_var(bc%next_domain%nrain,  file_list(curfile),   options%qnrvar,  &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary, &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        ! jh - added qr, qs, qg, ni and nr as optional fields END
 
         ! finally, if we need to read in land surface forcing read in those 2d variables as well.
         if (options%physics%landsurface==kLSM_BASIC) then

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -139,7 +139,7 @@ contains
 
             error=1
             curfile=0
-            do while ( (error/=0) .and. (curfile <= size(file_list)) )
+            do while ( (error/=0) .and. (curfile < size(file_list)) )
                 curfile = curfile + 1
                 curstep = find_timestep_in_file(file_list(curfile), options%time_var, time, error=error)
             enddo

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -461,7 +461,8 @@ module data_structures
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var, &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var, &
                                         swdown_var, lwdown_var, &
-                                        sst_var, rain_var, time_var
+                                        sst_var, rain_var, time_var, &
+                                        qnivar, qnrvar    ! jh - added as optional fields
 
         ! Filenames for files to read various physics options from
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, adv_options_filename, &

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -336,14 +336,16 @@ contains
                                         pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
-                                        swdown_var, lwdown_var, sst_var, rain_var, time_var
+                                        swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
+                                        qrvar, qsvar, qgvar, qnivar, qnrvar
 
         namelist /var_list/ pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                             landvar,latvar,lonvar,uvar,ulat,ulon,vvar,vlat,vlon,zvar,zbvar, &
                             hgt_hi,lat_hi,lon_hi,ulat_hi,ulon_hi,vlat_hi,vlon_hi,           &
                             soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                             vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
-                            swdown_var, lwdown_var, sst_var, rain_var, time_var
+                            swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
+                            qrvar, qsvar, qgvar, qnivar, qnrvar
 
         ! no default values supplied for variable names
         hgtvar=""
@@ -362,6 +364,11 @@ contains
         qvvar=""
         qcvar=""
         qivar=""
+        qrvar=""         ! jh - added as optional field
+        qsvar=""         ! jh - added as optional field
+        qgvar=""         ! jh - added as optional field
+        qnivar=""        ! jh - added as optional field
+        qnrvar=""        ! jh - added as optional field
         zvar=""
         zbvar=""
         shvar=""
@@ -419,7 +426,13 @@ contains
         options%qvvar       = qvvar
         options%qcvar       = qcvar
         options%qivar       = qivar
-
+        
+        options%qrvar       = qrvar    ! jh - added as optional field
+        options%qsvar       = qsvar    ! jh - added as optional field
+        options%qgvar       = qgvar    ! jh - added as optional field
+        options%qnivar      = qnivar   ! jh - added as optional field
+        options%qnrvar      = qnrvar   ! jh - added as optional field
+        
         ! vertical coordinate
         options%zvar        = zvar
         options%zbvar       = zbvar

--- a/src/main/model_tracking.f90
+++ b/src/main/model_tracking.f90
@@ -14,13 +14,13 @@ contains
 
     subroutine init_model_diffs()
         implicit none
-        integer::n=16
+        integer::n=18
 
         allocate(versionlist(n))
         allocate(deltas(n))
         versionlist=[character(len=1024) :: &
                      "0.5.1","0.5.2","0.6","0.7","0.7.1","0.7.2","0.7.3","0.8","0.8.1","0.8.2", &
-                     "0.9","0.9.1","0.9.2","0.9.3","0.9.4","0.9.5"]
+                     "0.9","0.9.1","0.9.2","0.9.3","0.9.4","0.9.5", "1.0", "1.0.1"]
         deltas=[ character(len=1024) :: &
         "Earliest version in git. ",                                                            &
         "Added dxlow and variable name definitions pvar,tvar,qvvar,qcvar,qivar,"//              &
@@ -48,7 +48,9 @@ contains
         "Added Morrison and WSM6 microphysics, and the ability to remove the low "  //          &
         "      resolution linear wind field.  Lots of smaller tweaks and bug fixes."//          &
         "      Also added online bias correction option. ",                                     &
-        "Added convective wind advection and improved Linear wind LUT. "                        &
+        "Added convective wind advection and improved Linear wind LUT. ",                       &
+        "Relatively stable checkpoint widely used. ",                                           &
+        "Significantly improved geographic interpolation bug fixes. "                           &
         ]
 
     end subroutine init_model_diffs

--- a/src/main/model_tracking.f90
+++ b/src/main/model_tracking.f90
@@ -49,7 +49,8 @@ contains
         "      resolution linear wind field.  Lots of smaller tweaks and bug fixes."//          &
         "      Also added online bias correction option. ",                                     &
         "Added convective wind advection and improved Linear wind LUT. ",                       &
-        "Relatively stable checkpoint widely used. ",                                           &
+        "Relatively stable checkpoint widely used. "//                                          &
+        "      Bugfixes also improved time handling (use time_var for forcing data)",           &
         "Significantly improved geographic interpolation bug fixes. "                           &
         ]
 

--- a/src/physics/cu_tiedtke.f90
+++ b/src/physics/cu_tiedtke.f90
@@ -11,8 +11,8 @@
 !   Added by Chunxi Zhang and Yuqing Wang to WRF3.2, May, 2010
 !   refenrence: Tiedtke (1989, MWR, 117, 1779-1800)
 !               Nordeng, T.E., (1995), CAPE closure and organized entrainment/detrainment
-!               Yuqing Wang et al. (2003,J. Climate, 16, 1721-1738) for improvements 
-!                                                  for cloud top detrainment 
+!               Yuqing Wang et al. (2003,J. Climate, 16, 1721-1738) for improvements
+!                                                  for cloud top detrainment
 !                       (2004, Mon. Wea. Rev., 132, 274-296), improvements for PBL clouds
 !                        (2007,Mon. Wea. Rev., 135, 567-585), diurnal cycle of precipitation
 !   This scheme is on testing
@@ -25,31 +25,31 @@ MODULE module_cu_tiedtke
       real,parameter ::  epsl  = 1.0e-20
       real,parameter ::  t000  = 273.15
       real,parameter ::  hgfr  = 233.15   ! defined in param.f in explct
-!-------------------------------------------------------------    
+!-------------------------------------------------------------
 !  Ends the parameters set
 !++++++++++++++++++++++++++++
      REAL,PRIVATE :: G,CPV
      REAL :: API,A,RD,RV,CPD,RCPD,VTMPC1,VTMPC2,   &
              RHOH2O,ALV,ALS,ALF,TMELT, &
-             C1ES,C2ES,C3LES,C3IES,C4LES,C4IES,C5LES,C5IES,ZRG 
-    
+             C1ES,C2ES,C3LES,C3IES,C4LES,C4IES,C5LES,C5IES,ZRG
+
      REAL :: ENTRPEN,ENTRSCV,ENTRMID,ENTRDD,CMFCTOP,RHM,RHC,    &
              CMFCMAX,CMFCMIN,CMFDEPS,CPRCON,CRIRH,ZBUO0,  &
              fdbk,ZTAU
- 
+
      INTEGER :: orgen,nturben,cutrigger
 
      REAL :: CVDIFTS, CEVAPCU1, CEVAPCU2,ZDNOPRC
-    
-  
+
+
      PARAMETER(A=6371.22E03,                                    &
-      ALV=2.5008E6,                 &                  
+      ALV=2.5008E6,                 &
       ALS=2.8345E6,                 &
       ALF=ALS-ALV,                  &
       CPD=1005.46,                  &
       CPV=1869.46,                  & ! CPV in module is 1846.4
       RCPD=1.0/CPD,                 &
-      RHOH2O=1.0E03,                & 
+      RHOH2O=1.0E03,                &
       TMELT=273.16,                 &
       G=9.806,                      & ! G=9.806
       ZRG=1.0/G,                    &
@@ -67,10 +67,10 @@ MODULE module_cu_tiedtke
       VTMPC1=RV/RD-1.0,             &
       VTMPC2=CPV/CPD-1.0,           &
       CVDIFTS=1.0,                  &
-      CEVAPCU1=1.93E-6*261.0*0.5/G, & 
+      CEVAPCU1=1.93E-6*261.0*0.5/G, &
       CEVAPCU2=1.E3/(38.3*0.293) )
 
-     
+
 !                SPECIFY PARAMETERS FOR MASSFLUX-SCHEME
 !                  --------------------------------------
 !                   These are tunable parameters
@@ -172,23 +172,23 @@ CONTAINS
 !-- P8w         3D hydrostatic pressure at full levels (Pa)
 !-- Pcps        3D hydrostatic pressure at half levels (Pa)
 !-- PI3D        3D exner function (dimensionless)
-!-- QVFTEN      3D water vapor advection tendency 
+!-- QVFTEN      3D water vapor advection tendency
 !-- QVPBLTEN    3D water vapor tendency due to a PBL
-!-- RTHCUTEN      Theta tendency due to 
+!-- RTHCUTEN      Theta tendency due to
 !                 cumulus scheme precipitation (K/s)
-!-- RUCUTEN       U wind tendency due to 
+!-- RUCUTEN       U wind tendency due to
 !                 cumulus scheme precipitation (K/s)
-!-- RVCUTEN       V wind tendency due to 
+!-- RVCUTEN       V wind tendency due to
 !                 cumulus scheme precipitation (K/s)
-!-- RQVCUTEN      Qv tendency due to 
+!-- RQVCUTEN      Qv tendency due to
 !                 cumulus scheme precipitation (kg/kg/s)
-!-- RQRCUTEN      Qr tendency due to 
+!-- RQRCUTEN      Qr tendency due to
 !                 cumulus scheme precipitation (kg/kg/s)
-!-- RQCCUTEN      Qc tendency due to 
+!-- RQCCUTEN      Qc tendency due to
 !                 cumulus scheme precipitation (kg/kg/s)
-!-- RQSCUTEN      Qs tendency due to 
+!-- RQSCUTEN      Qs tendency due to
 !                 cumulus scheme precipitation (kg/kg/s)
-!-- RQICUTEN      Qi tendency due to 
+!-- RQICUTEN      Qi tendency due to
 !                 cumulus scheme precipitation (kg/kg/s)
 !-- RAINC         accumulated total cumulus scheme precipitation (mm)
 !-- RAINCV        cumulus scheme precipitation (mm)
@@ -250,10 +250,10 @@ CONTAINS
                                         T3D,                            &
                                         U3D,                            &
                                         V3D,                            &
-                                        W                              
+                                        W
 
 !--------------------------- OPTIONAL VARS ----------------------------
-                                                                                                      
+
       REAL, DIMENSION(ims:ime, kms:kme, jms:jme),                       &
                OPTIONAL, INTENT(INOUT) ::                               &
                                         RQCCUTEN,                       &
@@ -262,7 +262,7 @@ CONTAINS
                                         RTHCUTEN,                       &
                                         RUCUTEN,                        &
                                         RVCUTEN
-                                                                                                      
+
 !
 ! Flags relating to the optional tendency arrays declared above
 ! Models that carry the optional tendencies will provdide the
@@ -276,52 +276,52 @@ CONTAINS
                                                   ,F_QR      &
                                                   ,F_QI      &
                                                   ,F_QS
- 
+
 !--------------------------- LOCAL VARS ------------------------------
 
       REAL,    DIMENSION(ims:ime, jms:jme) ::                           &
                                         QFX,                            &
-                                        HFX        
+                                        HFX
 
       REAL      ::                                      &
                                         DELT,                           &
-                                        RDELT                          
+                                        RDELT
 
       REAL     , DIMENSION(its:ite) ::                  &
                                         RCS,                            &
                                         RN,                             &
                                         EVAP,                           &
                                         heatflux,                       &
-                                        rho2d                            
-      INTEGER  , DIMENSION(its:ite) ::  SLIMSK                         
-      
+                                        rho2d
+      INTEGER  , DIMENSION(its:ite) ::  SLIMSK
+
 
       REAL     , DIMENSION(its:ite, kts:kte+1) ::       &
-                                        PRSI                            
+                                        PRSI
 
       REAL     , DIMENSION(its:ite, kts:kte) ::         &
                                         DEL,                            &
                                         DOT,                            &
                                         PHIL,                           &
                                         PRSL,                           &
-                                        Q1,                             & 
+                                        Q1,                             &
                                         Q2,                             &
                                         Q3,                             &
                                         Q1B,                            &
                                         Q1BL,                           &
                                         Q11,                            &
-                                        Q12,                            &  
-                                        T1,                             & 
-                                        U1,                             & 
-                                        V1,                             & 
-                                        ZI,                             & 
+                                        Q12,                            &
+                                        T1,                             &
+                                        U1,                             &
+                                        V1,                             &
+                                        ZI,                             &
                                         ZL,                             &
                                         OMG,                            &
-                                        GHT 
+                                        GHT
 
       INTEGER, DIMENSION(its:ite) ::                                    &
                                         KBOT,                           &
-                                        KTOP                           
+                                        KTOP
 
       INTEGER ::                                                        &
                                         I,                              &
@@ -337,7 +337,7 @@ CONTAINS
       INTEGER,DIMENSION( its:ite ) :: KTYPE
       REAL, DIMENSION( kts:kte )   :: sig1      ! half sigma levels
       REAL, DIMENSION( kms:kme )   :: ZNU
-      INTEGER                      :: zz 
+      INTEGER                      :: zz
 !-----------------------------------------------------------------------
 !
 
@@ -346,7 +346,7 @@ CONTAINS
             CU_ACT_FLAG(I,J)=.TRUE.
          ENDDO
       ENDDO
- 
+
       IM=ITE-ITS+1
       KX=KTE-KTS+1
       DELT=DT*STEPCU
@@ -397,7 +397,7 @@ CONTAINS
       ENDDO
 
       DO k=kts,kte
-        zz = kte+1-k        
+        zz = kte+1-k
         DO i=its,ite
           U1(i,zz)=U3D(i,k,j)
           V1(i,zz)=V3D(i,k,j)
@@ -423,7 +423,7 @@ CONTAINS
         DO i=its,ite
           PRSI(i,zz) = P8w(i,k,j)
         ENDDO
-      ENDDO 
+      ENDDO
 
       DO k=kts,kte
          zz = kte+1-k
@@ -441,7 +441,7 @@ CONTAINS
       ENDDO
 !########################################################################
       CALL TIECNV(U1,V1,T1,Q1,Q2,Q3,Q1B,Q1BL,GHT,OMG,PRSL,PRSI,EVAP,heatflux,rho2d,             &
-                  RN,SLIMSK,KTYPE,IM,KX,KX+1,sig1,DELT)      
+                  RN,SLIMSK,KTYPE,IM,KX,KX+1,sig1,DELT)
 
       DO I=ITS,ITE
          RAINCV(I,J)=RN(I)/STEPCU
@@ -454,9 +454,13 @@ CONTAINS
           RTHCUTEN(I,K,J)=(T1(I,zz)-T3D(I,K,J))/PI3D(I,K,J)*RDELT
           RQVCUTEN(I,K,J)=(Q1(I,zz)-QV3D(I,K,J))*RDELT
           RUCUTEN(I,K,J) =(U1(I,zz)-U3D(I,K,J))*RDELT
-          RVCUTEN(I,K,J) =(V1(I,zz)-V3D(I,K,J))*RDELT 
+          RVCUTEN(I,K,J) =(V1(I,zz)-V3D(I,K,J))*RDELT
         ENDDO
       ENDDO
+      ! if (j==55) then
+      !     print*, RUCUTEN(41,:,j)/RDELT
+      !     ! print*, U1(41,kte:kts:-1) - U3D(41,kts:kte,J)
+      ! endif
 
       IF(PRESENT(RQCCUTEN))THEN
         IF ( F_QC ) THEN
@@ -509,13 +513,13 @@ CONTAINS
                                                               RQVCUTEN, &
                                                               RQCCUTEN, &
                                                               RQICUTEN, &
-                                                              RUCUTEN,RVCUTEN 
+                                                              RUCUTEN,RVCUTEN
 
    INTEGER :: i, j, k, itf, jtf, ktf
 
-   jtf=min0(jte,jde-1)
-   ktf=min0(kte,kde-1)
-   itf=min0(ite,ide-1)
+   jtf=min(jte,jde-1)
+   ktf=min(kte,kde-1)
+   itf=min(ite,ide-1)
 
    IF(.not.restart)THEN
      DO j=jts,jtf
@@ -569,7 +573,7 @@ CONTAINS
       SUBROUTINE TIECNV(pu,pv,pt,pqv,pqc,pqi,pqvf,pqvbl,poz,pomg,  &
            pap,paph,evap,hfx,rho,zprecc,lndj,KTYPE,lq,km,km1,sig1,dt)
 !-----------------------------------------------------------------
-!  This is the interface between the meso-scale model and the mass 
+!  This is the interface between the meso-scale model and the mass
 !  flux convection module
 !-----------------------------------------------------------------
       implicit none
@@ -649,7 +653,7 @@ CONTAINS
          (lq,       km,       km1,      km-1,    ZTP1,   &
           ZQP1,     PUM1,     PVM1,     PVERV,   ZQSAT,  &
           PQHFL,    ZTMST,    PAP,      PAPH,    PGEO,   &
-          PTTE,     PQTE,     PVOM,     PVOL,    PRSFC,  & 
+          PTTE,     PQTE,     PVOM,     PVOL,    PRSFC,  &
           PSSFC,    PAPRC,    PAPRSM,   PAPRS,   LOCUM,  &
           KTYPE,    ICBOT,    ICTOP,    ZTU,     ZQU,    &
           ZLU,      ZLUDE,    ZMFU,     ZMFD,    ZRAIN,  &
@@ -718,7 +722,7 @@ CONTAINS
           PSSFC,    PAPRC,    PAPRSM,   PAPRS,    LDCUM, &
           KTYPE,    KCBOT,    KCTOP,    PTU,      PQU,   &
           PLU,      PLUDE,    PMFU,     PMFD,     PRAIN, &
-          PSRAIN,   PSEVAP,   PSHEAT,   PSDISS,   PSMELT,& 
+          PSRAIN,   PSEVAP,   PSHEAT,   PSDISS,   PSMELT,&
           PCTE,     PHHFL,       RHO,     sig1,     lndj)
 !
 !***CUMASTR*  MASTER ROUTINE FOR CUMULUS MASSFLUX-SCHEME
@@ -811,7 +815,7 @@ CONTAINS
               PTTE(KLON,KLEV),        PQTE(KLON,KLEV),  &
               PVOM(KLON,KLEV),        PVOL(KLON,KLEV),  &
               PQSEN(KLON,KLEV),       PGEO(KLON,KLEV),  &
-              PAP(KLON,KLEV),         PAPH(KLON,KLEVP1),& 
+              PAP(KLON,KLEV),         PAPH(KLON,KLEVP1),&
               PVERV(KLON,KLEV),       PQHFL(KLON),      &
               PHHFL(KLON),            RHO(KLON)
       REAL     PTU(KLON,KLEV),         PQU(KLON,KLEV),  &
@@ -825,20 +829,20 @@ CONTAINS
               ZTD(KLON,KLEV),         ZQD(KLON,KLEV),   &
               ZMFUS(KLON,KLEV),       ZMFDS(KLON,KLEV), &
               ZMFUQ(KLON,KLEV),       ZMFDQ(KLON,KLEV), &
-              ZDMFUP(KLON,KLEV),      ZDMFDP(KLON,KLEV),& 
+              ZDMFUP(KLON,KLEV),      ZDMFDP(KLON,KLEV),&
               ZMFUL(KLON,KLEV),       ZRFL(KLON),       &
               ZUU(KLON,KLEV),         ZVU(KLON,KLEV),   &
               ZUD(KLON,KLEV),         ZVD(KLON,KLEV)
       REAL     ZENTR(KLON),            ZHCBASE(KLON),   &
               ZMFUB(KLON),            ZMFUB1(KLON),     &
-              ZDQPBL(KLON),           ZDQCV(KLON) 
+              ZDQPBL(KLON),           ZDQCV(KLON)
       REAL     ZSFL(KLON),             ZDPMEL(KLON,KLEV), &
               PCTE(KLON,KLEV),        ZCAPE(KLON),        &
               ZHEAT(KLON),            ZHHATT(KLON,KLEV),  &
               ZHMIN(KLON),            ZRELH(KLON)
       REAL     sig1(KLEV)
       INTEGER  ILAB(KLON,KLEV),        IDTOP(KLON),   &
-              ICTOP0(KLON),           ILWMIN(KLON)    
+              ICTOP0(KLON),           ILWMIN(KLON)
       INTEGER  KCBOT(KLON),            KCTOP(KLON),   &
               KTYPE(KLON),            IHMIN(KLON),    &
               KTOP0,                  lndj(KLON)
@@ -973,7 +977,7 @@ CONTAINS
          ELSE
             IHMIN(JL) = -1
          END IF
- 440  CONTINUE 
+ 440  CONTINUE
 !
       ZBI = 1./(25.*G)
       DO 450 JK = KLEV, 1, -1
@@ -992,7 +996,7 @@ CONTAINS
         ZRH = -ALV*(ZQSENH(JL,JK)-ZQENH(JL,JK))*ZFAC
         IF (ZHMIN(JL).GT.ZRH) IHMIN(JL) = JK
       END IF
- 450  CONTINUE 
+ 450  CONTINUE
       DO 460 JL = 1, KLON
       IF (LDCUM(JL).AND.KTYPE(JL).EQ.1) THEN
         IF (IHMIN(JL).LT.ICTOP0(JL)) IHMIN(JL) = ICTOP0(JL)
@@ -1003,7 +1007,7 @@ CONTAINS
         ZENTR(JL)=ENTRSCV
       ENDIF
       if(lndj(JL).eq.1) ZENTR(JL)=ZENTR(JL)*1.05
- 460  CONTINUE 
+ 460  CONTINUE
 !*         (B) DO ASCENT IN 'CUASC'IN ABSENCE OF DOWNDRAFTS
 !----------------------------------------------------------
       CALL CUASC_NEW &
@@ -1100,8 +1104,8 @@ CONTAINS
        ENDIF
        ENDDO
 !
-       
-       if(cutrigger .eq. 1 ) then 
+
+       if(cutrigger .eq. 1 ) then
          IF(lndj(JL).EQ.1) then
            CRIRH1=CRIRH*0.8
          ELSE
@@ -1186,7 +1190,7 @@ CONTAINS
          (KLON,     KLEV,     KLEVP1,   KLEVM1,   ZTENH,  &
           ZQENH,    PUEN,     PVEN,     PTEN,     PQEN,   &
           PQSEN,    PGEO,     ZGEOH,    PAP,      PAPH,   &
-          PQTE,     PVERV,    ILWMIN,   LDCUM,    ZHCBASE,& 
+          PQTE,     PVERV,    ILWMIN,   LDCUM,    ZHCBASE,&
           KTYPE,    ILAB,     PTU,      PQU,      PLU,    &
           ZUU,      ZVU,      PMFU,     ZMFUB,    ZENTR,  &
           ZMFUS,    ZMFUQ,    ZMFUL,    PLUDE,    ZDMFUP, &
@@ -1286,7 +1290,7 @@ CONTAINS
               PMFU(KLON,KLEV),        PMFD(KLON,KLEV),     &
               PMFUS(KLON,KLEV),       PMFDS(KLON,KLEV),    &
               PMFUQ(KLON,KLEV),       PMFDQ(KLON,KLEV),    &
-              PDMFUP(KLON,KLEV),      PDMFDP(KLON,KLEV),   & 
+              PDMFUP(KLON,KLEV),      PDMFDP(KLON,KLEV),   &
               PLU(KLON,KLEV),         PLUDE(KLON,KLEV)
       REAL     ZWMAX(KLON),            ZPH(KLON),          &
               PDPMEL(KLON,KLEV)
@@ -1373,11 +1377,11 @@ CONTAINS
   220 CONTINUE
   230 CONTINUE
       RETURN
-      END SUBROUTINE CUINI   
+      END SUBROUTINE CUINI
 
 !**********************************************
 !       SUBROUTINE CUBASE
-!********************************************** 
+!**********************************************
       SUBROUTINE CUBASE &
          (KLON,     KLEV,     KLEVP1,   KLEVM1,   PTENH, &
           PQENH,    PGEOH,    PAPH,     PTU,      PQU,   &
@@ -1416,7 +1420,7 @@ CONTAINS
       REAL     PTU(KLON,KLEV),         PQU(KLON,KLEV),   &
               PLU(KLON,KLEV)
       REAL     PUEN(KLON,KLEV),        PVEN(KLON,KLEV),  &
-              PUU(KLON,KLEV),         PVU(KLON,KLEV) 
+              PUU(KLON,KLEV),         PVU(KLON,KLEV)
       REAL     ZQOLD(KLON,KLEV),       ZPH(KLON)
       INTEGER  KLAB(KLON,KLEV),        KCBOT(KLON)
       LOGICAL  LDCUM(KLON),            LOFLAG(KLON)
@@ -1525,7 +1529,7 @@ CONTAINS
 
 !**********************************************
 !       SUBROUTINE CUTYPE
-!********************************************** 
+!**********************************************
       SUBROUTINE CUTYPE    &
         ( KLON,     KLEV,     KLEVP1,   KLEVM1,&
           PTENH,   PQENH,     PQSENH,    PGEOH,   PAPH,&
@@ -1553,8 +1557,8 @@ CONTAINS
 !                        influence on triggering, updraft properties, and model climate, Mon.Wea.Rev.
 !                        131, 2765-2778
 !            and
-!                        IFS Documentation - Cy33r1 
-!          
+!                        IFS Documentation - Cy33r1
+!
 !***EXTERNALS
 !   ---------
 !          *CUADJTQ* FOR ADJUSTING T AND Q DUE TO CONDENSATION IN ASCENT
@@ -1638,7 +1642,7 @@ CONTAINS
           ZPH(JL)=PAPH(JL,JK)
         END DO
 
-! define the variables at the first level      
+! define the variables at the first level
       if(jk .eq. KLEVM1) then
       do jl=1,klon
         part1(jl) = 1.5*0.4*pgeoh(jl,jk+1)/(rho(jl)*ptenh(jl,jk+1))
@@ -1759,7 +1763,7 @@ CONTAINS
           ZPH(JL)=PAPH(JL,JK)
         END DO
 
-! define the variables at the first level      
+! define the variables at the first level
       if(jk .eq. levels) then
       do jl=1,klon
         deltT(jl) = 0.2
@@ -1772,7 +1776,7 @@ CONTAINS
                       deltT(jl)
         dh(jl,jk+1) = 0.25*(pgeoh(jl,jk+1)+pgeoh(jl,jk)+ &
                             pgeoh(jl,jk-1)+pgeoh(jl,jk-2)) + &
-                      Tup(jl,jk+1)*cpd 
+                      Tup(jl,jk+1)*cpd
         qh(jl,jk+1) = 0.25*(pqenh(jl,jk+1)+pqenh(jl,jk)+ &
                             pqenh(jl,jk-1)+pqenh(jl,jk-2))+ &
                       deltQ(jl) + ql(jl,jk+1)
@@ -1865,15 +1869,15 @@ CONTAINS
 !
 !**********************************************
 !       SUBROUTINE CUASC_NEW
-!********************************************** 
+!**********************************************
       SUBROUTINE CUASC_NEW &
          (KLON,     KLEV,     KLEVP1,   KLEVM1,   PTENH,  &
           PQENH,    PUEN,     PVEN,     PTEN,     PQEN,   &
           PQSEN,    PGEO,     PGEOH,    PAP,      PAPH,   &
-          PQTE,     PVERV,    KLWMIN,   LDCUM,    PHCBASE,& 
+          PQTE,     PVERV,    KLWMIN,   LDCUM,    PHCBASE,&
           KTYPE,    KLAB,     PTU,      PQU,      PLU,    &
           PUU,      PVU,      PMFU,     PMFUB,    PENTR,  &
-          PMFUS,    PMFUQ,    PMFUL,    PLUDE,    PDMFUP, & 
+          PMFUS,    PMFUQ,    PMFUL,    PLUDE,    PDMFUP, &
           KCBOT,    KCTOP,    KCTOP0,   KCUM,     ZTMST,  &
           KHMIN,    PHHATT,   PQSENH)
 !     THIS ROUTINE DOES THE CALCULATIONS FOR CLOUD ASCENTS
@@ -1963,7 +1967,7 @@ CONTAINS
               PGEO(KLON,KLEV),        PGEOH(KLON,KLEV),  &
               PAP(KLON,KLEV),         PAPH(KLON,KLEVP1), &
               PQSEN(KLON,KLEV),       PQTE(KLON,KLEV),   &
-              PVERV(KLON,KLEV),       PQSENH(KLON,KLEV)  
+              PVERV(KLON,KLEV),       PQSENH(KLON,KLEV)
       REAL     PTU(KLON,KLEV),         PQU(KLON,KLEV),   &
               PUU(KLON,KLEV),         PVU(KLON,KLEV),    &
               PMFU(KLON,KLEV),        ZPH(KLON),         &
@@ -2070,7 +2074,7 @@ CONTAINS
         zoentr(jl,ikb-1) = MAX(zoentr(jl,ikb-1),0.)
        end if
       END IF
-  322 CONTINUE 
+  322 CONTINUE
 !
 !-----------------------------------------------------------------
 !     4.       DO ASCENT: SUBCLOUD LAYER (KLAB=1) ,CLOUDS (KLAB=2)
@@ -2081,7 +2085,7 @@ CONTAINS
   400 CONTINUE
 
 ! let's define the levels in which the middle level convection could be activated
-	  leveltop=KLEVM1 !edg in case our model top is too low so we don't find anything below. 
+	  leveltop=KLEVM1 !edg in case our model top is too low so we don't find anything below.
 	  ! not sure this is needed but it broke occasionally before, ICAR uses a substantially lower model top than WRF
       do jk=KLEVM1,2,-1
       if(abs(paph(1,jk)*0.01 - 250) .lt. 50.) then
@@ -2091,7 +2095,7 @@ CONTAINS
       end do
       leveltop = min(KLEV-15,leveltop)
       levelbot = KLEVM1 - 4
-        
+
       DO 480 JK=KLEVM1,2,-1
 !                  SPECIFY CLOUD BASE VALUES FOR MIDLEVEL CONVECTION
 !                  IN *CUBASMC* IN CASE THERE IS NOT ALREADY CONVECTION
@@ -2269,9 +2273,9 @@ CONTAINS
               ZDMFDU=ZDMFDE(JL)+ZZ*ZDMFDE(JL)
               ZDMFDU=MIN(ZDMFDU,0.75*PMFU(JL,JK+1))
               ZMFUU(JL)=ZMFUU(JL)+                              &
-                       ZDMFEU*PUEN(JL,JK)-ZDMFDU*PUU(JL,JK+1)   
+                       ZDMFEU*PUEN(JL,JK)-ZDMFDU*PUU(JL,JK+1)
               ZMFUV(JL)=ZMFUV(JL)+                              &
-                       ZDMFEU*PVEN(JL,JK)-ZDMFDU*PVU(JL,JK+1)   
+                       ZDMFEU*PVEN(JL,JK)-ZDMFDU*PVU(JL,JK+1)
               IF(PMFU(JL,JK).GT.0.) THEN
                  PUU(JL,JK)=ZMFUU(JL)*(1./PMFU(JL,JK))
                  PVU(JL,JK)=ZMFUV(JL)*(1./PMFU(JL,JK))
@@ -2311,10 +2315,10 @@ CONTAINS
         zoentr(jl,jk-1) = 1.E-3*(1.3-PQEN(jl,jk-1)/PQSEN(jl,jk-1))*fscale(jl)
         zoentr(jl,jk-1) = MIN(zoentr(jl,jk-1),1.E-3)
         zoentr(jl,jk-1) = MAX(zoentr(jl,jk-1),0.)
-!        write(6,*) "zoentr=",zoentr(jl,jk-1) 
+!        write(6,*) "zoentr=",zoentr(jl,jk-1)
        end if
        END IF
-  470 CONTINUE 
+  470 CONTINUE
 !
   480 CONTINUE
 ! -----------------------------------------------------------------
@@ -2350,7 +2354,7 @@ CONTAINS
 	         PLUDE(JL,JK)=PMFUL(JL,JK)
 		 else
 	         PLUDE(JL,JK-1)=PMFUL(JL,JK)
-		end if			 
+		end if
          PDMFUP(JL,JK)=0.
       END IF
   530 CONTINUE
@@ -2370,7 +2374,7 @@ CONTAINS
 
 !**********************************************
 !       SUBROUTINE CUDLFS
-!********************************************** 
+!**********************************************
       SUBROUTINE CUDLFS &
          (KLON,     KLEV,     KLEVP1,   PTENH,    PQENH,  &
           PUEN,     PVEN,     PGEOH,    PAPH,     PTU,    &
@@ -2415,7 +2419,7 @@ CONTAINS
       REAL     PTD(KLON,KLEV),         PQD(KLON,KLEV),     &
               PUD(KLON,KLEV),         PVD(KLON,KLEV),      &
               PMFD(KLON,KLEV),        PMFDS(KLON,KLEV),    &
-              PMFDQ(KLON,KLEV),       PDMFDP(KLON,KLEV)    
+              PMFDQ(KLON,KLEV),       PDMFDP(KLON,KLEV)
       REAL     ZTENWB(KLON,KLEV),      ZQENWB(KLON,KLEV),  &
               ZCOND(KLON),            ZPH(KLON)
       INTEGER  KCBOT(KLON),            KCTOP(KLON),        &
@@ -2512,7 +2516,7 @@ CONTAINS
 
 !**********************************************
 !       SUBROUTINE CUDDRAF
-!********************************************** 
+!**********************************************
       SUBROUTINE CUDDRAF &
          (KLON,     KLEV,     KLEVP1,   PTENH,    PQENH, &
           PUEN,     PVEN,     PGEOH,    PAPH,     PRFL,  &
@@ -2552,14 +2556,14 @@ CONTAINS
       REAL      ZBUO, ZDMFDP, ZMFDUK, ZMFDVK
       REAL     PTENH(KLON,KLEV),       PQENH(KLON,KLEV),  &
               PUEN(KLON,KLEV),        PVEN(KLON,KLEV),    &
-              PGEOH(KLON,KLEV),       PAPH(KLON,KLEVP1) 
+              PGEOH(KLON,KLEV),       PAPH(KLON,KLEVP1)
       REAL     PTD(KLON,KLEV),         PQD(KLON,KLEV),    &
               PUD(KLON,KLEV),         PVD(KLON,KLEV),     &
               PMFD(KLON,KLEV),        PMFDS(KLON,KLEV),   &
               PMFDQ(KLON,KLEV),       PDMFDP(KLON,KLEV),  &
               PRFL(KLON)
       REAL     ZDMFEN(KLON),           ZDMFDE(KLON),      &
-              ZCOND(KLON),            ZPH(KLON)       
+              ZCOND(KLON),            ZPH(KLON)
       LOGICAL  LDDRAF(KLON),           LLO2(KLON)
 !--------------------------------------------------------------
 !     1.       CALCULATE MOIST DESCENT FOR CUMULUS DOWNDRAFT BY
@@ -2654,7 +2658,7 @@ CONTAINS
 
 !**********************************************
 !       SUBROUTINE CUFLX
-!********************************************** 
+!**********************************************
       SUBROUTINE CUFLX &
          (KLON,     KLEV,     KLEVP1,   PQEN,    PQSEN,     &
           PTENH,    PQENH,    PAPH,     PGEOH,   KCBOT,    &
@@ -2685,7 +2689,7 @@ CONTAINS
       REAL      ZRMIN, ZRFLN, ZDRFL, ZDPEVAP
       REAL     PQEN(KLON,KLEV),        PQSEN(KLON,KLEV),  &
               PTENH(KLON,KLEV),       PQENH(KLON,KLEV),   &
-              PAPH(KLON,KLEVP1),      PGEOH(KLON,KLEV)    
+              PAPH(KLON,KLEVP1),      PGEOH(KLON,KLEV)
       REAL     PMFU(KLON,KLEV),        PMFD(KLON,KLEV),   &
               PMFUS(KLON,KLEV),       PMFDS(KLON,KLEV),   &
               PMFUQ(KLON,KLEV),       PMFDQ(KLON,KLEV),   &
@@ -2828,7 +2832,7 @@ CONTAINS
 
 !**********************************************
 !       SUBROUTINE CUDTDQ
-!********************************************** 
+!**********************************************
       SUBROUTINE CUDTDQ &
          (KLON,     KLEV,     KLEVP1,   KTOPM2,   PAPH,   &
           LDCUM,    PTEN,     PTTE,     PQTE,     PMFUS,  &
@@ -2860,7 +2864,7 @@ CONTAINS
       REAL     PMFUS(KLON,KLEV),       PMFDS(KLON,KLEV), &
               PMFUQ(KLON,KLEV),       PMFDQ(KLON,KLEV), &
               PMFUL(KLON,KLEV),       PQSEN(KLON,KLEV), &
-              PDMFUP(KLON,KLEV),      PDMFDP(KLON,KLEV),& 
+              PDMFUP(KLON,KLEV),      PDMFDP(KLON,KLEV),&
               PRFL(KLON),             PRAIN(KLON),      &
               PQEN(KLON,KLEV)
       REAL     PDPMEL(KLON,KLEV),      PSFL(KLON)
@@ -2898,7 +2902,7 @@ CONTAINS
               -ZALV*(PMFUL(JL,JK+1)-PMFUL(JL,JK)-pldfd-      &
               (PDMFUP(JL,JK)+PDMFDP(JL,JK))))
             PTTE(JL,JK)=PTTE(JL,JK)+ZDTDT
-            ZDQDT=(G/(PAPH(JL,JK+1)-PAPH(JL,JK)))*& 
+            ZDQDT=(G/(PAPH(JL,JK+1)-PAPH(JL,JK)))*&
               (PMFUQ(JL,JK+1)-PMFUQ(JL,JK)+       &
               PMFDQ(JL,JK+1)-PMFDQ(JL,JK)+        &
               PMFUL(JL,JK+1)-PMFUL(JL,JK)-pldfd-  &
@@ -2922,11 +2926,11 @@ CONTAINS
             pldfd=MAX(0.0,RHCOE*fdbk*PLUDE(JL,JK))
             ZDTDT=-(G/(PAPH(JL,JK+1)-PAPH(JL,JK)))*RCPD*           &
                 (PMFUS(JL,JK)+PMFDS(JL,JK)+ALF*PDPMEL(JL,JK)-ZALV* &
-                (PMFUL(JL,JK)+PDMFUP(JL,JK)+PDMFDP(JL,JK)+pldfd))  
+                (PMFUL(JL,JK)+PDMFUP(JL,JK)+PDMFDP(JL,JK)+pldfd))
             PTTE(JL,JK)=PTTE(JL,JK)+ZDTDT
             ZDQDT=-(G/(PAPH(JL,JK+1)-PAPH(JL,JK)))*                &
                      (PMFUQ(JL,JK)+PMFDQ(JL,JK)+pldfd+             &
-                     (PMFUL(JL,JK)+PDMFUP(JL,JK)+PDMFDP(JL,JK)))   
+                     (PMFUL(JL,JK)+PDMFUP(JL,JK)+PDMFDP(JL,JK)))
             PQTE(JL,JK)=PQTE(JL,JK)+ZDQDT
             PCTE(JL,JK)=(G/(PAPH(JL,JK+1)-PAPH(JL,JK)))*pldfd
             ZSHEAT(JL)=ZSHEAT(JL)+ZALV*(PDMFUP(JL,JK)+PDMFDP(JL,JK))
@@ -2956,7 +2960,7 @@ CONTAINS
 !
 !**********************************************
 !       SUBROUTINE CUDUDV
-!********************************************** 
+!**********************************************
       SUBROUTINE CUDUDV &
          (KLON,     KLEV,     KLEVP1,   KTOPM2,   KTYPE,  &
           KCBOT,    PAPH,     LDCUM,    PUEN,     PVEN,   &
@@ -3076,7 +3080,7 @@ CONTAINS
           PGEO,     PGEOH,    LDCUM,   KTYPE,  KLAB,  &
           PMFU,     PMFUB,    PENTR,   KCBOT,  PTU,   &
           PQU,      PLU,      PUU,     PVU,    PMFUS, &
-          PMFUQ,    PMFUL,    PDMFUP,  PMFUU,  PMFUV) 
+          PMFUQ,    PMFUL,    PDMFUP,  PMFUU,  PMFUV)
 !      M.TIEDTKE         E.C.M.W.F.     12/89
 !***PURPOSE.
 !   --------
@@ -3102,7 +3106,7 @@ CONTAINS
       REAL      zzzmb
       REAL     PTEN(KLON,KLEV),        PQEN(KLON,KLEV),  &
               PUEN(KLON,KLEV),        PVEN(KLON,KLEV),   &
-              PQSEN(KLON,KLEV),       PVERV(KLON,KLEV),  & 
+              PQSEN(KLON,KLEV),       PVERV(KLON,KLEV),  &
               PGEO(KLON,KLEV),        PGEOH(KLON,KLEV)
       REAL     PTU(KLON,KLEV),         PQU(KLON,KLEV),   &
               PUU(KLON,KLEV),         PVU(KLON,KLEV),    &
@@ -3314,7 +3318,7 @@ CONTAINS
 !**********************************************************
 !        SUBROUTINE CUENTR_NEW
 !**********************************************************
-      SUBROUTINE CUENTR_NEW                              &   
+      SUBROUTINE CUENTR_NEW                              &
          (KLON,     KLEV,     KLEVP1,   KK,       PTENH, &
           PAPH,     PAP,      PGEOH,    KLWMIN,   LDCUM, &
           KTYPE,    KCBOT,    KCTOP0,   ZPBASE,   PMFU,  &

--- a/src/physics/linear_winds.f90
+++ b/src/physics/linear_winds.f90
@@ -1128,16 +1128,6 @@ contains
                         sweight = calc_weight(spd_values, spos, nexts, curspd)
                         nweight = calc_weight(nsq_values, npos, nextn, curnsq)
 
-                        ! if ((k==25) .and. (j==25) .and. (i>105) .and.(i<115)) then
-                        if ((k==25) .and. (i==120).and.(j<10)) then
-                            ! print*, "--------------------------------------------------------"
-                            print*, j, npos, curnsq, domain%nsquared(i,j,k)
-                            ! print*, dpos, spos, npos
-                            ! print*, dweight, sweight, nweight
-                            ! print*, " nsq=", domain%nsquared(i,j,k)
-                            ! print*, curdir, curspd, curnsq
-                        endif
-
                         ! perform linear interpolation between LUT values
                         if (k<=ny) then
                             wind_first =      nweight  * (dweight * u_LUT(spos, dpos,npos, i,j,k) + (1-dweight) * u_LUT(spos, nextd,npos, i,j,k))   &
@@ -1173,21 +1163,10 @@ contains
                             endif
                         endif
 
-                        ! if ((k==25) .and. (i>=110).and.(i<112)) then
-                        !     print*, domain%u(i-1,j,k), domain%u(i,j,k), domain%u(i,j,k)-domain%u(i-1,j,k)
-                        ! endif
-                        ! if ((k==25) .and. (j==25) .and. (i>105) .and.(i<115)) then
-                        !     print*, domain%u(i-1,j,k), domain%u(i,j,k), domain%u(i,j,k)-domain%u(i-1,j,k)
-                        !     print*, domain%v(i,j,k-1), domain%v(i,j,k), domain%v(i,j,k)-domain%v(i,j,k-1)
-                        !     ! print*, wind_first, wind_second, linear_update_fraction, 1-blocked, linear_mask(i,k)
-                        ! endif
-
                     endif
                 end do
             end do
         end do
-        call io_write("test_u_"//trim(str(nth_file))//".nc", "data", domain%u(:,:,25))
-        nth_file = nth_file + 1
 
         ! $omp end do
         deallocate(u1d, v1d)

--- a/src/physics/linear_winds.f90
+++ b/src/physics/linear_winds.f90
@@ -38,7 +38,7 @@ module linear_theory_winds
     use fft ! note fft module is defined in fftshift.f90
     use fftshifter
     use data_structures
-    use io_routines,               only : io_read
+    use io_routines,               only : io_read, io_write
     use string,                    only : str
     use linear_theory_lut_disk_io, only : read_LUT, write_LUT
     use mod_atm_utilities
@@ -54,6 +54,7 @@ module linear_theory_winds
     logical :: smooth_nsq
     logical :: using_blocked_flow
     real    :: N_squared
+    integer :: nth_file=1
 
     !! unfortunately these have to be allocated every call because we could be calling on both the high-res
     !! domain and the low res domain (to "remove" the linear winds)
@@ -967,15 +968,15 @@ contains
         endif
 
         if (reverse) print*, "WARNING using fixed nsq for linear wind removal: 3e-6"
-        !$omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
-        !$omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
-        !$omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
-        !$omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
-        !$omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
-        !$omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
-        !$omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
-
-        !$omp do
+        ! $omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
+        ! $omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
+        ! $omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
+        ! $omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
+        ! $omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
+        ! $omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
+        ! $omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
+        !
+        ! $omp do
         do k=1,ny
             do j=1,nz
                 do i=1,nx
@@ -1022,23 +1023,23 @@ contains
                 end do
             endif
         end do
-        !$omp end do
-        !$omp end parallel
+        ! $omp end do
+        ! $omp end parallel
 
         ! smooth array has it's own parallelization, so this probably can't go in a critical section
         if (smooth_nsq) then
             call smooth_array(domain%nsquared, winsz, ydim=3)
         endif
 
-        !$omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
-        !$omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
-        !$omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
-        !$omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
-        !$omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
-        !$omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
-        !$omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
+        ! $omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
+        ! $omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
+        ! $omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
+        ! $omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
+        ! $omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
+        ! $omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
+        ! $omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
         allocate(u1d(nxu), v1d(nxu))
-        !$omp do
+        ! $omp do
         do k=1, nyv
 
             uk = min(k,ny)
@@ -1127,6 +1128,16 @@ contains
                         sweight = calc_weight(spd_values, spos, nexts, curspd)
                         nweight = calc_weight(nsq_values, npos, nextn, curnsq)
 
+                        ! if ((k==25) .and. (j==25) .and. (i>105) .and.(i<115)) then
+                        if ((k==25) .and. (i==120).and.(j<10)) then
+                            ! print*, "--------------------------------------------------------"
+                            print*, j, npos, curnsq, domain%nsquared(i,j,k)
+                            ! print*, dpos, spos, npos
+                            ! print*, dweight, sweight, nweight
+                            ! print*, " nsq=", domain%nsquared(i,j,k)
+                            ! print*, curdir, curspd, curnsq
+                        endif
+
                         ! perform linear interpolation between LUT values
                         if (k<=ny) then
                             wind_first =      nweight  * (dweight * u_LUT(spos, dpos,npos, i,j,k) + (1-dweight) * u_LUT(spos, nextd,npos, i,j,k))   &
@@ -1161,13 +1172,26 @@ contains
                                 domain%v(i,j,k) = domain%v(i,j,k) + v_perturbation(i,j,k) * linear_mask(min(nx,i),min(ny,k)) * (1-blocked)
                             endif
                         endif
+
+                        ! if ((k==25) .and. (i>=110).and.(i<112)) then
+                        !     print*, domain%u(i-1,j,k), domain%u(i,j,k), domain%u(i,j,k)-domain%u(i-1,j,k)
+                        ! endif
+                        ! if ((k==25) .and. (j==25) .and. (i>105) .and.(i<115)) then
+                        !     print*, domain%u(i-1,j,k), domain%u(i,j,k), domain%u(i,j,k)-domain%u(i-1,j,k)
+                        !     print*, domain%v(i,j,k-1), domain%v(i,j,k), domain%v(i,j,k)-domain%v(i,j,k-1)
+                        !     ! print*, wind_first, wind_second, linear_update_fraction, 1-blocked, linear_mask(i,k)
+                        ! endif
+
                     endif
                 end do
             end do
         end do
-        !$omp end do
+        call io_write("test_u_"//trim(str(nth_file))//".nc", "data", domain%u(:,:,25))
+        nth_file = nth_file + 1
+
+        ! $omp end do
         deallocate(u1d, v1d)
-        !$omp end parallel
+        ! $omp end parallel
     end subroutine spatial_winds
 
 

--- a/src/utilities/geo_reader.f90
+++ b/src/utilities/geo_reader.f90
@@ -134,7 +134,7 @@ contains
             stop "Denominator in triangulation is broken"
         endif
 
-        ! This is the core of the algorithm.
+        ! This is the core of the algorithm weights for Barycentric coordinates.
         ! compute weights for each x,y point
         w1 = ((y2-y3) * (xi-x3) + (x3-x2) * (yi-y3)) &
                            / denom
@@ -509,37 +509,42 @@ contains
     !! precision optionally defines the tolerance permitted to consider around the line
     !!
     !!------------------------------------------------------------
-    function point_is_on_line(x,y,x0,y0,x1,y1, precision) result(online)
+    function point_is_on_line(x,y,x0,y0,x1,y1, precision, error) result(online)
         ! WARNING: assumes y is between y0 and y1 and x < max(x0,x1)
         implicit none
         real, intent(in) :: x,y,x0,y0,x1,y1
         real, intent(in), optional :: precision
+        real, intent(out),optional :: error
         logical :: online
 
         real :: internal_precision
         double precision :: slope, offset
 
-        internal_precision = 1e-4
+        internal_precision = 1e-5
         if (present(precision)) internal_precision = precision
 
-        online=.False.
+        online = .False.
         ! can we abort testing whether we are actually on a border?
         if (x >= min(x0,x1)) then
             ! we COULD be on a border
-            if (x0/=x1) then
+            if (x0 /= x1) then
                 ! find the equation of the line and check if we are on it.
                 ! this is performed in double precision space to be as precise as possible
                 ! so that rounding errors are minimized
-                slope = (DBLE(y1)-y0) / (DBLE(x1)-x0)
+                slope = (DBLE(y1) - y0) / (DBLE(x1) - x0)
                 offset = y0 - (slope * x0)
                 ! note that due to rounding errors we could be "close" but not on it...
                 if (abs( ((slope * x) + offset) - y) < internal_precision) then
                     ! we are on a border, return true
-                    online=.True.
+                    online = .True.
+                    if (present(error)) error = abs( ((slope * x) + offset) - y)
                 endif
             else
                 ! if x0=x1 and x is between x0,x1 and y is between y0,y1 then
-                online=.True.
+                if (x == x0) then ! this is assumed from the input requirements, also assumes y is between y0 and y1
+                    online = .True.
+                    if (present(error)) error = 0
+                endif
             endif
         endif
 
@@ -558,11 +563,14 @@ contains
     !! Flips the inside/outside boolean if it intersected one or both verticies
     !!
     !!------------------------------------------------------------
-    subroutine check_vertex_hits(y, y0, y1, inside, top_vertex, bottom_vertex, precision)
+    subroutine check_vertex_hits(y, y0, y1, inside, top_vertex, bottom_vertex, precision, error)
         implicit none
         real,    intent(in)    :: y, y0, y1
         logical, intent(inout) :: top_vertex, bottom_vertex, inside
         real,    intent(in)    :: precision
+        real,    intent(out), optional :: error
+
+        if (present(error)) error = 0
 
         ! if the segment just parallels the line, then don't reset top_vertex, bottom_vertex history
         ! and don't flip inside/out
@@ -570,6 +578,7 @@ contains
 
         ! check if we hit the y0 vertex with our ray
         if (abs(y-y0) < precision) then
+            if (present(error)) error = abs(y-y0)
             ! if so, check if we are above or below the other vertex segment
             if (y<=y1) then
                 ! we are below the other vertex
@@ -593,6 +602,8 @@ contains
         endif
 
         if (abs(y-y1) < precision) then
+            if (present(error)) error = abs(y-y1)
+
             if (y<=y0) then
                 if (top_vertex) then
                     top_vertex=.False.
@@ -621,24 +632,30 @@ contains
     !! Note additional discussion here: https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
     !!
     !!------------------------------------------------------------
-    function point_in_poly(x, y, poly, precision) result(inside)
+    function point_in_poly(x, y, poly, precision, error) result(inside)
         implicit none
         real, intent(in) :: x, y
         real, intent(in) :: poly(:,:)
         real, intent(in), optional :: precision
+        real, intent(out), optional :: error
         logical :: inside
         logical :: top_vertex, bottom_vertex
 
         real :: internal_precision
+        logical :: point_on_line
         integer :: n, i
         real :: x0,y0,x1,y1
         double precision :: slope, x_line
+        real :: err, err_temp, line_err_temp
 
-        internal_precision = 1e-4
+        internal_precision = 1e-5
         if (present(precision)) internal_precision = precision
         n = size(poly,2)
+        err = 9999
+        if (present(error)) error = 0
 
         ! by default we assume we are not in the polygon
+        point_on_line = .False.
         inside = .False.
         top_vertex = .False.
         bottom_vertex = .False.
@@ -664,9 +681,10 @@ contains
                 if (y <= max(y0,y1)) then
                     if (x <= max(x0,x1)) then
 
-                        if (point_is_on_line(x,y,x0,y0,x1,y1, internal_precision)) then
-                            inside=.True.
-                            return
+                        if (point_is_on_line(x,y,x0,y0,x1,y1, internal_precision, error=line_err_temp)) then
+                            point_on_line = .True.
+                            err = min(err, line_err_temp)
+                            if (present(error)) error = err
                         endif
 
                         if (y0 /= y1) then
@@ -677,10 +695,12 @@ contains
                         else
                             x_line = -1e10 ! only inside if x0==x1
                         endif
+
                         ! if we cross one line then we are inside, but if we cross two we are outside, and so on
                         if ((x0 == x1) .or. (dble(x) <= x_line)) then
                             inside = .not. inside
-                            call check_vertex_hits(y,y0,y1,inside, top_vertex, bottom_vertex, internal_precision)
+                            call check_vertex_hits(y,y0,y1,inside, top_vertex, bottom_vertex, internal_precision, error=err_temp)
+                            err = max(err, err_temp)
                         else
                             top_vertex = .False.
                             bottom_vertex = .False.
@@ -693,20 +713,28 @@ contains
             y0 = y1
         enddo
 
+        if (inside) err = 0
+        if (point_on_line) inside = .True.
+        if (present(error)) error = err
+
         ! inside will be set to the correct value
     end function point_in_poly
 
 
-    function test_surrounding(lat,lon, lo, positions, nx, ny, n) result(surrounded)
+    function test_surrounding(lat,lon, lo, positions, nx, ny, n, error) result(surrounded)
         implicit none
         real,                    intent(in) :: lat, lon
         class(interpolable_type),intent(in) :: lo
         type(fourpos),           intent(inout) :: positions
         integer,                 intent(in) :: nx, ny, n
+        real,                    intent(out), optional :: error
         logical :: surrounded
         integer :: i
+        real :: err
 
         real :: polygon(2,n)
+
+        err = 0
 
         ! first enforce that all points passed in are within the bounds of the lat/lon arrays
         do i=1,n
@@ -721,20 +749,26 @@ contains
         enddo
 
         ! finally test that the provided lat/lon point falls within this polygon
-        surrounded = point_in_poly(lon, lat, polygon)
+        surrounded = point_in_poly(lon, lat, polygon, error=err)
+
+        if (present(error)) error = err
 
     end function test_surrounding
 
-    function test_triangle(lat,lon, lo, positions, nx, ny) result(surrounded)
+    function test_triangle(lat,lon, lo, positions, nx, ny, error) result(surrounded)
         implicit none
         real,                    intent(in) :: lat, lon
         class(interpolable_type),intent(in) :: lo
         type(fourpos),           intent(inout) :: positions
         integer,                 intent(in) :: nx, ny
+        real,                    intent(out), optional :: error
         logical :: surrounded
         integer :: i
+        real :: err
 
         real :: polygon(2,3)
+
+        err = 0
 
         ! assumes all points passed in are within the bounds of the lat/lon arrays!
         ! this is enforced in test_surrounding which should have passed by now
@@ -753,7 +787,9 @@ contains
         polygon(:,3) = polygon(:,3) / 4
 
         ! finally test that the provided lat/lon point falls within this polygon
-        surrounded = point_in_poly(lon, lat, polygon)
+        surrounded = point_in_poly(lon, lat, polygon, error=err)
+
+        if (present(error)) error = err
 
     end function test_triangle
 
@@ -770,50 +806,68 @@ contains
         integer,intent(in) :: nx,ny
         integer :: i, j
         integer :: xdeltas(4), ydeltas(4), dx, dy
+        real :: best_err, current_err, tri1_err, tri2_err
+        logical :: tri_1, tri_2
+        type(fourpos) :: search_point
 
-        xdeltas=[-1,-1,1,1]
-        ydeltas=[-1,1,-1,1]
+        best_err = 1e10
+
+        xdeltas = [-1,-1,1,1]
+        ydeltas = [-1,1,-1,1]
+
+        find_surrounding%x = -999
+        find_surrounding%y = -999
 
         do i=1,4
             dx = xdeltas(i)
             dy = ydeltas(i)
-            find_surrounding%x = [pos%x, pos%x+dx, pos%x+dx, pos%x  ]
-            find_surrounding%y = [pos%y, pos%y,   pos%y+dy, pos%y+dy]
+            search_point%x = [pos%x, pos%x+dx, pos%x+dx, pos%x  ]
+            search_point%y = [pos%y, pos%y,   pos%y+dy, pos%y+dy]
 
-            if (test_surrounding(lat, lon, lo, find_surrounding, nx, ny, 4)) then
-                ! if it is not in this triangle, it must be in the other.
+            if (test_surrounding(lat, lon, lo, search_point, nx, ny, 4, error=current_err)) then
+                if (current_err < best_err) then
+                    best_err = current_err
+                    ! if it is not in this triangle, it must be in the other.
 
-                if (.not.test_triangle(lat, lon, lo, find_surrounding, nx, ny)) then
-                    find_surrounding%x = [pos%x, pos%x,   pos%x+dx, pos%x+dx ]
-                    find_surrounding%y = [pos%y, pos%y+dy, pos%y,   pos%y+dy]
+                    tri_1 = test_triangle(lat, lon, lo, search_point, nx, ny, error=tri1_err)
 
-                    if (.not.test_triangle(lat, lon, lo, find_surrounding, nx, ny)) then
-                        find_surrounding%x = [pos%x+dx, pos%x,   pos%x+dx, pos%x]
-                        find_surrounding%y = [pos%y+dy, pos%y+dy, pos%y,   pos%y]
+                    search_point%x = [pos%x, pos%x,   pos%x+dx, pos%x+dx ]
+                    search_point%y = [pos%y, pos%y+dy, pos%y,   pos%y+dy]
 
-                        if (.not.test_triangle(lat, lon, lo, find_surrounding, nx, ny)) then
-                            find_surrounding%x = [pos%x+dx, pos%x+dx,   pos%x, pos%x]
-                            find_surrounding%y = [pos%y+dy, pos%y,   pos%y+dy, pos%y]
+                    tri_2 = test_triangle(lat, lon, lo, search_point, nx, ny, error=tri2_err)
 
-                            if (.not.test_triangle(lat, lon, lo, find_surrounding, nx, ny)) then
+                    if (tri_1) then
+                        search_point%x = [pos%x, pos%x+dx, pos%x+dx, pos%x  ]
+                        search_point%y = [pos%y, pos%y,   pos%y+dy, pos%y+dy]
 
-                                write(*,*) "ERROR finding triangle"
-                                write(*,*) find_surrounding%x
-                                write(*,*) find_surrounding%y
-                                write(*,*) lat, lon
-                                do j=1,4
-                                    write(*,*) lo%lat(find_surrounding%x(j), find_surrounding%y(j)), &
-                                               lo%lon(find_surrounding%x(j), find_surrounding%y(j))
-                                enddo
+                        if (tri_2) then
+                            if (tri2_err < tri1_err) then
+                                search_point%x = [pos%x, pos%x,   pos%x+dx, pos%x+dx ]
+                                search_point%y = [pos%y, pos%y+dy, pos%y,   pos%y+dy]
                             endif
                         endif
                     endif
-                endif
+                    find_surrounding = search_point
 
-                return
+
+                    if (.not.test_triangle(lat, lon, lo, search_point, nx, ny)) then
+
+                        write(*,*) "Warning point in box, but not triangle"
+                        write(*,*) search_point%x
+                        write(*,*) search_point%y
+                        write(*,*) lat, lon
+                        do j=1,4
+                            write(*,*) lo%lat(search_point%x(j), search_point%y(j)), &
+                                       lo%lon(search_point%x(j), search_point%y(j))
+                        enddo
+                    endif
+
+                endif
 
             endif
         enddo
+
+        if (find_surrounding%x(1) > -999) return
 
         write(*,*) "ERROR: Failed to find point", lon, lat, " in a quadrant near:"
         write(*,*) lo%lon(pos%x, pos%y), lo%lat(pos%x, pos%y)

--- a/src/utilities/string.f90
+++ b/src/utilities/string.f90
@@ -8,6 +8,8 @@
 !!------------------------------------------------------------
 module string
 
+    use iso_fortran_env, only : real32, real64
+
     implicit none
     !>-----------------------------
     !!  Generic interface to various types of string conversion functions
@@ -25,7 +27,7 @@ contains
     !! Convert a string to a double precision real number
     !!
     !!------------------------------
-    function get_double(str_in)
+    elemental function get_double(str_in)
         implicit none
         character(len=*), intent(in) :: str_in      ! input string
         double precision :: get_double              ! double precision return value
@@ -38,7 +40,7 @@ contains
     !! Convert a string to a single precision real number
     !!
     !!------------------------------
-    function get_real(str_in)
+    elemental function get_real(str_in)
         implicit none
         character(len=*), intent(in) :: str_in      ! input string
         real :: get_real                            ! return real value
@@ -51,7 +53,7 @@ contains
     !! Convert a string to a single precision integer
     !!
     !!------------------------------
-    function get_integer(str_in)
+    elemental function get_integer(str_in)
         implicit none
         character(len=*), intent(in) :: str_in      ! input string
         integer :: get_integer                      ! return integer value
@@ -67,10 +69,10 @@ contains
     !!  Optionally specify a format string
     !!
     !!------------------------------
-    function str_d(value,fmt) result(output_string)
+    elemental function str_d(value,fmt) result(output_string)
         implicit none
-        double precision :: value                       ! double precision value to be converted
-        character(len=*), optional :: fmt               ! optional format string for conversion
+        double precision, intent(in) :: value                       ! double precision value to be converted
+        character(len=*), intent(in), optional :: fmt               ! optional format string for conversion
         character(len=MAXSTRINGLENGTH) :: output_string ! return value
         
         if (present(fmt)) then
@@ -88,10 +90,10 @@ contains
     !!  Optionally specify a format string
     !!
     !!------------------------------
-    function str_r(value,fmt) result(output_string)
+    elemental function str_r(value,fmt) result(output_string)
         implicit none
-        real :: value                                   ! single precision value to be converted
-        character(len=*), optional :: fmt               ! optional format string for conversion
+        real, intent(in) :: value                                   ! single precision value to be converted
+        character(len=*), intent(in), optional :: fmt               ! optional format string for conversion
         character(len=MAXSTRINGLENGTH) :: output_string ! return value
         
         if (present(fmt)) then
@@ -109,10 +111,10 @@ contains
     !!  Optionally specify a format string
     !!
     !!------------------------------
-    function str_i(value,fmt) result(output_string)
+    elemental function str_i(value,fmt) result(output_string)
         implicit none
-        integer :: value                                ! integer value to be converted
-        character(len=*), optional :: fmt               ! optional format string for conversion
+        integer, intent(in) :: value                                ! integer value to be converted
+        character(len=*), intent(in), optional :: fmt               ! optional format string for conversion
         character(len=MAXSTRINGLENGTH) :: output_string ! return value
         
         if (present(fmt)) then
@@ -123,6 +125,5 @@ contains
         
         output_string=adjustl(output_string)
     end function str_i
-
 
 end module string

--- a/src/utilities/time_io.f90
+++ b/src/utilities/time_io.f90
@@ -138,6 +138,34 @@ contains
 
     end function day_from_units
 
+    function hour_from_units(units, error) result(hour)
+        implicit none
+        character(len=*), intent(in) :: units
+        integer, intent(out), optional :: error
+        integer :: hour
+        
+        integer :: since_loc, hour_loc
+        if (present(error)) error = 0
+
+        since_loc = index(units,"since")
+
+        hour_loc = index(units(since_loc:)," ") + 11
+        hour_loc = hour_loc + since_loc
+
+        ! default return value if hours can't be read from the units attribute (e.g. they aren't present)
+        hour = 0
+
+        if( hour_loc+1 <= len(units) ) then
+           if (trim(units(hour_loc:hour_loc+1)) /= "") then
+               hour = get_integer(units(hour_loc:hour_loc+1))
+           endif
+        else
+           if (present(error)) error = 1
+        endif
+
+    end function hour_from_units
+  
+
     subroutine read_times(filename, varname, times, timezone_offset)
         implicit none
         character(len=*),   intent(in) :: filename, varname
@@ -146,13 +174,13 @@ contains
 
         double precision, allocatable, dimension(:) :: temp_times
         integer :: time_idx, error
-        integer :: start_year, start_month, start_day
+        integer :: start_year, start_month, start_day, start_hour
         character(len=MAXSTRINGLENGTH) :: calendar, units
         double precision :: calendar_gain
 
         ! first read the time variable (presumebly a 1D double precision array)
         call io_read(trim(filename), trim(varname), temp_times)
-
+         
         ! attempt to read the calendar attribute from the time variable
         call io_read_attribute(trim(filename),"calendar", calendar, var_name=trim(varname), error=error)
         ! if time attribute it not present, set calendar to one specified in the config file
@@ -169,6 +197,7 @@ contains
             start_year    = year_from_units(units)
             start_month   = month_from_units(units)
             start_day     = day_from_units(units)
+            start_hour    = hour_from_units(units)            
             ! based off of the string "Days since" (or "seconds" or...)
             calendar_gain = time_gain_from_units(units)
         else
@@ -178,6 +207,7 @@ contains
         ! converts the input units to "days since ..."
         ! in case it is in units of e.g. "hours since" or "seconds since"
         temp_times = temp_times / calendar_gain
+                
         if (present(timezone_offset)) then
             temp_times = temp_times + timezone_offset / 24.0
         endif
@@ -186,10 +216,8 @@ contains
         allocate(times(size(temp_times)))
 
         do time_idx = 1, size(temp_times,1)
-
-            call times(time_idx)%init(calendar, start_year, start_month, start_day)
+            call times(time_idx)%init(calendar, start_year, start_month, start_day, start_hour)
             call times(time_idx)%set(days=temp_times(time_idx))
-
         end do
 
         deallocate(temp_times)

--- a/tests/test_string.f90
+++ b/tests/test_string.f90
@@ -1,0 +1,46 @@
+program main
+  use string, only : get_double, get_real, get_integer, str
+  use iso_fortran_env, only : real32, real64, int32, output_unit, error_unit
+  implicit none
+
+  ! Enumerate the test-result array indices:
+  enum, bind(C)
+    enumerator ::  get_double_, get_real_, get_integer_, str_d_, str_r_, str_i_
+  end enum
+  logical :: test_passed(get_double_:str_i_)=.false.
+
+  ! Test data
+  real(real64), parameter :: real64_datum=0.3_real64
+  real(real32), parameter :: real32_datum=0.3_real32
+  integer,      parameter :: integer_datum=1234567
+
+  ! Construct expected results
+  character(len=32) :: real64_string, real32_string, integer_string
+
+  write(real64_string,*) real64_datum
+  write(real32_string,*) real32_datum
+  write(integer_string,*) integer_datum
+
+  ! Test each string conversion function
+  if ( get_double(real64_string)   == real64_datum  ) test_passed(get_double_) = .true.
+  if ( get_real(real32_string)     == real32_datum  ) test_passed(get_real_) = .true.
+  if ( get_integer(integer_string) == integer_datum ) test_passed(get_integer_) = .true.
+
+  ! Left-justify the expected results for comparison
+  if ( adjustl(real64_string)      == str(real64_datum)  ) test_passed(str_d_) = .true.
+  if ( adjustl(real32_string)      == str(real32_datum)  ) test_passed(str_r_) = .true.
+  if ( adjustl(integer_string)     == str(integer_datum) ) test_passed(str_i_) = .true.
+
+  ! Test each string conversion function
+  if (all(test_passed)) then
+     write(output_unit,*) "Test passed." 
+  else
+     if ( .not. test_passed(get_double_ )) write(error_unit,*) "Test get_double failed."
+     if ( .not. test_passed(get_real_   )) write(error_unit,*) "Test get_real failed."
+     if ( .not. test_passed(get_integer_)) write(error_unit,*) "Test get_integer failed."
+     if ( .not. test_passed(str_d_      )) write(error_unit,*) "Test str_d failed."
+     if ( .not. test_passed(str_r_      )) write(error_unit,*) "Test str_r failed."
+     if ( .not. test_passed(str_i_      )) write(error_unit,*) "Test str_i failed."
+  end if
+
+end program


### PR DESCRIPTION
This update adds the capability to specify additional microphysics fields that should be imported from the forcing dataset. Their behaviour is the same as for the already pre-existing optional fields such as cloud ice mixing ratio and cloud water mixing ratio. If specified these fields are also applied at the domain boundaries during the simulation. The new optional fields are:

- qrvar ... rain mixing ratio [kg/kg] 
- qsvar ... snow mixing ratio [kg/kg]
- qgvar ... graupel mixing ratio [kg/kg]
- qnivar ... ice number density [1/kg] 
- qnrvar ... rain number density [1/kg]

and must be specified in the var_list section of the icar options file.

**Example** 
if  a WRF simulation is used as forcing dataset and the additional microphysics fields should be used:
    qrvar   = "QRAIN",     ! rain mixing ratio [kg/kg] OPTIONAL
    qsvar   = "QSNOW",  ! snow mixing ratio [kg/kg] OPTIONAL
    qgvar   = "QGRAU",  ! graupel mixing ratio [kg/kg] OPTIONAL
    qnivar  = "NICE",        ! ice number density [1/kg] OPTIONAL
    qnrvar  = "NRAIN",    ! rain number density [1/kg] OPTIONAL

The attached graphic shows the field in the WRF forcing dataset, the field as reproduced by ICAR at timestep zero, and the difference between the two.

![more_mpfields](https://user-images.githubusercontent.com/18684786/66938577-b6af6800-f041-11e9-9177-e4eabd2a55f6.png)
