### PR TITLE
Added the option N_from_forcing to the linear theory namelist.

### DIFF
--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -1413,11 +1413,17 @@ contains
         ! the current model state
         call update_dxdt(bc,domain)
 
-        ! we need the internal values of these fields to be in sync with the high res model
-        ! for the linear wind calculations... albeit these are for time t, and winds are for time t+1
-        bc%next_domain%qv=domain%qv
-        bc%next_domain%th=domain%th
-        bc%next_domain%cloud=domain%cloud + domain%ice + domain%qrain + domain%qsnow
+        ! 20190513 jh ... added an option to calculate the Brunt Vaisala frequency from the forcing dataset
+        !                 instead of the current state of the ICAR domain. If that option is set to true then
+        !                 we skip the assignment of domain quantities to bc%next_domain. That way we don't over
+        !                 write the values of the quantities in the forcing already stored there.
+        if (.NOT. options%lt_options%N_from_forcing) then
+            ! we need the internal values of these fields to be in sync with the high res model
+            ! for the linear wind calculations... albeit these are for time t, and winds are for time t+1
+            bc%next_domain%qv=domain%qv
+            bc%next_domain%th=domain%th
+            bc%next_domain%cloud=domain%cloud + domain%ice + domain%qrain + domain%qsnow
+        endif
 
         ! these are required by update_winds for most options
         bc%next_domain%pii = (bc%next_domain%p / 100000.0)** (Rd / cp)

--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -1061,7 +1061,7 @@ contains
         call update_edges(bc%dth_dt,bc%next_domain%th,domain%th)
         call update_edges(bc%dqv_dt,bc%next_domain%qv,domain%qv)
         call update_edges(bc%dqc_dt,bc%next_domain%cloud,domain%cloud)
-        call update_edges(bc%dqi_dt,bc%next_domain%ice,domain%cloud)
+        call update_edges(bc%dqi_dt,bc%next_domain%ice,domain%ice)
     end subroutine update_dxdt
 
     !>------------------------------------------------------------

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -381,6 +381,7 @@ module data_structures
         real    :: min_stability            ! these may need to be a little narrower.
         logical :: variable_N               ! Compute the Brunt Vaisala Frequency (N^2) every time step
         logical :: smooth_nsq               ! Smooth the Calculated N^2 over vert_smooth vertical levels
+        logical :: N_from_forcing           ! If true N is calculated from the forcing data at every forcing timestep instead of using the atmosperic fields of ICAR (standard: False)
         integer :: vert_smooth              ! number of model levels to smooth winds over in the vertical
 
         real    :: N_squared                ! static Brunt Vaisala Frequency (N^2) to use

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -302,7 +302,7 @@ module data_structures
 
         ! dX_dt variables are the change in variable X between two forcing time steps
         ! wind and pressure dX_dt fields applied to full 3d grid, others applied only to boundaries
-        real, allocatable, dimension(:,:,:) :: du_dt,dv_dt,dp_dt,dth_dt,dqv_dt,dqc_dt
+        real, allocatable, dimension(:,:,:) :: du_dt,dv_dt,dp_dt,dth_dt,dqv_dt,dqc_dt,dqi_dt
         ! sh, lh, and pblh fields are only 2d.
         ! These are only used with LSM option 1 and are derived from forcing file
         real, allocatable, dimension(:,:)   :: dsh_dt,dlh_dt,dpblh_dt

--- a/src/main/init.f90
+++ b/src/main/init.f90
@@ -746,6 +746,8 @@ contains
         boundary%dqv_dt = 0
         allocate(boundary%dqc_dt(nz,max(nx,ny),4))
         boundary%dqc_dt = 0
+        allocate(boundary%dqi_dt(nz,max(nx,ny),4))
+        boundary%dqi_dt = 0
         allocate(boundary%dlh_dt(nx,ny))
         boundary%dlh_dt = 0
         allocate(boundary%dsh_dt(nx,ny))

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -833,7 +833,8 @@ contains
         integer :: name_unit
 
         integer :: vert_smooth
-        logical :: variable_N           ! Compute the Brunt Vaisala Frequency (N^2) every time step
+        logical :: variable_N               ! Compute the Brunt Vaisala Frequency (N^2) every time step
+        logical :: N_from_forcing           ! If true N is calculated from the forcing data at every forcing timestep instead of using the atmosperic fields of ICAR (standard: False)
         logical :: smooth_nsq               ! Smooth the Calculated N^2 over vert_smooth vertical levels
         integer :: buffer                   ! number of grid cells to buffer around the domain MUST be >=1
         integer :: stability_window_size    ! window to average nsq over
@@ -865,7 +866,7 @@ contains
         logical :: overwrite_lt_lut
 
         ! define the namelist
-        namelist /lt_parameters/ variable_N, smooth_nsq, buffer, stability_window_size, max_stability, min_stability, &
+        namelist /lt_parameters/ variable_N, N_from_forcing, smooth_nsq, buffer, stability_window_size, max_stability, min_stability, &
                                  linear_contribution, linear_update_fraction, N_squared, vert_smooth, &
                                  remove_lowres_linear, rm_N_squared, rm_linear_contribution, &
                                  spatial_linear_fields, linear_mask, nsq_calibration, minimum_layer_size, &
@@ -882,6 +883,7 @@ contains
 
         ! set default values
         variable_N = .True.
+        N_from_forcing = .False.       ! standard is set to false to preserve original behaviour
         smooth_nsq = .True.
         buffer = 50                    ! number of grid cells to buffer around the domain MUST be >=1
         stability_window_size = 10     ! window to average nsq over
@@ -933,6 +935,7 @@ contains
             opt%max_stability = max_stability
             opt%min_stability = min_stability
             opt%variable_N = variable_N
+            opt%N_from_forcing = N_from_forcing
             opt%smooth_nsq = smooth_nsq
 
             if (vert_smooth<0) then
@@ -976,6 +979,18 @@ contains
             opt%overwrite_lt_lut = overwrite_lt_lut
 
         end associate
+        
+        if (options%debug) then
+                if (options%lt_options%N_from_forcing) then
+                        write(*,*) "DEBUG"
+                        write(*,*) "DEBUG experimental linear theory option activated"
+                        write(*,*) "DEBUG N_from_forcing is set to true. Calculating N from forcing."
+                        if (.NOT. options%lt_options%variable_N) then
+                                write(*,*) "DEBUG however, setting is useless since variable_N is set to false!"
+                        endif
+                        write(*,*) "DEBUG"
+                endif
+        endif
 
     end subroutine lt_parameters_namelist
 

--- a/src/main/time_step.f90
+++ b/src/main/time_step.f90
@@ -128,6 +128,7 @@ contains
             call boundary_update(domain%th, bc%dth_dt * dt)
             call boundary_update(domain%qv, bc%dqv_dt * dt)
             call boundary_update(domain%cloud, bc%dqc_dt * dt)
+            call boundary_update(domain%ice,   bc%dqi_dt * dt)
         endif
 
         ! because density changes with each time step, u/v/w have to be rebalanced as well.

--- a/src/main/time_step.f90
+++ b/src/main/time_step.f90
@@ -259,6 +259,7 @@ contains
         bc%dth_dt = bc%dth_dt / dt
         bc%dqv_dt = bc%dqv_dt / dt
         bc%dqc_dt = bc%dqc_dt / dt
+        bc%dqi_dt = bc%dqi_dt / dt
 
         if (trim(options%rain_var)/="") then
             bc%drain_dt = bc%drain_dt / dt


### PR DESCRIPTION
If set to true ICAR calculates the atmospheric stability within the ICAR domain from the current state of the forcing data set instead of the ICAR domain. This is in agreement with the theoretical basis of ICAR,  linear mountain-wave theory, where atmospheric stability is considered a property of the atmospheric background state and not of the perturbed atmosphere. In case of ICAR, the background state is given by the forcing.

The standard behaviour of ICAR is preserved, to activate this behaviour set `N_from_forcing = .True.` in the `lt_parameters` namelist in the options file of ICAR.