### PR TITLE
tweaked interpolation error testing for float precision

### DIFF
--- a/src/utilities/geo_reader.f90
+++ b/src/utilities/geo_reader.f90
@@ -145,7 +145,7 @@ contains
 
         w3 = 1 - w1 - w2
 
-        if (minval([w1,w2,w3]) < -1e-3) then
+        if (minval([w1,w2,w3]) < -1e-2) then
             write(*,*) "ERROR: Point not located in bounding triangle"
             write(*,*) xi, yi
             write(*,*) "Triangle vertices"
@@ -157,7 +157,7 @@ contains
         endif
         w1=max(0.,w1); w2=max(0.,w2); w3=max(0.,w3);
 
-        if (abs((w1+w2+w3)-1)>1e-3) then
+        if (abs((w1+w2+w3)-1)>1e-2) then
             write(*,*) "Error, w1+w2+w3 != 1"
             write(*,*) w1,w2,w3
             write(*,*) "Point"


### PR DESCRIPTION
Increased the maximum acceptable error in triangulation weights to 0.01.  This is particularly useful for very high resolution grids (<<1km) because that pushes what a float can reliably reproduce when a lat lon values may be O(100).  As a result, the method that finds the bounding points and the method that computes the weights end up with very slightly different values (because they are doing different things), and one of the weights can be <-1e-3 (the previous criteria).  It now accepts such negative weights, sets them to 0, and renormalizes the remaining weights. 