### PR TITLE
Fix/mp fields boundaries

### DIFF
--- a/src/main/boundary.f90
+++ b/src/main/boundary.f90
@@ -1105,9 +1105,13 @@ contains
         bc%dsst_dt  =bc%next_domain%sst-domain%sst
 
         ! these fields are only updated along the edges of the domain
-        call update_edges(bc%dth_dt,bc%next_domain%th,domain%th)
-        call update_edges(bc%dqv_dt,bc%next_domain%qv,domain%qv)
-        call update_edges(bc%dqc_dt,bc%next_domain%cloud,domain%cloud)
+        call update_edges(bc%dth_dt,bc%next_domain%th    ,domain%th)
+        call update_edges(bc%dqv_dt,bc%next_domain%qv    ,domain%qv)
+        call update_edges(bc%dqc_dt,bc%next_domain%cloud ,domain%cloud)
+        call update_edges(bc%dqi_dt,bc%next_domain%ice   ,domain%ice)
+        call update_edges(bc%dqr_dt,bc%next_domain%qrain ,domain%qrain)
+        call update_edges(bc%dqs_dt,bc%next_domain%qsnow ,domain%qsnow)
+        call update_edges(bc%dqg_dt,bc%next_domain%qgrau ,domain%qgrau)
     end subroutine update_dxdt
 
     !>------------------------------------------------------------
@@ -1485,6 +1489,9 @@ contains
             call mean_boundaries(bc%next_domain%qv)
             call mean_boundaries(bc%next_domain%cloud)
             call mean_boundaries(bc%next_domain%ice)
+            call mean_boundaries(bc%next_domain%qrain)
+            call mean_boundaries(bc%next_domain%qsnow)
+            call mean_boundaries(bc%next_domain%qgrau)
         endif
 
 

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -302,7 +302,7 @@ module data_structures
 
         ! dX_dt variables are the change in variable X between two forcing time steps
         ! wind and pressure dX_dt fields applied to full 3d grid, others applied only to boundaries
-        real, allocatable, dimension(:,:,:) :: du_dt,dv_dt,dp_dt,dth_dt,dqv_dt,dqc_dt
+        real, allocatable, dimension(:,:,:) :: du_dt,dv_dt,dp_dt,dth_dt,dqv_dt,dqc_dt,dqi_dt,dqr_dt,dqs_dt,dqg_dt
         ! sh, lh, and pblh fields are only 2d.
         ! These are only used with LSM option 1 and are derived from forcing file
         real, allocatable, dimension(:,:)   :: dsh_dt,dlh_dt,dpblh_dt

--- a/src/main/init.f90
+++ b/src/main/init.f90
@@ -746,6 +746,14 @@ contains
         boundary%dqv_dt = 0
         allocate(boundary%dqc_dt(nz,max(nx,ny),4))
         boundary%dqc_dt = 0
+        allocate(boundary%dqi_dt(nz,max(nx,ny),4))
+        boundary%dqi_dt = 0
+        allocate(boundary%dqr_dt(nz,max(nx,ny),4))
+        boundary%dqr_dt = 0
+        allocate(boundary%dqs_dt(nz,max(nx,ny),4))
+        boundary%dqs_dt = 0
+        allocate(boundary%dqg_dt(nz,max(nx,ny),4))
+        boundary%dqg_dt = 0
         allocate(boundary%dlh_dt(nx,ny))
         boundary%dlh_dt = 0
         allocate(boundary%dsh_dt(nx,ny))

--- a/src/main/time_step.f90
+++ b/src/main/time_step.f90
@@ -123,11 +123,15 @@ contains
         ! v has one more y element than others
         ny = ny + 1
         domain%v(:,:,ny) = domain%v(:,:,ny) + (bc%dv_dt(:,:,ny) * dt)
-        ! dXdt for qv,qc,th are only applied to the boundarys
+        ! dXdt for qv,qc,qi,qr,qs,qg and th are only applied to the boundarys
         if (.not.options%ideal) then
-            call boundary_update(domain%th, bc%dth_dt * dt)
-            call boundary_update(domain%qv, bc%dqv_dt * dt)
+            call boundary_update(domain%th,    bc%dth_dt * dt)
+            call boundary_update(domain%qv,    bc%dqv_dt * dt)
             call boundary_update(domain%cloud, bc%dqc_dt * dt)
+            call boundary_update(domain%ice,   bc%dqi_dt * dt)
+            call boundary_update(domain%qrain, bc%dqr_dt * dt)
+            call boundary_update(domain%qsnow, bc%dqs_dt * dt)
+            call boundary_update(domain%qgrau, bc%dqg_dt * dt)
         endif
 
         ! because density changes with each time step, u/v/w have to be rebalanced as well.


### PR DESCRIPTION
Previously additional microphysics fields that are to be read from the forcing (rain, snow and graupel) were not updated along the boundaries, leaving them at their initial values. this commit should fix this. if mean_fields=True the fields are now also averaged correctly along the boundary.

As discussed here https://github.com/NCAR/icar/pull/61#issuecomment-552944452 I've built a separate fix for this. I will remove the handling of the ice field from the N_from_forcing branch to avoid merging conflicts later down the line.