### PR TITLE
Small changes to Makefile for portability.

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -27,8 +27,7 @@
 # Variables that need to be set by the user:
 #
 # INSTALLDIR : default = ~/bin/
-# LIBFFT	 : location of fftw libraries		default = /usr/local/lib
-# INCFFT	 : location of fftw headers			default = /usr/local/include
+# FFTW       : location of fftw installation    default = $home/usr/local
 # LIBNETCDF	 : location of netdcdf libraries	default = compiler/machine dependant /usr/local/lib
 # INCNETCDF	 : location of netcdf headers		default = compiler/machine dependant /usr/local/include
 #
@@ -306,7 +305,7 @@ ifeq ($(COMPILER), intel)
 		CAF_FLAG=-coarray=single
 	else
 		CAF_FLAG=-coarray=distributed
-		LINKER=mpif90
+		LINKER=mpiifort
 	endif
 endif
 


### PR DESCRIPTION
This PR contains two small modifications.
*) The documentation in the Makefile suggests setting the environmental variables LIBFFT and INCFFT. These variables are created further on in the Makefile using the variable FFTW. If FFTW is not set, then FFTW_PATH defaults to /usr/local/.
*) Change mpi fortran compiler from mpif90 to mpiifort. mpif90 is a compiler wrapper to mpiifort on Cheyenne, but this is a special case. This is confusing as mpif90 is the default name for the gfortran mpi compiler. Change to mpiifort, which still works on Cheynne and is portable.