### PR TITLE
added calendar attribute to output files

### DIFF
--- a/helpers/erai/convert.py
+++ b/helpers/erai/convert.py
@@ -51,6 +51,7 @@ def convert_sfc(data):
     output_data.tskin           = data.tskin[np.newaxis,::-1,:]             # K
     output_data.sw              = data.sw[np.newaxis,::-1,:] / dt   # convert from Joules to W /m^2
     output_data.lw              = data.lw[np.newaxis,::-1,:] / dt   # convert from Joules to W /m^2
+    output_data.cp              = data.cp[np.newaxis,::-1,:] * 1000 # convert m to mm
 
     # this is now handled in io so it can just use the last value in the file, much simple
     #  ... though in some ways what is below is better as it integrates over a longer time period

--- a/helpers/erai/io_routines.py
+++ b/helpers/erai/io_routines.py
@@ -4,8 +4,8 @@ import mygis
 from bunch import Bunch
 
 
-sfcvarlist=["SSHF_GDS4_SFC","SLHF_GDS4_SFC","Z_GDS4_SFC","BLH_GDS4_SFC","SSRD_GDS4_SFC","STRD_GDS4_SFC", "SKT_GDS4_SFC"]
-icar_sfc_var=["sensible_heat","latent_heat","hgt_98","PBL_height","sw","lw", "tskin"]
+sfcvarlist=["SSHF_GDS4_SFC","SLHF_GDS4_SFC","Z_GDS4_SFC","BLH_GDS4_SFC","SSRD_GDS4_SFC","STRD_GDS4_SFC", "SKT_GDS4_SFC", "CP_GDS4_SFC"]
+icar_sfc_var=["sensible_heat","latent_heat","hgt_98","PBL_height","sw","lw", "tskin", "cp"]
 
 atmvarlist=["Z_GDS4_HYBL","T_GDS4_HYBL","Q_GDS4_HYBL","LNSP_GDS4_HYBL","CLWC_GDS4_HYBL","CIWC_GDS4_HYBL","lv_HYBL2_a","lv_HYBL2_b","P0"]
 icar_atm_var=["gph","t","qv","ln_p_sfc","cloud","ice","sigma_a","sigma_b","P0"]
@@ -79,6 +79,9 @@ def load_sfc(time,info):
                 input_data[offset,...]/2.0
             elif offset>=1:
                 input_data[offset,...]-=input_data[offset-1,...]
+
+        if (s=="cp"):
+            input_data[1:,:,:]-=input_data[:-1,:,:]
 
         outputdata[s]=input_data[int(offset),:,:]
         nc_data.ncfile.close()

--- a/helpers/erai/output.py
+++ b/helpers/erai/output.py
@@ -66,6 +66,9 @@ def write_file(date,info,erai):
     atts=Bunch(long_name="Skin Temperature",units="K")
     extra_vars.append(Bunch(name="tskin",data=erai["tskin"],dims=dims2dt,dtype="f",attributes=atts))
 
+    atts=Bunch(long_name="Convective precipitation",units="mm")
+    extra_vars.append(Bunch(name="cp",data=erai["cp"],dims=dims2dt,dtype="f",attributes=atts))
+
     atts=Bunch(long_name="latitude",units="degrees_north")
     extra_vars.append(Bunch(name="lat",data=info.lat_data[:,0],dims=("lat",),dtype="f",attributes=atts))
 

--- a/src/io/output_h.f90
+++ b/src/io/output_h.f90
@@ -18,7 +18,7 @@ module output_interface
   use variable_interface, only : variable_t
   use domain_interface,   only : domain_t
   use meta_data_interface,only : meta_data_t
-  use time_object,        only : Time_type
+  use time_object,        only : Time_type, THREESIXTY, GREGORIAN, NOCALENDAR, NOLEAP
 
   implicit none
 

--- a/src/io/output_obj.f90
+++ b/src/io/output_obj.f90
@@ -210,11 +210,24 @@ contains
         class(output_t), intent(inout) :: this
         type(Time_type), intent(in)    :: time
         integer :: err
+        character(len=kMAX_NAME_LENGTH) :: calendar
 
         associate(var => this%time)
         var%name = "time"
         var%dimensions = [ "time" ]
         var%n_dimensions = 1
+
+        select case (time%calendar)
+            case(GREGORIAN)
+                calendar = "proleptic_gregorian"
+            case(NOLEAP)
+                calendar = "noleap"
+            case(THREESIXTY)
+                calendar = "360-day"
+            case default
+                calendar = "standard"
+        end select
+
 
         err = nf90_inq_varid(this%ncfile_id, var%name, var%var_id)
 
@@ -235,6 +248,7 @@ contains
 
             call check( nf90_def_var(this%ncfile_id, var%name, NF90_DOUBLE, var%dim_ids(1), var%var_id), "Defining time" )
             call check( nf90_put_att(this%ncfile_id, var%var_id,"standard_name","time"))
+            call check( nf90_put_att(this%ncfile_id, var%var_id,"calendar",trim(calendar)))
             call check( nf90_put_att(this%ncfile_id, var%var_id,"units",time%units()))
             call check( nf90_put_att(this%ncfile_id, var%var_id,"UTCoffset","0"))
 


### PR DESCRIPTION
Update the output_obj.f90 object to write a "calendar" attribute to the netcdf time variable to store the calendar being used. 

TYPE: 
bugfix

KEYWORDS: 
time, climate model, calendar

SOURCE: 
Ethan Gutmann, NCAR

DESCRIPTION OF CHANGES: 
Modified time objects setup_time_variable routine to test for the value of the time objects calendar attribute.  Use that attribute to set a calendar attribute in the resulting netcdf time variable. 

ISSUE: 
Previously calendar would not be specified, when using GCMs with a noleap or 360-day calendar, this would result in incorrect date stamps (as they would by default be interpreted in a gregorian calendar). 

### Checklist
 - [X] Backwards compatible
 - [X] CI action completes
 - [X] testing confirms that the update works (calendar attribute is now saved in output files)
