### PR TITLE
Additional microphysics fields for initialisation and domain boundaries

### DIFF
--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -942,6 +942,53 @@ contains
                 domain%ice=0
             endif
 
+            ! jh - added qr, qs, qg, ni and nr as optional fields BEGIN
+            if (trim(options%qrvar)/="") then
+                call read_var(domain%qrain,  file_list(curfile),   options%qrvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Rain specified"
+                domain%qrain=0
+            endif
+
+            if (trim(options%qsvar)/="") then
+                call read_var(domain%qsnow,  file_list(curfile),   options%qsvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Snow specified"
+                domain%qsnow=0
+            endif
+            
+            if (trim(options%qgvar)/="") then
+                call read_var(domain%qgrau,  file_list(curfile),   options%qgvar, &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value,  &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Graupel specified"
+                domain%qgrau=0
+            endif
+            
+            if (trim(options%qnivar)/="") then
+                call read_var(domain%nice,  file_list(curfile),   options%qnivar,  &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value, &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Ice number density specified"
+                domain%nice=0
+            endif
+            
+            if (trim(options%qnrvar)/="") then
+                call read_var(domain%nrain,  file_list(curfile),   options%qnrvar,  &
+                                bc%geolut, bc%vert_lut, curstep, boundary_value, &
+                                options)
+            else
+                if (options%debug) write(*,*) "No Rain number density specified"
+                domain%nrain=0
+            endif
+            ! jh - added qr, qs, qg, ni and nr as optional fields END
+
             if (options%physics%landsurface==kLSM_BASIC) then
                 call read_2dvar(domain%sensible_heat,file_list(curfile),options%shvar,  bc%geolut,curstep)
                 call read_2dvar(domain%latent_heat,  file_list(curfile),options%lhvar,  bc%geolut,curstep)
@@ -1368,6 +1415,38 @@ contains
                           bc%geolut, bc%vert_lut, curstep, use_boundary,              &
                           options, time_varying_zlut=newbc%vert_lut)
         endif
+        
+        ! jh - added qr, qs, qg, ni and nr as optional fields BEGIN
+        if (trim(options%qrvar)/="") then
+            call read_var(bc%next_domain%qrain,  file_list(curfile),   options%qrvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+
+        if (trim(options%qsvar)/="") then
+            call read_var(bc%next_domain%qsnow,  file_list(curfile),   options%qsvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qgvar)/="") then
+            call read_var(bc%next_domain%qgrau,  file_list(curfile),   options%qgvar, &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary,  &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qnivar)/="") then
+            call read_var(bc%next_domain%nice,  file_list(curfile),   options%qnivar,  &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary, &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        
+        if (trim(options%qnrvar)/="") then
+            call read_var(bc%next_domain%nrain,  file_list(curfile),   options%qnrvar,  &
+                            bc%geolut, bc%vert_lut, curstep, use_boundary, &
+                            options, time_varying_zlut=newbc%vert_lut)
+        endif
+        ! jh - added qr, qs, qg, ni and nr as optional fields END
 
         ! finally, if we need to read in land surface forcing read in those 2d variables as well.
         if (options%physics%landsurface==kLSM_BASIC) then

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -461,7 +461,8 @@ module data_structures
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var, &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var, &
                                         swdown_var, lwdown_var, &
-                                        sst_var, rain_var, time_var
+                                        sst_var, rain_var, time_var, &
+                                        qnivar, qnrvar    ! jh - added as optional fields
 
         ! Filenames for files to read various physics options from
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, adv_options_filename, &

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -336,14 +336,16 @@ contains
                                         pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
-                                        swdown_var, lwdown_var, sst_var, rain_var, time_var
+                                        swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
+                                        qrvar, qsvar, qgvar, qnivar, qnrvar
 
         namelist /var_list/ pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                             landvar,latvar,lonvar,uvar,ulat,ulon,vvar,vlat,vlon,zvar,zbvar, &
                             hgt_hi,lat_hi,lon_hi,ulat_hi,ulon_hi,vlat_hi,vlon_hi,           &
                             soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                             vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
-                            swdown_var, lwdown_var, sst_var, rain_var, time_var
+                            swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
+                            qrvar, qsvar, qgvar, qnivar, qnrvar
 
         ! no default values supplied for variable names
         hgtvar=""
@@ -362,6 +364,11 @@ contains
         qvvar=""
         qcvar=""
         qivar=""
+        qrvar=""         ! jh - added as optional field
+        qsvar=""         ! jh - added as optional field
+        qgvar=""         ! jh - added as optional field
+        qnivar=""        ! jh - added as optional field
+        qnrvar=""        ! jh - added as optional field
         zvar=""
         zbvar=""
         shvar=""
@@ -419,7 +426,13 @@ contains
         options%qvvar       = qvvar
         options%qcvar       = qcvar
         options%qivar       = qivar
-
+        
+        options%qrvar       = qrvar    ! jh - added as optional field
+        options%qsvar       = qsvar    ! jh - added as optional field
+        options%qgvar       = qgvar    ! jh - added as optional field
+        options%qnivar      = qnivar   ! jh - added as optional field
+        options%qnrvar      = qnrvar   ! jh - added as optional field
+        
         ! vertical coordinate
         options%zvar        = zvar
         options%zbvar       = zbvar


### PR DESCRIPTION
This update adds the capability to specify additional microphysics fields that should be imported from the forcing dataset. Their behaviour is the same as for the already pre-existing optional fields such as cloud ice mixing ratio and cloud water mixing ratio. If specified these fields are also applied at the domain boundaries during the simulation. The new optional fields are:

- qrvar ... rain mixing ratio [kg/kg]
- qsvar ... snow mixing ratio [kg/kg]
- qgvar ... graupel mixing ratio [kg/kg]
- qnivar ... ice number density [1/kg]
- qnrvar ... rain number density [1/kg]

and must be specified in the var_list section of the icar options file.

**Example**
if a WRF simulation is used as forcing dataset and the additional microphysics fields should be used:
qrvar = "QRAIN", ! rain mixing ratio [kg/kg] OPTIONAL
qsvar = "QSNOW", ! snow mixing ratio [kg/kg] OPTIONAL
qgvar = "QGRAU", ! graupel mixing ratio [kg/kg] OPTIONAL
qnivar = "NICE", ! ice number density [1/kg] OPTIONAL
qnrvar = "NRAIN", ! rain number density [1/kg] OPTIONAL

The attached graphic shows the field in the WRF forcing dataset, the field as reproduced by ICAR at timestep zero, and the difference between the two.

![more_mpfields](https://user-images.githubusercontent.com/18684786/66940626-8ff33080-f045-11e9-9cd2-dcd06a7fb01d.png)
