### PR TITLE
Fixing potential restart issue, moving towards v2 release, minor bug fix

### DIFF
--- a/helpers/aggregate_parallel_files.py
+++ b/helpers/aggregate_parallel_files.py
@@ -76,7 +76,7 @@ def set_up_dataset(d):
             data = np.zeros((nt, nz, ny + y_off, nx + x_off))
 
         # print(name, data.shape, dims, attrs)
-        data_vars[v] = xr.DataArray(data, dims=dims, name=name, attrs=attrs)#, coords=coords)
+        data_vars[v] = xr.DataArray(data.astype(np.float32), dims=dims, name=name, attrs=attrs)#, coords=coords)
 
     ds = xr.Dataset(data_vars, attrs=d.attrs)
     ds.encoding = d.encoding

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -2,7 +2,7 @@
 !   Model and run meta-data
 !---------------------------------------------------------
 &model_version
-    version = "2.0a3",                    ! This must match the version of the compiled code
+    version = "2.0",                      ! This must match the version of the compiled code
     comment = "Add your comment here"     ! This will be stored in output files
 /
 
@@ -11,12 +11,10 @@
 !---------------------------------------------------------
 &z_info
     ! use dz_levels as a guide but allow dz to vary in space so that z is constant in space at flat_z_height
+    ! note spatially varying dz does not work well with linear_theory, use with wind=2 more options coming soon
     ! space_varying = .False.
     ! height at which the z coordinate value should be constant in space (if space_varying=True), if < 0 make the model top flat (computed as sum(dz_levels) + mean(terrain))
     ! flat_z_height = -1
-
-    ! compensate for varying dz in advection, effectively speeding up air through smaller dz windows.
-    ! fixed_dz_advection = .False.
 
     !   Sample model level thickness [m]  Bottom levels could be thicker.
     !   NB: if using gfortran put all on one line
@@ -114,10 +112,6 @@
     !   The length of an input forcing time step
     inputinterval = 3600,   ! [s]
 
-    !   Limit output data to near surface variables
-    !   WARNING if true it is impossible to restart the run (for now)
-    ! surface_io_only = False,
-
     !   The grid spacing of the high-resolution data
     dx = 4000.0,        ! [m]
 
@@ -135,7 +129,7 @@
     !   this is now optional, if not supplied, ICAR will determine it from the number of levels specified
     !   if it is supplied it must be less than or equal to the number of levels specified below
     !   but it can be used to subset the number of levels used.
-    !   WARNING : ICAR can be surprisingly sensitive to this parameter
+    !   WARNING : ICAR can be surprisingly sensitive to this parameter see Horak et al 2019 and 2020
     nz = 15, ! []
 
     !   Set this to true of the zvar in the input data is actually in units of geopotential height (m/s^2)
@@ -192,12 +186,8 @@
     !   Use density in the advection step (violates linear theory assumptions)
     advect_density = false,
 
-    !   The number of grid cells to remove from all sides of the high-resolution grid
-    !   used primarily for faster test runs over a smaller domain
-    ! buffer = 0,   ! [n-gridcells]
-
-    !   Doesn't do much at the moment, increases output print at runtime
-    debug = true,
+    !   Increases output print at runtime and tests domain wide values for realistic values throughout the simulation.
+    debug = false,
     warning_level = 4, ! 0-10 increases the level of errors it warns about and quits over (slightly)
 
     ! controls printing of % completed for longer processes.  Nice if it is running in a console, not nice in a log file.
@@ -241,7 +231,7 @@
     sst_var = "TSK"         ! Water surface temperature [K]          OPTIONAL (used with water=2)
 
     ! WARNING, if U and V are "grid relative" (e.g. output from WRF) and on a skewed grid, this will cause problems
-    ! run the helpers/wrf2icar.sh script first to rotate the wind field to be east-west, north-south relative
+    ! run the helpers/wrf2icar.sh script first to rotate the wind field to be east-west, north-south relative or supply sinalpha cosalpha... this may be broken
     ! variables on the ew staggered (U) grid
     uvar    = "U",          ! East-West wind speed      [m/s]
 
@@ -272,8 +262,8 @@
     hgt_hi  = "HGT_M"       ! surface elevation             [m]
 
     ! used to rotate E-W/N-S wind fields into the ICAR high-res domain
-    sinalpha_var="SINALPHA"
-    cosalpha_var="COSALPHA"
+    ! sinalpha_var="SINALPHA"
+    ! cosalpha_var="COSALPHA"
 
 
     ! to use the Noah LSM the following fields should also be specified on the high-res grid

--- a/run/short_icar_options.nml
+++ b/run/short_icar_options.nml
@@ -2,7 +2,7 @@
 !   Model and run meta-data
 !---------------------------------------------------------
 &model_version
-    version = "2.0a3",                    ! This must match the version of the compiled code
+    version = "2.0",                      ! This must match the version of the compiled code
     comment = "Add your comment here"     ! This will be stored in output files
 /
 
@@ -114,9 +114,6 @@
     !   Use height above ground level to interpolate the wind field instead of height above sea level.
     use_agl_height = False,
 
-    !   If the forcing data come from WRF, the temperature data probably have an offset applied
-    !   t_offset will be added to the forcing temperature data.  Defaults to 0
-    t_offset = 300, ! [K]
 
     !   Distance to smooth winds over [m] ~100000 is reasonable
     !   larger values result in less large scale convergence/divergence in the flow field
@@ -179,12 +176,10 @@
 !---------------------------------------------------------
 &z_info
     ! use dz_levels as a guide but allow dz to vary in space so that z is constant in space at flat_z_height
+    ! note spatially varying dz does not work well with linear_theory, use with wind=2 more options coming soon
     ! space_varying = .False.
     ! height at which the z coordinate value should be constant in space (if space_varying=True), if < 0 make the model top flat (computed as sum(dz_levels) + mean(terrain))
     ! flat_z_height = -1
-
-    ! compensate for varying dz in advection, effectively speeding up air through smaller dz windows.
-    ! fixed_dz_advection = .False.
 
     !   Sample model level thickness [m]  Bottom levels could be thicker.
     dz_levels = 50.,   75.,  125.,  200.,  300.,  400.,  500.,  500.,  500.,  500.,   500.,  500.,  500.,  500.,  500.,  500.,  500.,  500.,  500.,  500.,    ! 1-20

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -6,7 +6,7 @@ module icar_constants
 
     implicit none
 
-    character(len=5) :: kVERSION_STRING = "2.0a3"
+    character(len=5) :: kVERSION_STRING = "2.0"
 
     ! string lengths
     integer, parameter :: kMAX_FILE_LENGTH = 1024

--- a/src/io/restart.f90
+++ b/src/io/restart.f90
@@ -18,8 +18,8 @@ module subroutine restart_model(domain, dataset, options)
     character(len=kMAX_FILE_LENGTH) :: restart_file
 
     ! options%parameters%restart_file,
-    restart_file = get_image_filename(this_image(), options%output_options%output_file, options%parameters%restart_time)
-
+    ! restart_file = get_image_filename(this_image(), options%output_options%restart_file, options%parameters%restart_time)
+    restart_file = options%parameters%restart_file
     call read_restart_data(domain, dataset, restart_file, options%parameters%restart_step_in_file)
 
 

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -393,6 +393,31 @@ contains
 
     end subroutine options_check
 
+
+    !> ------------------
+    !!  Determine the filename to be used for this particular image/process based on the restart filename, restart time, and image number
+    !!
+    !!  Uses the same calculation that is used to get the output filename when writing.
+    !! -------------------
+    function get_image_filename(image_number, initial_filename, restart_time) result(file_name)
+        implicit none
+        integer,            intent(in) :: image_number
+        character(len=*),   intent(in) :: initial_filename
+        type(Time_type),    intent(in) :: restart_time
+
+        character(len=kMAX_FILE_LENGTH) :: file_name
+        integer :: n, i
+
+        character(len=49)   :: file_date_format = '(I4,"-",I0.2,"-",I0.2,"_",I0.2,"-",I0.2,"-",I0.2)'
+
+        write(file_name, '(A,I6.6,"_",A,".nc")') trim(initial_filename), image_number, trim(restart_time%as_string(file_date_format))
+
+        n = len(trim(file_name))
+        file_name(n-10:n-9) = "00"
+
+    end function get_image_filename
+
+
     !> -------------------------------
     !! Initialize the restart options
     !!
@@ -433,6 +458,7 @@ contains
                               restart_date(4), restart_date(5), restart_date(6))
 
         ! find the time step that most closely matches the requested restart time (<=)
+        restart_file = get_image_filename(this_image(), restart_file, restart_time)
         restart_step = find_timestep_in_file(restart_file, 'time', restart_time, time_at_step)
 
         ! check to see if we actually udpated the restart date and print if in a more verbose mode

--- a/src/physics/mp_thompson_aer.f90
+++ b/src/physics/mp_thompson_aer.f90
@@ -1899,8 +1899,16 @@
          if (temp(k).ge.270.65) k_0 = MAX(k_0, k)
       enddo
       do k = kte, kts, -1
-         if (k.gt.k_0 .and. L_qr(k) .and. mvd_r(k).gt.100.E-6) then
-            xslw1 = 4.01 + alog10(mvd_r(k))
+         if (k.gt.k_0) then
+             if (L_qr(k)) then
+                 if (mvd_r(k).gt.100.E-6) then
+                    xslw1 = 4.01 + alog10(mvd_r(k))
+                else
+                   xslw1 = 0.01
+                endif
+            else
+               xslw1 = 0.01
+            endif
          else
             xslw1 = 0.01
          endif


### PR DESCRIPTION
changed version number to 2.0 as this is feature complete, think of it as 2.0rc1 I suppose

Fixed minor bug in microphysics where in nested ands in an if statement can be tested out of order in newer compilers, and in at least one case this can cause a crash.  

Update restart code to use the restart filename specified in the restart namelist.  Note that the date units can change for a new run, and as a result, output files that are present but will be re-written need to be removed before restarting. 