### PR TITLE
 N can now be read in from a field in the forcing data

### DIFF
--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -463,7 +463,7 @@ module data_structures
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var, &
                                         swdown_var, lwdown_var, &
                                         sst_var, rain_var, time_var, &
-                                        qnivar, qnrvar    ! jh - added as optional fields
+                                        qnivar, qnrvar, nvar    ! jh - added as optional fields
 
         ! Filenames for files to read various physics options from
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, adv_options_filename, &

--- a/src/main/init_options.f90
+++ b/src/main/init_options.f90
@@ -337,7 +337,7 @@ contains
                                         soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                                         vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
                                         swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
-                                        qrvar, qsvar, qgvar, qnivar, qnrvar
+                                        qrvar, qsvar, qgvar, qnivar, qnrvar, nvar
 
         namelist /var_list/ pvar,pbvar,tvar,qvvar,qcvar,qivar,hgtvar,shvar,lhvar,pblhvar,   &
                             landvar,latvar,lonvar,uvar,ulat,ulon,vvar,vlat,vlon,zvar,zbvar, &
@@ -345,7 +345,7 @@ contains
                             soiltype_var, soil_t_var,soil_vwc_var,soil_deept_var,           &
                             vegtype_var,vegfrac_var, linear_mask_var, nsq_calibration_var,  &
                             swdown_var, lwdown_var, sst_var, rain_var, time_var,            &
-                            qrvar, qsvar, qgvar, qnivar, qnrvar
+                            qrvar, qsvar, qgvar, qnivar, qnrvar, nvar
 
         ! no default values supplied for variable names
         hgtvar=""
@@ -369,6 +369,7 @@ contains
         qgvar=""         ! jh - added as optional field
         qnivar=""        ! jh - added as optional field
         qnrvar=""        ! jh - added as optional field
+        nvar=""          ! jh - added as optional field
         zvar=""
         zbvar=""
         shvar=""
@@ -432,6 +433,8 @@ contains
         options%qgvar       = qgvar    ! jh - added as optional field
         options%qnivar      = qnivar   ! jh - added as optional field
         options%qnrvar      = qnrvar   ! jh - added as optional field
+        
+        options%nvar        = nvar     ! jh - added as optional field
         
         ! vertical coordinate
         options%zvar        = zvar

--- a/src/physics/linear_winds.f90
+++ b/src/physics/linear_winds.f90
@@ -933,13 +933,15 @@ contains
     !! then bilinearly interpolate the nearest LUT values for that points linear wind field
     !!
     !!----------------------------------------------------------
-    subroutine spatial_winds(domain,reverse, vsmooth, winsz)
+    subroutine spatial_winds(domain,options,reverse, vsmooth, winsz)
         implicit none
         class(linearizable_type),intent(inout)::domain
+        type(options_type), intent(in) :: options
         logical, intent(in) :: reverse
         integer, intent(in) :: vsmooth
         integer, intent(in) :: winsz
-
+        
+        logical :: externalN ! flag whether N is read from a field in the forcing dataset
         integer :: nx,nxu, ny,nyv, nz, i,j,k, smoothz
         integer :: uk, vi !store a separate value of i for v and of k for u to we can handle nx+1, ny+1
         integer :: step, dpos, npos, spos, nexts, nextd, nextn
@@ -954,6 +956,21 @@ contains
         nz  = size(domain%u,2)
         nxu = size(domain%u,1)
         nyv = size(domain%v,3)
+        
+        ! Here we just set externalN based on two options.
+        ! if NfromForcing is True and nvar is defined then N is to be
+        ! read from the forcing data set instead of being calculated by ICAR,
+        ! meaning that externalN = True. If not both conditions are satisfied,
+        ! externalN is False.
+        if (trim(options%nvar)/="") then
+            if (options%lt_options%N_from_forcing) then
+                externalN = .True.
+            else
+                externalN = .False.
+            endif
+        else
+            externalN = .False.
+        endif
 
         if (reverse) then
             u_LUT=>rev_u_LUT
@@ -968,63 +985,70 @@ contains
         endif
 
         if (reverse) print*, "WARNING using fixed nsq for linear wind removal: 3e-6"
-        ! $omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
-        ! $omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
-        ! $omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
-        ! $omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
-        ! $omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
-        ! $omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
-        ! $omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
-        !
-        ! $omp do
-        do k=1,ny
-            do j=1,nz
-                do i=1,nx
-
-                    ! look up vsmooth gridcells up to nz at the maximum
-                    top = min(j+vsmooth, nz)
-                    ! if (top-j)/=vsmooth, then look down enough layers to make the window vsmooth in size
-                    bottom = max(1, j - (vsmooth - (top-j)))
-
-                    if (.not.reverse) then
-                        domain%nsquared(i,j,k) = calc_stability(domain%th(i,bottom,k), domain%th(i,top,k),  &
-                                                                domain%pii(i,bottom,k),domain%pii(i,top,k), &
-                                                                domain%z(i,bottom,k),  domain%z(i,top,k),   &
-                                                                domain%qv(i,bottom,k), domain%qv(i,top,k),  &
-                                                                domain%cloud(i,j,k)+domain%ice(i,j,k)       &
-                                                                +domain%qrain(i,j,k)+domain%qsnow(i,j,k))
-
-                        domain%nsquared(i,j,k) = max(min_stability, min(max_stability, &
-                                                domain%nsquared(i,j,k) * nsq_calibration(i,k)))
-                    else
-                        ! Low-res boundary condition variables will be in a different array format.  It should be
-                        ! easy enough to call calc_stability after e.g. transposing z and y dimension, but some
-                        ! e.g. pii will not be set in the forcing data, so this may need a little thought.
-                        domain%nsquared(i,j,k) = 3e-6
+        ! we only need to go through the calculations if N is variable
+        if (options%lt_options%variable_N) then
+            if (.NOT. externalN) then
+                ! $omp parallel firstprivate(nx,nxu,ny,nyv,nz, reverse, vsmooth, winsz, using_blocked_flow), default(none), &
+                ! $omp private(i,j,k,step, uk, vi, east, west, north, south, top, bottom, u1d, v1d), &
+                ! $omp private(spos, dpos, npos, nexts,nextd, nextn,n, smoothz, u, v, blocked), &
+                ! $omp private(wind_first, wind_second, curspd, curdir, curnsq, sweight,dweight, nweight), &
+                ! $omp shared(domain, spd_values, dir_values, nsq_values, u_LUT, v_LUT, linear_mask), &
+                ! $omp shared(u_perturbation, v_perturbation, linear_update_fraction, linear_contribution, nsq_calibration), &
+                ! $omp shared(min_stability, max_stability, n_dir_values, n_spd_values, n_nsq_values, smooth_nsq)
+                !
+                ! $omp do
+                do k=1,ny
+                    do j=1,nz
+                        do i=1,nx
+        
+                            ! look up vsmooth gridcells up to nz at the maximum
+                            top = min(j+vsmooth, nz)
+                            ! if (top-j)/=vsmooth, then look down enough layers to make the window vsmooth in size
+                            bottom = max(1, j - (vsmooth - (top-j)))
+        
+                            if (.not.reverse) then
+                                    domain%nsquared(i,j,k) = calc_stability(domain%th(i,bottom,k), domain%th(i,top,k),  &
+                                                                            domain%pii(i,bottom,k),domain%pii(i,top,k), &
+                                                                            domain%z(i,bottom,k),  domain%z(i,top,k),   &
+                                                                            domain%qv(i,bottom,k), domain%qv(i,top,k),  &
+                                                                            domain%cloud(i,j,k)+domain%ice(i,j,k)       &
+                                                                            +domain%qrain(i,j,k)+domain%qsnow(i,j,k))
+            
+                                    domain%nsquared(i,j,k) = max(min_stability, min(max_stability, &
+                                                            domain%nsquared(i,j,k) * nsq_calibration(i,k)))
+                            else
+                                ! Low-res boundary condition variables will be in a different array format.  It should be
+                                ! easy enough to call calc_stability after e.g. transposing z and y dimension, but some
+                                ! e.g. pii will not be set in the forcing data, so this may need a little thought.
+                                domain%nsquared(i,j,k) = 3e-6
+                            endif
+                        end do
+                        ! look up table is computed in log space
+                        domain%nsquared(:,j,k) = log(domain%nsquared(:,j,k))
+                    end do
+        
+                    if (smooth_nsq) then
+                        do j=1,nz
+                            ! compute window as above.
+                            top = min(j+vsmooth,nz)
+                            bottom = max(1, j - (vsmooth - (top-j)) )
+        
+                            do smoothz = bottom, j-1
+                                domain%nsquared(:,j,k) = domain%nsquared(:,j,k) + domain%nsquared(:,smoothz,k)
+                            end do
+                            do smoothz = j+1, top
+                                domain%nsquared(:,j,k) = domain%nsquared(:,j,k) + domain%nsquared(:,smoothz,k)
+                            end do
+                            domain%nsquared(:,j,k) = domain%nsquared(:,j,k)/(top-bottom+1)
+                        end do
                     endif
                 end do
-                ! look up table is computed in log space
-                domain%nsquared(:,j,k) = log(domain%nsquared(:,j,k))
-            end do
-
-            if (smooth_nsq) then
-                do j=1,nz
-                    ! compute window as above.
-                    top = min(j+vsmooth,nz)
-                    bottom = max(1, j - (vsmooth - (top-j)) )
-
-                    do smoothz = bottom, j-1
-                        domain%nsquared(:,j,k) = domain%nsquared(:,j,k) + domain%nsquared(:,smoothz,k)
-                    end do
-                    do smoothz = j+1, top
-                        domain%nsquared(:,j,k) = domain%nsquared(:,j,k) + domain%nsquared(:,smoothz,k)
-                    end do
-                    domain%nsquared(:,j,k) = domain%nsquared(:,j,k)/(top-bottom+1)
-                end do
+                ! $omp end do
+                ! $omp end parallel
             endif
-        end do
-        ! $omp end do
-        ! $omp end parallel
+        else
+                domain%nsquared = options%lt_options%N_squared
+        endif
 
         ! smooth array has it's own parallelization, so this probably can't go in a critical section
         if (smooth_nsq) then
@@ -1402,7 +1426,7 @@ contains
         ! if we are reverseing the effects, that means we are in the low-res domain
         ! that domain does not have a spatial LUT calculated, so it can not be performed
         if (use_spatial_linear_fields)then
-            call spatial_winds(domain,rev, vsmooth, stability_window_size)
+            call spatial_winds(domain, options, rev, vsmooth, stability_window_size)
         else
             ! Nsq = squared Brunt Vaisalla frequency (1/s) typically from dry static stability
             stability = calc_domain_stability(domain)


### PR DESCRIPTION
The Brunt-Vaisala frequency N can now be read from a field in theforcing dataset. To do so N_from_forcing in the linear theory options must be set to true and the name of the field that contains the squared Brunt Vaisala frequency must be set in the ICAR options with the option nvar.

**Note:** the field in the forcing dataset must store N^2.

The following plot show the resulting difference in the Brunt-Väisälä frequency field due to different calculation methods:

- The uppermost panel plots log(N^2) used by ICAR for the case where ICAR calculates it from the state of the atmosphere in the ICAR domain - this is the default behavior so far.
- The middle panel plots log(N^2) used by ICAR for the case where it is read from a field in the forcing dataset. This is the result if the options added with these pull-request are activated.
- The lower panel shows log(N^2) as stored in a field of the forcing dataset. It is extracted from the grid points closest to the ICAR cross sections shown in the other two panels above.

![image](https://user-images.githubusercontent.com/18684786/72978087-0c7c7480-3dd6-11ea-9e08-4d896be8f515.png)

The center and bottom panel show, as expected, a very close agreement. The remaining differences are explicable due to the horizontal grid points in the forcing and the ICAR simulation not overlapping exactly.