### PR TITLE
Updates to RRTMG code to improve/implement cloud feedbacks

### DIFF
--- a/src/objects/opt_types.f90
+++ b/src/objects/opt_types.f90
@@ -141,6 +141,15 @@ module options_types
     end type lsm_options_type
 
     ! ------------------------------------------------
+    ! store Radiation options
+    ! ------------------------------------------------
+    type rad_options_type
+       integer :: update_interval_rrtmg                ! how ofen to update the radiation in seconds.
+                                                       ! RRTMG scheme is expensive. Default is 1800s (30 minutes)
+       integer :: icloud                               ! How RRTMG interact with clouds
+    end type rad_options_type
+
+    ! ------------------------------------------------
     ! store output file related options
     ! ------------------------------------------------
     type output_options_type
@@ -194,7 +203,7 @@ module options_types
         ! Filenames for files to read various physics options from
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, adv_options_filename, &
                                         lsm_options_filename, bias_options_filename, block_options_filename, &
-                                        cu_options_filename
+                                        cu_options_filename, rad_options_filename
         character(len=MAXFILELENGTH) :: calendar
 
 
@@ -281,6 +290,9 @@ module options_types
 
         real    :: agl_cap              ! height up to which AGL height is used for vertical interpolation
 
+        integer :: update_interval_rrtmg !How often to update the RRTMG scheme
+        integer :: icloud               ! How to treat clouds in RRTMG scheme
+
         ! physics parameterization options
         logical :: use_mp_options
         logical :: use_cu_options
@@ -288,6 +300,7 @@ module options_types
         logical :: use_block_options
         logical :: use_adv_options
         logical :: use_lsm_options
+        logical :: use_rad_options
         logical :: use_bias_correction
 
         integer :: warning_level        ! level of warnings to issue when checking options settings 0-10.

--- a/src/objects/opt_types.f90
+++ b/src/objects/opt_types.f90
@@ -290,8 +290,6 @@ module options_types
 
         real    :: agl_cap              ! height up to which AGL height is used for vertical interpolation
 
-        integer :: update_interval_rrtmg !How often to update the RRTMG scheme
-        integer :: icloud               ! How to treat clouds in RRTMG scheme
 
         ! physics parameterization options
         logical :: use_mp_options

--- a/src/objects/options_h.f90
+++ b/src/objects/options_h.f90
@@ -3,7 +3,7 @@ module options_interface
     use icar_constants,             only : kMAX_STRING_LENGTH, kMAX_STORAGE_VARS
     use options_types,              only : parameter_options_type, physics_type, mp_options_type, lt_options_type,      &
                                            block_options_type, adv_options_type, lsm_options_type, bias_options_type,   &
-                                           cu_options_type, output_options_type
+                                           cu_options_type, output_options_type, rad_options_type
 
     implicit none
 
@@ -45,6 +45,7 @@ module options_interface
 
         type(bias_options_type)         :: bias_options
 
+        type(rad_options_type)          :: rad_options
     contains
 
         procedure, public  :: init

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -64,6 +64,7 @@ contains
         call lsm_parameters_namelist(   this%parameters%lsm_options_filename,   this)
         call cu_parameters_namelist(    this%parameters%cu_options_filename,    this)
         call bias_parameters_namelist(  this%parameters%bias_options_filename,  this)
+        call rad_parameters_namelist(   this%parameters%rad_options_filename,   this)
 
         if (this%parameters%restart) then
             ! if (this_image()==1) write(*,*) "  (opt) Restart = ", this%parameters%restart
@@ -532,6 +533,7 @@ contains
         rad = 0 ! 0 = no RAD,
                 ! 1 = Surface fluxes from GCM, (radiative cooling ~1K/day in LSM=1 module),
                 ! 2 = cloud fraction based radiation + radiative cooling
+                ! 3 = RRTMG
 
         conv= 0 ! 0 = no CONV,
                 ! 1 = Tiedke scheme
@@ -913,19 +915,20 @@ contains
         integer :: ntimesteps, wind_iterations
         integer :: longitude_system
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
+        integer :: update_interval_rrtmg, icloud
         logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, qv_is_spec_humidity, &
                    qv_is_relative_humidity, &
                    use_mp_options, use_lt_options, use_adv_options, use_lsm_options, use_bias_correction, &
-                   use_block_options, use_cu_options
+                   use_block_options, use_cu_options, use_rad_options
 
         character(len=MAXFILELENGTH) :: date, calendar, start_date, forcing_start_date, end_date
         integer :: year, month, day, hour, minute, second
         character(len=MAXFILELENGTH) :: mp_options_filename, lt_options_filename, &
                                         adv_options_filename, lsm_options_filename, &
                                         bias_options_filename, block_options_filename, &
-                                        cu_options_filename
+                                        cu_options_filename, rad_options_filename
 
 
         namelist /parameters/ ntimesteps, wind_iterations, outputinterval, frames_per_outfile, inputinterval, surface_io_only,                &
@@ -944,7 +947,9 @@ contains
                               lsm_options_filename,     use_lsm_options,    &
                               adv_options_filename,     use_adv_options,    &
                               bias_options_filename,    use_bias_correction,&
-                              cu_options_filename,      use_cu_options
+                              cu_options_filename,      use_cu_options,     &
+                              rad_options_filename,     use_rad_options,    &
+                              update_interval_rrtmg,    icloud
 
 !       default parameters
         surface_io_only     = .False.
@@ -987,6 +992,8 @@ contains
         outputinterval      =  3600
         frames_per_outfile  =  24
         longitude_system    = kMAINTAIN_LON
+        update_interval_rrtmg = 1800
+        icloud             =  3
 
         ! flag set to read specific parameterization options
         use_mp_options=.False.
@@ -1003,6 +1010,9 @@ contains
 
         use_lsm_options=.False.
         lsm_options_filename = filename
+
+        use_rad_options=.False.
+        rad_options_filename = filename
 
         use_bias_correction=.False.
         bias_options_filename = filename
@@ -1127,6 +1137,8 @@ contains
         options%cfl_reduction_factor = cfl_reduction_factor
         options%cfl_strictness = cfl_strictness
 
+        options%update_interval_rrtmg = update_interval_rrtmg
+        options%icloud                = icloud
 
         options%use_mp_options      = use_mp_options
         options%mp_options_filename = mp_options_filename
@@ -1142,6 +1154,9 @@ contains
 
         options%use_lsm_options     = use_lsm_options
         options%lsm_options_filename= lsm_options_filename
+
+        options%use_rad_options     = use_rad_options
+        options%rad_options_filename= rad_options_filename
 
         options%use_bias_correction  = use_bias_correction
         options%bias_options_filename= bias_options_filename
@@ -1747,6 +1762,56 @@ contains
         ! copy the data back into the global options data structure
         options%lsm_options = lsm_options
     end subroutine lsm_parameters_namelist
+
+
+    !> -------------------------------
+    !! Initialize the radiation model options
+    !!
+    !! Reads the rad_parameters namelist or sets default values
+    !! Perhaps not use this subroutine, since icloud and update_interval_rrtmg is set in icar_options
+    !! -------------------------------
+    subroutine rad_parameters_namelist(filename, options)
+        implicit none
+        character(len=*),   intent(in)   :: filename
+        type(options_t),    intent(inout)::options
+
+        type(rad_options_type) :: rad_options
+        integer :: name_unit
+
+        integer :: update_interval_rrtmg             ! minimum number of seconds between RRTMG updates
+        integer :: icloud                            ! how RRTMG interacts with clouds
+
+        ! define the namelist
+        namelist /rad_parameters/ update_interval_rrtmg, icloud
+
+
+         ! because adv_options could be in a separate file
+         if (options%parameters%use_rad_options) then
+             if (trim(filename)/=trim(get_options_file())) then
+                 call version_check(filename,options%parameters)
+             endif
+         endif
+
+
+        ! set default values
+        update_interval_rrtmg = 1800 ! 30 minutes
+        icloud          = 3    ! effective radius from microphysics scheme
+
+        ! read the namelist options
+        if (options%parameters%use_rad_options) then
+            open(io_newunit(name_unit), file=filename)
+            read(name_unit,nml=rad_parameters)
+            close(name_unit)
+        endif
+
+        ! store everything in the radiation_options structure
+        rad_options%update_interval_rrtmg = update_interval_rrtmg
+        rad_options%icloud                = icloud
+
+        ! copy the data back into the global options data structure
+        options%rad_options = rad_options
+    end subroutine rad_parameters_namelist
+
 
 
     !> -------------------------------

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -915,7 +915,6 @@ contains
         integer :: ntimesteps, wind_iterations
         integer :: longitude_system
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
-        integer :: update_interval_rrtmg, icloud
         logical :: ideal, readz, readdz, interactive, debug, external_winds, surface_io_only, &
                    mean_winds, mean_fields, restart, advect_density, z_is_geopotential, z_is_on_interface,&
                    high_res_soil_state, use_agl_height, time_varying_z, t_is_potential, qv_is_spec_humidity, &
@@ -948,8 +947,7 @@ contains
                               adv_options_filename,     use_adv_options,    &
                               bias_options_filename,    use_bias_correction,&
                               cu_options_filename,      use_cu_options,     &
-                              rad_options_filename,     use_rad_options,    &
-                              update_interval_rrtmg,    icloud
+                              rad_options_filename,     use_rad_options
 
 !       default parameters
         surface_io_only     = .False.
@@ -992,8 +990,6 @@ contains
         outputinterval      =  3600
         frames_per_outfile  =  24
         longitude_system    = kMAINTAIN_LON
-        update_interval_rrtmg = 1800
-        icloud             =  3
 
         ! flag set to read specific parameterization options
         use_mp_options=.False.
@@ -1136,9 +1132,6 @@ contains
 
         options%cfl_reduction_factor = cfl_reduction_factor
         options%cfl_strictness = cfl_strictness
-
-        options%update_interval_rrtmg = update_interval_rrtmg
-        options%icloud                = icloud
 
         options%use_mp_options      = use_mp_options
         options%mp_options_filename = mp_options_filename

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -1,4 +1,4 @@
-!>----------------------------------------------------------
+ !>----------------------------------------------------------
 !! This module provides a wrapper to call various radiation models
 !! It sets up variables specific to the physics package to be used
 !!
@@ -77,7 +77,7 @@ contains
                 domain%tend%th_swrad = 0
                 domain%tend%th_lwrad = 0
         endif
-        update_interval=1800 ! 30 min, 1800 s   600 ! 10 min (600 s)
+        update_interval=options%parameters%update_interval_rrtmg ! 30 min, 1800 s   600 ! 10 min (600 s)
         last_model_time=-999
         
     end subroutine radiation_init
@@ -279,7 +279,7 @@ contains
                     has_reqc=1,                                           & ! use with icloud > 0
                     has_reqi=1,                                           & ! use with icloud > 0
                     has_reqs=1,                                           & ! use with icloud > 0 ! G. Thompson
-                    icloud = 0,                                           & ! set to nonzero if effective radius is available from microphysics
+                    icloud = options%parameters%icloud,                  & ! set to nonzero if effective radius is available from microphysics
                     warm_rain = .False.,                                  & ! when a dding WSM3scheme, add option for .True.
                     cldovrlp=1,                                  & ! J. Henderson AER: cldovrlp namelist value
                 !f_ice_phy, f_rain_phy,                     &
@@ -349,9 +349,9 @@ contains
                             rho3d = domain%density%data_3d,                       &
                             r = Rd,                                               &
                             g = gravity,                                          &
-                            icloud = 0,                                           & ! set to nonzero if effective radius is available from microphysics
+                            icloud = options%parameters%icloud,                  & ! set to nonzero if effective radius is available from microphysics
                             warm_rain = .False.,                                  & ! when a dding WSM3scheme, add option for .True.
-                            cldfra3d = cldfra3d,                                 & ! if icloud > 0, include this
+                            cldfra3d = cldfra3d,                                  & ! if icloud > 0, include this
                             cldovrlp=1,                                           & ! set to 1 for now. Could make this ICAR namelist option
 !                            lradius,iradius,                                     & !goes with CAMMGMP (Morrison Gettelman CAM mp)
                             is_cammgmp_used = .False.,                            & !goes with CAMMGMP (Morrison Gettelman CAM mp)

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -77,7 +77,7 @@ contains
                 domain%tend%th_swrad = 0
                 domain%tend%th_lwrad = 0
         endif
-        update_interval=600 ! 10 min (600 s)
+        update_interval=1800 ! 30 min, 1800 s   600 ! 10 min (600 s)
         last_model_time=-999
         
     end subroutine radiation_init
@@ -173,6 +173,7 @@ contains
         integer :: ids, ide, jds, jde, kds, kde
 
         real, dimension(:,:,:,:), pointer :: tauaer_sw=>null(), ssaaer_sw=>null(), asyaer_sw=>null() 
+        real, allocatable :: cldfra3d(:,:,:)
         real, allocatable :: day_frac(:), solar_elevation(:)
         real, allocatable:: albedo(:,:)
         integer :: j
@@ -201,6 +202,9 @@ contains
         allocate(day_frac(ims:ime))
         allocate(solar_elevation(ims:ime))
         allocate(albedo(ims:ime,jms:jme))
+        allocate(cldfra3d(ims:ime,kms:kme,jms:jme))
+
+        where(domain%cloud_water_mass%data_3d+domain%snow_mass%data_3d+domain%cloud_ice_mass%data_3d>0) cldfra3d=1
 
         ! Note, need to link NoahMP to update albedo
         albedo=0.17
@@ -264,7 +268,7 @@ contains
                     pi3d = domain%exner%data_3d,                          &
                     rho3d = domain%density%data_3d,                       &
                     dz8w = domain%dz_interface%data_3d,                   &
-                    !cldfra3d
+                    cldfra3d = cldfra3d,                                  &
                     !, lradius, iradius,          & 
                     is_cammgmp_used = .False.,                            &
                     r = Rd,                                               &
@@ -347,7 +351,7 @@ contains
                             g = gravity,                                          &
                             icloud = 0,                                           & ! set to nonzero if effective radius is available from microphysics
                             warm_rain = .False.,                                  & ! when a dding WSM3scheme, add option for .True.
-!                            cldfra3d  ,                                          & ! if icloud > 0, include this
+                            cldfra3d = cldfra3d,                                 & ! if icloud > 0, include this
                             cldovrlp=1,                                           & ! set to 1 for now. Could make this ICAR namelist option
 !                            lradius,iradius,                                     & !goes with CAMMGMP (Morrison Gettelman CAM mp)
                             is_cammgmp_used = .False.,                            & !goes with CAMMGMP (Morrison Gettelman CAM mp)

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -77,7 +77,7 @@ contains
                 domain%tend%th_swrad = 0
                 domain%tend%th_lwrad = 0
         endif
-        update_interval=options%parameters%update_interval_rrtmg ! 30 min, 1800 s   600 ! 10 min (600 s)
+        update_interval=options%rad_options%update_interval_rrtmg ! 30 min, 1800 s   600 ! 10 min (600 s)
         last_model_time=-999
         
     end subroutine radiation_init
@@ -185,6 +185,8 @@ contains
         real, allocatable :: qc(:,:,:),qi(:,:,:), qs(:,:,:), cldfra(:,:,:)
         real, allocatable :: xland(:,:)
 
+        logical :: f_qr, f_qc, f_qi, f_qs, f_qg, f_qv, f_qndrop
+
         ims = domain%grid%ims
         ime = domain%grid%ime
         jms = domain%grid%jms
@@ -229,6 +231,25 @@ contains
 
         ! Note, need to link NoahMP to update albedo
         albedo=0.17
+        F_QI=.false.
+        F_QC=.false.
+        F_QR=.false.
+        F_QS=.false.
+        F_QG=.false.
+        f_qndrop=.false.
+        F_QV=.false.
+
+        F_QI=associated(domain%cloud_ice_mass%data_3d )
+        F_QC=associated(domain%cloud_water_mass%data_3d )
+        F_QR=associated(domain%rain_mass%data_3d )
+        F_QS=associated(domain%snow_mass%data_3d )
+        F_QV=associated(domain%water_vapor%data_3d )
+        F_QG=associated(domain%graupel_mass%data_3d )
+        F_QNDROP=associated(domain%cloud_number%data_3d)
+
+        if (F_QC) qc(:,:,:) = domain%cloud_water_mass%data_3d
+        if (F_QI) qi(:,:,:) = domain%cloud_ice_mass%data_3d
+        if (F_QS) qs(:,:,:) = domain%snow_mass%data_3d
 
         if (options%physics%radiation==kRA_SIMPLE) then
             call ra_simple(theta = domain%potential_temperature%data_3d,         &
@@ -268,50 +289,52 @@ contains
                 domain%tend%th_swrad = 0
                 domain%shortwave%data_2d = 0
                 ! Calculate cloud fraction
-                If (options%parameters%icloud == 3) THEN
-                    DO j = jts,jte
-                        DO i = its,ite
-                            DO k = kts,kte
-                                p_1d(k) = domain%pressure%data_3d(i,k,j) !p(i,k,j)
-                                t_1d(k) = domain%temperature%data_3d(i,k,j)
-                                qv_1d(k) = domain%water_vapor%data_3d(i,k,j)
-                                qc_1d(k) = domain%cloud_water_mass%data_3d(i,k,j)
-                                qi_1d(k) = domain%cloud_ice_mass%data_3d(i,k,j)
-                                qs_1d(k) = domain%snow_mass%data_3d(i,k,j)
-                                Dz_1d(k) = domain%dz_interface%data_3d(i,k,j)
-                                cf_1d(k) = cldfra(i,k,j)
-                            ENDDO
-                            gridkm = domain%dx*1000
-                            XLAND = domain%land_mask
-                            CALL cal_cldfra3(cf_1d, qv_1d, qc_1d, qi_1d, qs_1d, Dz_1d, &
-                 &                          p_1d, t_1d, XLAND(i,j), gridkm,        &
-                 &                          .false., 1.5, kts, kte)
+                If (options%rad_options%icloud == 3) THEN
+                    IF ( F_QC .AND. F_QI ) THEN
+                        DO j = jts,jte
+                            DO i = its,ite
+                                DO k = kts,kte
+                                    p_1d(k) = domain%pressure%data_3d(i,k,j) !p(i,k,j)
+                                    t_1d(k) = domain%temperature%data_3d(i,k,j)
+                                    qv_1d(k) = domain%water_vapor%data_3d(i,k,j)
+                                    qc_1d(k) = domain%cloud_water_mass%data_3d(i,k,j)
+                                    qi_1d(k) = domain%cloud_ice_mass%data_3d(i,k,j)
+                                    qs_1d(k) = domain%snow_mass%data_3d(i,k,j)
+                                    Dz_1d(k) = domain%dz_interface%data_3d(i,k,j)
+                                    cf_1d(k) = cldfra(i,k,j)
+                                ENDDO
+                                gridkm = domain%dx*1000
+                                XLAND = domain%land_mask
+                                CALL cal_cldfra3(cf_1d, qv_1d, qc_1d, qi_1d, qs_1d, Dz_1d, &
+                 &                              p_1d, t_1d, XLAND(i,j), gridkm,        &
+                 &                              .false., 1.5, kts, kte)
 
-                            DO k = kts,kte
-                                qc(i,k,j) = qc_1d(k)
-                                qi(i,k,j) = qi_1d(k)
-                                qs(i,k,j) = qs_1d(k)
-                                cldfra(i,k,j) = cf_1d(k)
+                                DO k = kts,kte
+                                    ! qc, qi and qs are locally recalculated in cal_cldfra3 base on RH to account for subgrid clouds                                     qc(i,k,j) = qc_1d(k)
+                                    qc(i,k,j) = qc_1d(k)
+                                    qi(i,k,j) = qi_1d(k)
+                                    qs(i,k,j) = qs_1d(k)
+                                    cldfra(i,k,j) = cf_1d(k)
+                                ENDDO
                             ENDDO
                         ENDDO
-                    ENDDO
+                    END IF
                 END IF
 
-
-                call RRTMG_SWRAD(rthratensw=domain%tend%th_swrad,                 &
+                call RRTMG_SWRAD(rthratensw=domain%tend%th_swrad,         &
 !                swupt, swuptc, swuptcln, swdnt, swdntc, swdntcln, &
 !                swupb, swupbc, swupbcln, swdnb, swdnbc, swdnbcln, &
 !                      swupflx, swupflxc, swdnflx, swdnflxc,      &            
                     swcf = domain%shortwave_cloud_forcing%data_2d,        &
                     gsw = domain%shortwave%data_2d,                       &
                     xtime = 0., gmt = 0.,                                 &  ! not used  
-                    xlat = domain%latitude%data_2d,                 &  ! not used 
-                    xlong = domain%longitude%data_2d,              &  ! not used
+                    xlat = domain%latitude%data_2d,                       &  ! not used
+                    xlong = domain%longitude%data_2d,                     &  ! not used
                     radt = 0., degrad = 0., declin = 0.,                  &  ! not used                        
                     coszr = domain%cosine_zenith_angle%data_2d,           & 
                     julday = 0,                                           &  ! not used
                     solcon = solar_constant,                              &
-                    albedo = albedo,                                      & 
+                    albedo = albedo,                                      &
                     t3d = domain%temperature%data_3d,                     &
                     t8w = domain%temperature_interface%data_3d,           & 
                     tsk = domain%skin_temperature%data_2d,                &
@@ -321,7 +344,7 @@ contains
                     rho3d = domain%density%data_3d,                       &
                     dz8w = domain%dz_interface%data_3d,                   &
                     cldfra3d=cldfra,                                      &
-                    !, lradius, iradius,          & 
+                    !, lradius, iradius,                                  &
                     is_cammgmp_used = .False.,                            &
                     r = Rd,                                               &
                     g = gravity,                                          &
@@ -331,10 +354,10 @@ contains
                     has_reqc=1,                                           & ! use with icloud > 0
                     has_reqi=1,                                           & ! use with icloud > 0
                     has_reqs=1,                                           & ! use with icloud > 0 ! G. Thompson
-                    icloud = options%parameters%icloud,                  & ! set to nonzero if effective radius is available from microphysics
+                    icloud = options%rad_options%icloud,                  & ! set to nonzero if effective radius is available from microphysics
                     warm_rain = .False.,                                  & ! when a dding WSM3scheme, add option for .True.
-                    cldovrlp=1,                                  & ! J. Henderson AER: cldovrlp namelist value
-                !f_ice_phy, f_rain_phy,                     &
+                    cldovrlp=1,                                           & ! J. Henderson AER: cldovrlp namelist value
+                    !f_ice_phy, f_rain_phy,                               &
                     xland=real(domain%land_mask),                         &
                     xice=real(domain%land_mask)*0,                        & ! should add a variable for sea ice fraction
                     snow=domain%snow_water_equivalent%data_2d,            &
@@ -344,49 +367,48 @@ contains
                     qi3d=qi,                                              &
                     qs3d=qs,                                              &
                     qg3d=domain%graupel_mass%data_3d,                     &
-                    !o3input, o33d,                             &
+                    !o3input, o33d,                                       &
                     aer_opt=0,                                            & 
-                    !aerod, 
+                    !aerod,                                               &
                     no_src = 1,                                           &
-!                        alswvisdir, alswvisdif,                    &  !Zhenxin ssib alb comp (06/20/2011)
-!                        alswnirdir, alswnirdif,                    &  !Zhenxin ssib alb comp (06/20/2011)
-!                        swvisdir, swvisdif,                        &  !Zhenxin ssib swr comp (06/20/2011)
-!                        swnirdir, swnirdif,                        &  !Zhenxin ssib swi comp (06/20/2011)
+!                   alswvisdir, alswvisdif,                               &  !Zhenxin ssib alb comp (06/20/2011)
+!                   alswnirdir, alswnirdif,                               &  !Zhenxin ssib alb comp (06/20/2011)
+!                   swvisdir, swvisdif,                                   &  !Zhenxin ssib swr comp (06/20/2011)
+!                   swnirdir, swnirdif,                                   &  !Zhenxin ssib swi comp (06/20/2011)
                     sf_surface_physics=1,                                 &  !Zhenxin
-                    !f_qv, f_qc, f_qr, f_qi, f_qs, f_qg,        &
-                !tauaer300,tauaer400,tauaer600,tauaer999,   & ! czhao 
-                !gaer300,gaer400,gaer600,gaer999,           & ! czhao 
-                !waer300,waer400,waer600,waer999,           & ! czhao 
-!                        aer_ra_feedback,                           &
-!jdfcz                 progn,prescribe,                           &
-                !progn,
-                    calc_clean_atm_diag=0,                 &
-                    !qndrop3d,f_qndrop,                         & !czhao
-                    mp_physics=0,                                & !wang 2014/12
-                    ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,  &
-                    ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,  &
-!                       its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte &
+                    f_qv=f_qv, f_qc=f_qc, f_qr=f_qr,                      &
+                    f_qi=f_qi, f_qs=f_qs, f_qg=f_qg,                      &
+                    !tauaer300,tauaer400,tauaer600,tauaer999,             & ! czhao
+                    !gaer300,gaer400,gaer600,gaer999,                     & ! czhao
+                    !waer300,waer400,waer600,waer999,                     & ! czhao
+!                   aer_ra_feedback,                                      &
+!jdfcz              progn,prescribe,                                      &
+                    calc_clean_atm_diag=0,                                &
+                    qndrop3d=domain%cloud_number%data_3d,                 &
+                    f_qndrop=f_qndrop,                                    & !czhao
+                    mp_physics=0,                                         & !wang 2014/12
+                    ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde, &
+                    ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
                     its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1, &
-            !swupflx, swupflxc,                         &
-            !swdnflx, swdnflxc,                         &
-                    tauaer3d_sw=tauaer_sw,                             & ! jararias 2013/11        
-                    ssaaer3d_sw=ssaaer_sw,                             & ! jararias 2013/11        
-                    asyaer3d_sw=asyaer_sw,                             &
-                    
-!                        swddir = domain%skin_temperature%data_2d,          & 
-!                        swddni = domain%skin_temperature%data_2d,          &
-!                        swddif = domain%skin_temperature%data_2d,          & ! jararias 2013/08
-!                        swdownc = domain%skin_temperature%data_2d,         &
-!                        swddnic = domain%skin_temperature%data_2d,         & 
-!                        swddirc = domain%skin_temperature%data_2d,         &   ! PAJ
-                    xcoszen = domain%cosine_zenith_angle%data_2d,          &  ! NEED TO CALCULATE THIS. 
-                    yr=domain%model_time%year,                             &
-                    julian=domain%model_time%day_of_year()                 &
+                    !swupflx, swupflxc,                                   &
+                    !swdnflx, swdnflxc,                                   &
+                    tauaer3d_sw=tauaer_sw,                                & ! jararias 2013/11
+                    ssaaer3d_sw=ssaaer_sw,                                & ! jararias 2013/11
+                    asyaer3d_sw=asyaer_sw,                                &
+!                   swddir = domain%skin_temperature%data_2d,             &
+!                   swddni = domain%skin_temperature%data_2d,             &
+!                   swddif = domain%skin_temperature%data_2d,             & ! jararias 2013/08
+!                   swdownc = domain%skin_temperature%data_2d,            &
+!                   swddnic = domain%skin_temperature%data_2d,            &
+!                   swddirc = domain%skin_temperature%data_2d,            &   ! PAJ
+                    xcoszen = domain%cosine_zenith_angle%data_2d,         &  ! NEED TO CALCULATE THIS.
+                    yr=domain%model_time%year,                            &
+                    julian=domain%model_time%day_of_year()                &
                                                    )
                       
-                call RRTMG_LWRAD(rthratenlw=domain%tend%th_lwrad,                     &
-!                lwupt, lwuptc, lwuptcln, lwdnt, lwdntc, lwdntcln, &        !if lwupt defined, all MUST be defined
-!                lwupb, lwupbc, lwupbcln, lwdnb, lwdnbc, lwdnbcln, &
+                call RRTMG_LWRAD(rthratenlw=domain%tend%th_lwrad,                 &
+!                           lwupt, lwuptc, lwuptcln, lwdnt, lwdntc, lwdntcln,     &        !if lwupt defined, all MUST be defined
+!                           lwupb, lwupbc, lwupbcln, lwdnb, lwdnbc, lwdnbcln,     &
                             glw = domain%longwave%data_2d,                        &
                             olr = domain%out_longwave_rad%data_2d,                &
                             lwcf = domain%longwave_cloud_forcing%data_2d,         &
@@ -401,7 +423,7 @@ contains
                             rho3d = domain%density%data_3d,                       &
                             r = Rd,                                               &
                             g = gravity,                                          &
-                            icloud = options%parameters%icloud,                   & ! set to nonzero if effective radius is available from microphysics
+                            icloud = options%rad_options%icloud,                  & ! set to nonzero if effective radius is available from microphysics
                             warm_rain = .False.,                                  & ! when a dding WSM3scheme, add option for .True.
                             cldfra3d = cldfra,                                    &
                             cldovrlp=1,                                           & ! set to 1 for now. Could make this ICAR namelist option
@@ -417,24 +439,24 @@ contains
                             qi3d=qi,                                              &
                             qs3d=qs,                                              &
                             qg3d=domain%graupel_mass%data_3d,                     &
-!                            o3input, o33d,                             &
-!                            f_qv, f_qc, f_qr, f_qi, f_qs, f_qg,                  & ! if icloud > 0, these can be set to true
+!                           o3input, o33d,                                        &
+                            f_qv=f_qv, f_qc=f_qc, f_qr=f_qr,                      &
+                            f_qi=f_qi, f_qs=f_qs, f_qg=f_qg,                      &
                             re_cloud = domain%re_cloud%data_3d,                   &
                             re_ice   = domain%re_ice%data_3d,                     &
                             re_snow  = domain%re_snow%data_3d,                    &
                             has_reqc=1,                                           & ! use with icloud > 0
                             has_reqi=1,                                           & ! use with icloud > 0
                             has_reqs=1,                                           & ! use with icloud > 0 ! G. Thompson
-!                            tauaerlw1,tauaerlw2,tauaerlw3,tauaerlw4,   & ! czhao
-!                            tauaerlw5,tauaerlw6,tauaerlw7,tauaerlw8,   & ! czhao
-!                            tauaerlw9,tauaerlw10,tauaerlw11,tauaerlw12,   & ! czhao
-!                            tauaerlw13,tauaerlw14,tauaerlw15,tauaerlw16,   & ! czhao
-!                            aer_ra_feedback,                           & !czhao
-!                        !jdfcz                 progn,prescribe,                           & !czhao
-!                            progn,
-                            calc_clean_atm_diag=0,                               & ! used with wrf_chem !czhao
-!                            qndrop3d=domain%cloud_number%data_3d,                & ! used with icould > 0
-!                            f_qndrop,                         & ! if icloud > 0, use this
+!                           tauaerlw1,tauaerlw2,tauaerlw3,tauaerlw4,              & ! czhao
+!                           tauaerlw5,tauaerlw6,tauaerlw7,tauaerlw8,              & ! czhao
+!                           tauaerlw9,tauaerlw10,tauaerlw11,tauaerlw12,           & ! czhao
+!                           tauaerlw13,tauaerlw14,tauaerlw15,tauaerlw16,          & ! czhao
+!                           aer_ra_feedback,                                      & !czhao
+!                    !jdfcz progn,prescribe,                                      & !czhao
+                            calc_clean_atm_diag=0,                                & ! used with wrf_chem !czhao
+                            qndrop3d=domain%cloud_number%data_3d,                 & ! used with icould > 0
+                            f_qndrop=f_qndrop,                                    & ! if icloud > 0, use this
                         !ccc added for time varying gases.
                             yr=domain%model_time%year,                             &
                             julian=domain%model_time%day_of_year(),                &
@@ -442,9 +464,8 @@ contains
                             mp_physics=0,                                          &
                             ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,  &
                             ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,  &
-!                            its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte &
                             its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1 &
-!                            lwupflx, lwupflxc, lwdnflx, lwdnflxc       &
+!                           lwupflx, lwupflxc, lwdnflx, lwdnflxc                   &
                             )
             endif
             domain%temperature%data_3d = domain%temperature%data_3d+domain%tend%th_lwrad*dt+domain%tend%th_swrad*dt

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -227,8 +227,6 @@ contains
         allocate(albedo(ims:ime,jms:jme))
         allocate(cldfra3d(ims:ime,kms:kme,jms:jme))
 
-        where(domain%cloud_water_mass%data_3d+domain%snow_mass%data_3d+domain%cloud_ice_mass%data_3d>0) cldfra3d=1
-
         ! Note, need to link NoahMP to update albedo
         
         qc = 0

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -230,6 +230,11 @@ contains
         where(domain%cloud_water_mass%data_3d+domain%snow_mass%data_3d+domain%cloud_ice_mass%data_3d>0) cldfra3d=1
 
         ! Note, need to link NoahMP to update albedo
+        
+        qc = 0
+        qi = 0
+        qs = 0
+
         albedo=0.17
         F_QI=.false.
         F_QC=.false.
@@ -244,7 +249,7 @@ contains
         F_QR=associated(domain%rain_mass%data_3d )
         F_QS=associated(domain%snow_mass%data_3d )
         F_QV=associated(domain%water_vapor%data_3d )
-        F_QG=associated(domain%graupel_mass%data_3d )
+        !F_QG=associated(domain%graupel_mass%data_3d )
         F_QNDROP=associated(domain%cloud_number%data_3d)
 
         if (F_QC) qc(:,:,:) = domain%cloud_water_mass%data_3d
@@ -384,7 +389,7 @@ contains
 !                   aer_ra_feedback,                                      &
 !jdfcz              progn,prescribe,                                      &
                     calc_clean_atm_diag=0,                                &
-                    qndrop3d=domain%cloud_number%data_3d,                 &
+!                    qndrop3d=domain%cloud_number%data_3d,                 &
                     f_qndrop=f_qndrop,                                    & !czhao
                     mp_physics=0,                                         & !wang 2014/12
                     ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde, &
@@ -455,7 +460,7 @@ contains
 !                           aer_ra_feedback,                                      & !czhao
 !                    !jdfcz progn,prescribe,                                      & !czhao
                             calc_clean_atm_diag=0,                                & ! used with wrf_chem !czhao
-                            qndrop3d=domain%cloud_number%data_3d,                 & ! used with icould > 0
+!                            qndrop3d=domain%cloud_number%data_3d,                 & ! used with icould > 0
                             f_qndrop=f_qndrop,                                    & ! if icloud > 0, use this
                         !ccc added for time varying gases.
                             yr=domain%model_time%year,                             &

--- a/src/physics/ra_rrtmg_lw.f90
+++ b/src/physics/ra_rrtmg_lw.f90
@@ -12074,13 +12074,13 @@ CONTAINS
 !        IF ( mp_physics == FER_MP_HIRES .OR. &
 !             mp_physics == FER_MP_HIRES_ADVECT) THEN
 !#endif
-!                  DO K=kts,kte
-!                     qi1d(k) = qi3d(i,k,j)
-!                     qs1d(k) = 0.0
-!                     qc1d(k) = qc3d(i,k,j)
-!                     qi1d(k) = max(0.,qi1d(k))
-!                     qc1d(k) = max(0.,qc1d(k))
-!                  ENDDO
+                  DO K=kts,kte
+                     qi1d(k) = qi3d(i,k,j)
+                     qs1d(k) = 0.0
+                     qc1d(k) = qc3d(i,k,j)
+                     qi1d(k) = max(0.,qi1d(k))
+                     qc1d(k) = max(0.,qc1d(k))
+                  ENDDO
 !        ENDIF
 
 !         EMISS0=EMISS(I,J)
@@ -12565,6 +12565,7 @@ CONTAINS
                rel(ncol,k) = reliq(ncol,k)
                rei(ncol,k) = reice(ncol,k)
             enddo
+
 
 !Mukul
             if (inflglw .eq. 5) then

--- a/src/physics/ra_rrtmg_sw.f90
+++ b/src/physics/ra_rrtmg_sw.f90
@@ -10529,13 +10529,13 @@ CONTAINS
 !           IF ( mp_physics == FER_MP_HIRES .OR. &
 !                mp_physics == FER_MP_HIRES_ADVECT) THEN
 !#endif
-!                  DO K=kts,kte
-!                     qi1d(k) = qi3d(i,k,j)
-!                     qs1d(k) = 0.0
-!                     qc1d(k) = qc3d(i,k,j)
-!                     qi1d(k) = max(0.,qi1d(k))
-!                     qc1d(k) = max(0.,qc1d(k))
-!                  ENDDO
+                  DO K=kts,kte
+                     qi1d(k) = qi3d(i,k,j)
+                     qs1d(k) = 0.0
+                     qc1d(k) = qc3d(i,k,j)
+                     qi1d(k) = max(0.,qi1d(k))
+                     qc1d(k) = max(0.,qc1d(k))
+                  ENDDO
 !           ENDIF
 !-- Trude
 

--- a/src/physics/ra_rrtmg_sw.f90
+++ b/src/physics/ra_rrtmg_sw.f90
@@ -10529,13 +10529,13 @@ CONTAINS
 !           IF ( mp_physics == FER_MP_HIRES .OR. &
 !                mp_physics == FER_MP_HIRES_ADVECT) THEN
 !#endif
-                  DO K=kts,kte
-                     qi1d(k) = qi3d(i,k,j)
-                     qs1d(k) = 0.0
-                     qc1d(k) = qc3d(i,k,j)
-                     qi1d(k) = max(0.,qi1d(k))
-                     qc1d(k) = max(0.,qc1d(k))
-                  ENDDO
+!                  DO K=kts,kte
+!                     qi1d(k) = qi3d(i,k,j)
+!                     qs1d(k) = 0.0
+!                     qc1d(k) = qc3d(i,k,j)
+!                     qi1d(k) = max(0.,qi1d(k))
+!                     qc1d(k) = max(0.,qc1d(k))
+!                  ENDDO
 !           ENDIF
 !-- Trude
 

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -632,4 +632,417 @@ contains
 
     end subroutine init_atm_utilities
 
+!+---+-----------------------------------------------------------------+
+!..Cloud fraction scheme by G. Thompson (NCAR-RAL), not intended for
+!.. combining with any cumulus or shallow cumulus parameterization
+!.. scheme cloud fractions.  This is intended as a stand-alone for
+!.. cloud fraction and is relatively good at getting widespread stratus
+!.. and stratoCu without caring whether any deep/shallow Cu param schemes
+!.. is making sub-grid-spacing clouds/precip.  Under the hood, this
+!.. scheme follows Mocko and Cotton (1995) in applicaiton of the
+!.. Sundqvist et al (1989) scheme but using a grid-scale dependent
+!.. RH threshold, one each for land v. ocean points based on
+!.. experiences with HWRF testing.
+!+---+-----------------------------------------------------------------+
+!
+!+---+-----------------------------------------------------------------+
+
+    SUBROUTINE cal_cldfra3(CLDFRA, qv, qc, qi, qs, dz,                &
+        &                 p, t, XLAND, gridkm,                             &
+        &                 modify_qvapor, max_relh,                         &
+        &                 kts,kte)
+   !
+        USE module_mp_thompson   , ONLY : rsif, rslf
+        IMPLICIT NONE
+   !
+        INTEGER, INTENT(IN):: kts, kte
+        LOGICAL, INTENT(IN):: modify_qvapor
+        REAL, DIMENSION(kts:kte), INTENT(INOUT):: qv, qc, qi, cldfra
+        REAL, DIMENSION(kts:kte), INTENT(IN):: p, t, dz, qs
+        REAL, INTENT(IN):: gridkm, XLAND, max_relh
+
+   !..Local vars.
+        REAL:: RH_00L, RH_00O, RH_00
+        REAL:: entrmnt=0.5
+        INTEGER:: k
+        REAL:: TC, qvsi, qvsw, RHUM, delz
+        REAL, DIMENSION(kts:kte):: qvs, rh, rhoa
+
+   !+---+
+
+   !..Initialize cloud fraction, compute RH, and rho-air.
+
+        DO k = kts,kte
+            CLDFRA(K) = 0.0
+            qvsw = rslf(P(k), t(k))
+            qvsi = rsif(P(k), t(k))
+
+            tc = t(k) - 273.15
+            if (tc .ge. -12.0) then
+                qvs(k) = qvsw
+            elseif (tc .lt. -35.0) then
+                qvs(k) = qvsi
+            else
+                qvs(k) = qvsw - (qvsw-qvsi)*(-12.0-tc)/(-12.0+35.)
+            endif
+
+            rh(k) = MAX(0.01, qv(k)/qvs(k))
+            rhoa(k) = p(k)/(287.0*t(k))
+        ENDDO
+
+
+   !..First cut scale-aware. Higher resolution should require closer to
+   !.. saturated grid box for higher cloud fraction.  Simple functions
+   !.. chosen based on Mocko and Cotton (1995) starting point and desire
+   !.. to get near 100% RH as grid spacing moves toward 1.0km, but higher
+   !.. RH over ocean required as compared to over land.
+
+        DO k = kts,kte
+
+            delz = MAX(100., dz(k))
+            RH_00L = 0.65 + SQRT(1./(25.0+gridkm*gridkm*delz*0.01))
+            RH_00O = 0.81 + SQRT(1./(50.0+gridkm*gridkm*delz*0.01))
+            RHUM = rh(k)
+
+            if (qc(k).gt.1.E-7 .or. qi(k).ge.1.E-7                         &
+        &                    .or. (qs(k).gt.1.E-6 .and. t(k).lt.273.)) then
+               CLDFRA(K) = 1.0
+               qvs(k) = qv(k)
+            else
+
+                IF ((XLAND-1.5).GT.0.) THEN                                  !--- Ocean
+                    RH_00 = RH_00O
+                ELSE                                                         !--- Land
+                    RH_00 = RH_00L
+                ENDIF
+
+                tc = t(k) - 273.15
+                if (tc .lt. -12.0) RH_00 = RH_00L
+
+                if (tc .ge. 20.0) then
+                    CLDFRA(K) = 0.0
+                elseif (tc .ge. -12.0) then
+                    RHUM = MIN(rh(k), 1.0)
+                    CLDFRA(K) = MAX(0., 1.0-SQRT((1.005-RHUM)/(1.005-RH_00)))
+                else
+                    if (max_relh.gt.1.12 .or. (.NOT.(modify_qvapor)) ) then
+   !..For HRRR model, the following look OK.
+                        RHUM = MIN(rh(k), 1.45)
+                        RH_00 = RH_00 + (1.45-RH_00)*(-12.0-tc)/(-12.0+100.)
+                        if (RH_00 .ge. 1.5) then
+                            WRITE (*,*) ' FATAL: RH_00 too large (1.5): ', RH_00, RH_00L, tc
+                        endif
+                        CLDFRA(K) = MAX(0., 1.0-SQRT((1.5-RHUM)/(1.5-RH_00)))
+                    else
+   !..but for the GFS model, RH is way lower.
+                        RHUM = MIN(rh(k), 1.05)
+                        RH_00 = RH_00 + (1.05-RH_00)*(-12.0-tc)/(-12.0+100.)
+                        if (RH_00 .ge. 1.05) then
+                            WRITE (*,*) ' FATAL: RH_00 too large (1.05): ', RH_00, RH_00L, tc
+                        endif
+                        CLDFRA(K) = MAX(0., 1.0-SQRT((1.05-RHUM)/(1.05-RH_00)))
+                    endif
+                endif
+                if (CLDFRA(K).gt.0.) CLDFRA(K) = MAX(0.01, MIN(CLDFRA(K),0.9))
+            endif
+        ENDDO
+
+        call find_cloudLayers(qvs, cldfra, T, P, Dz, entrmnt,             &
+        &                      qc, qi, qs, kts,kte)
+
+   !..Do a final total column adjustment since we may have added more than 1mm
+   !.. LWP/IWP for multiple cloud decks.
+
+        call adjust_cloudFinal(cldfra, qc, qi, rhoa, dz, kts,kte)
+        if (modify_qvapor) then
+            DO k = kts,kte
+                if (cldfra(k).gt.0.20 .and. cldfra(k).lt.1.0) then
+                  qv(k) = qvs(k)
+                endif
+            ENDDO
+        endif
+
+    END SUBROUTINE cal_cldfra3
+
+!+---+-----------------------------------------------------------------+
+!..From cloud fraction array, find clouds of multi-level depth and compute
+!.. a reasonable value of LWP or IWP that might be contained in that depth,
+!.. unless existing LWC/IWC is already there.
+
+    SUBROUTINE find_cloudLayers(qvs1d, cfr1d, T1d, P1d, Dz1d, entrmnt,&
+            &                            qc1d, qi1d, qs1d, kts,kte)
+       !
+        IMPLICIT NONE
+       !
+        INTEGER, INTENT(IN):: kts, kte
+        REAL, INTENT(IN):: entrmnt
+        REAL, DIMENSION(kts:kte), INTENT(IN):: qs1d,qvs1d,T1d,P1d,Dz1d
+        REAL, DIMENSION(kts:kte), INTENT(INOUT):: cfr1d, qc1d, qi1d
+
+       !..Local vars.
+        REAL, DIMENSION(kts:kte):: theta
+        REAL:: theta1, theta2, delz
+        INTEGER:: k, k2, k_tropo, k_m12C, k_cldb, k_cldt, kbot
+        LOGICAL:: in_cloud
+
+       !+---+
+
+        k_m12C = 0
+        DO k = kte, kts, -1
+            theta(k) = T1d(k)*((100000.0/P1d(k))**(287.05/1004.))
+            if (T1d(k)-273.16 .gt. -12.0 .and. P1d(k).gt.10100.0) k_m12C = MAX(k_m12C, k)
+        ENDDO
+        if (k_m12C .le. kts) k_m12C = kts
+
+        if (k_m12C.gt.kte-3) then
+            WRITE (*,*) 'DEBUG-GT: WARNING, no possible way neg12C can occur this high up: ', k_m12C
+            do k = kte, kts, -1
+                WRITE (*,*) 'DEBUG-GT,  k,  P, T : ', k,P1d(k)*0.01,T1d(k)-273.15
+            enddo
+            write(*,*) ('FATAL ERROR, problem in temperature profile.')
+        endif
+
+       !..Find tropopause height, best surrogate, because we would not really
+       !.. wish to put fake clouds into the stratosphere.  The 10/1500 ratio
+       !.. d(Theta)/d(Z) approximates a vertical line on typical SkewT chart
+       !.. near typical (mid-latitude) tropopause height.  Since messy data
+       !.. could give us a false signal of such a transition, do the check over
+       !.. three K-level change, not just a level-to-level check.  This method
+       !.. has potential failure in arctic-like conditions with extremely low
+       !.. tropopause height, as would any other diagnostic, so ensure resulting
+       !.. k_tropo level is above 700hPa.
+
+        DO k = kte-3, kts, -1
+            theta1 = theta(k)
+            theta2 = theta(k+2)
+            delz = dz1d(k) + dz1d(k+1) + dz1d(k+2)
+            if ( ((((theta2-theta1)/delz) .lt. 10./1500. ) .AND.       &
+            &                 (P1d(k).gt.8500.)) .or. (P1d(k).gt.70000.) ) then
+                goto 86
+            endif
+        ENDDO
+    86  continue
+        k_tropo = MAX(kts+2, MIN(k+2, kte-1))
+
+        if (k_tropo.gt.kte-2) then
+            WRITE (*,*) 'DEBUG-GT: CAUTION, tropopause appears to be very high up: ', k_tropo
+            do k = kte, kts, -1
+                WRITE (*,*) 'DEBUG-GT,   P, T : ', k,P1d(k)*0.01,T1d(k)-273.16
+            enddo
+        endif
+
+       !..Eliminate possible fractional clouds above supposed tropopause.
+        DO k = k_tropo+1, kte
+            if (cfr1d(k).gt.0.0 .and. cfr1d(k).lt.1.0) then
+                cfr1d(k) = 0.
+            endif
+        ENDDO
+
+       !..We would like to prevent fractional clouds below LCL in idealized
+       !.. situation with deep well-mixed convective PBL, that otherwise is
+       !.. likely to get clouds in more realistic capping inversion layer.
+
+        kbot = kts+2
+        DO k = kbot, k_m12C
+            if ( (theta(k)-theta(k-1)) .gt. 0.025E-3*Dz1d(k)) EXIT
+        ENDDO
+        kbot = MAX(kts+1, k-2)
+        DO k = kts, kbot
+            if (cfr1d(k).gt.0.0 .and. cfr1d(k).lt.1.0) cfr1d(k) = 0.
+        ENDDO
+
+       !..Starting below tropo height, if cloud fraction greater than 1 percent,
+       !.. compute an approximate total layer depth of cloud, determine a total
+       !.. liquid water/ice path (LWP/IWP), then reduce that amount with tuning
+       !.. parameter to represent entrainment factor, then divide up LWP/IWP
+       !.. into delta-Z weighted amounts for individual levels per cloud layer.
+
+        k_cldb = k_tropo
+        in_cloud = .false.
+        k = k_tropo
+        DO WHILE (.not. in_cloud .AND. k.gt.k_m12C+1)
+            k_cldt = 0
+            if (cfr1d(k).ge.0.01) then
+                in_cloud = .true.
+                k_cldt = MAX(k_cldt, k)
+            endif
+            if (in_cloud) then
+                DO k2 = k_cldt-1, k_m12C, -1
+                    if (cfr1d(k2).lt.0.01 .or. k2.eq.k_m12C) then
+                        k_cldb = k2+1
+                        goto 87
+                    endif
+                ENDDO
+        87      continue
+                in_cloud = .false.
+            endif
+            if ((k_cldt - k_cldb + 1) .ge. 2) then
+                call adjust_cloudIce(cfr1d, qi1d, qs1d, qvs1d, T1d, Dz1d,   &
+            &                           entrmnt, k_cldb,k_cldt,kts,kte)
+                k = k_cldb
+            elseif ((k_cldt - k_cldb + 1) .eq. 1) then
+                if (cfr1d(k_cldb).gt.0.and.cfr1d(k_cldb).lt.1.)             &
+            &               qi1d(k_cldb)=0.05*qvs1d(k_cldb)
+                k = k_cldb
+            endif
+                k = k - 1
+        ENDDO
+
+
+        k_cldb = k_m12C + 3
+        in_cloud = .false.
+        k = k_m12C + 2
+        DO WHILE (.not. in_cloud .AND. k.gt.kbot)
+            k_cldt = 0
+            if (cfr1d(k).ge.0.01) then
+                in_cloud = .true.
+                k_cldt = MAX(k_cldt, k)
+            endif
+            if (in_cloud) then
+                DO k2 = k_cldt-1, kbot, -1
+                    if (cfr1d(k2).lt.0.01 .or. k2.eq.kbot) then
+                        k_cldb = k2+1
+                        goto 88
+                    endif
+                ENDDO
+        88      continue
+                in_cloud = .false.
+            endif
+            if ((k_cldt - k_cldb + 1) .ge. 2) then
+                call adjust_cloudH2O(cfr1d, qc1d, qvs1d, T1d, Dz1d,         &
+            &                           entrmnt, k_cldb,k_cldt,kts,kte)
+                k = k_cldb
+            elseif ((k_cldt - k_cldb + 1) .eq. 1) then
+                if (cfr1d(k_cldb).gt.0.and.cfr1d(k_cldb).lt.1.)             &
+            &                qc1d(k_cldb)=0.05*qvs1d(k_cldb)
+                k = k_cldb
+            endif
+            k = k - 1
+        ENDDO
+
+    END SUBROUTINE find_cloudLayers
+
+!+---+-----------------------------------------------------------------+
+
+    SUBROUTINE adjust_cloudIce(cfr,qi,qs,qvs,T,dz,entr, k1,k2,kts,kte)
+                !
+        IMPLICIT NONE
+                !
+        INTEGER, INTENT(IN):: k1,k2, kts,kte
+        REAL, INTENT(IN):: entr
+        REAL, DIMENSION(kts:kte), INTENT(IN):: cfr, qs, qvs, T, dz
+        REAL, DIMENSION(kts:kte), INTENT(INOUT):: qi
+        REAL:: iwc, max_iwc, tdz, this_iwc, this_dz
+        INTEGER:: k
+
+        tdz = 0.
+        do k = k1, k2
+            tdz = tdz + dz(k)
+        enddo
+        ax_iwc = ABS(qvs(k2)-qvs(k1))
+
+        do k = k1, k2
+            max_iwc = MAX(1.E-6, max_iwc - (qi(k)+qs(k)))
+        enddo
+        max_iwc = MIN(1.E-3, max_iwc)
+
+        this_dz = 0.0
+        do k = k1, k2
+            if (k.eq.k1) then
+                this_dz = this_dz + 0.5*dz(k)
+            else
+                this_dz = this_dz + dz(k)
+            endif
+            this_iwc = max_iwc*this_dz/tdz
+            iwc = MAX(1.E-6, this_iwc*(1.-entr))
+            if (cfr(k).gt.0.0.and.cfr(k).lt.1.0.and.T(k).ge.203.16) then
+                qi(k) = qi(k) + cfr(k)*cfr(k)*iwc
+            endif
+        enddo
+
+    END SUBROUTINE adjust_cloudIce
+
+    !+---+-----------------------------------------------------------------
+
+    SUBROUTINE adjust_cloudH2O(cfr, qc, qvs,T,dz,entr, k1,k2,kts,kte)
+                !
+        IMPLICIT NONE
+                !
+        INTEGER, INTENT(IN):: k1,k2, kts,kte
+        REAL, INTENT(IN):: entr
+        REAL, DIMENSION(kts:kte), INTENT(IN):: cfr, qvs, T, dz
+        REAL, DIMENSION(kts:kte), INTENT(INOUT):: qc
+        REAL:: lwc, max_lwc, tdz, this_lwc, this_dz
+        INTEGER:: k
+
+        tdz = 0.
+        do k = k1, k2
+            tdz = tdz + dz(k)
+        enddo
+        max_lwc = ABS(qvs(k2)-qvs(k1))
+
+        do k = k1, k2
+            max_lwc = MAX(1.E-6, max_lwc - qc(k))
+        enddo
+        max_lwc = MIN(1.E-3, max_lwc)
+        this_dz = 0.0
+        do k = k1, k2
+            if (k.eq.k1) then
+                this_dz = this_dz + 0.5*dz(k)
+            else
+                this_dz = this_dz + dz(k)
+            endif
+            this_lwc = max_lwc*this_dz/tdz
+            lwc = MAX(1.E-6, this_lwc*(1.-entr))
+            if (cfr(k).gt.0.0.and.cfr(k).lt.1.0.and.T(k).ge.253.16) then
+                qc(k) = qc(k) + cfr(k)*cfr(k)*lwc
+            endif
+        enddo
+
+    END SUBROUTINE adjust_cloudH2O
+
+    !+---+-----------------------------------------------------------------+
+
+    !..Do not alter any grid-explicitly resolved hydrometeors, rather only
+    !.. the supposed amounts due to the cloud fraction scheme.
+
+    SUBROUTINE adjust_cloudFinal(cfr, qc, qi, Rho,dz, kts,kte)
+
+        IMPLICIT NONE
+                !
+        INTEGER, INTENT(IN):: kts,kte
+        REAL, DIMENSION(kts:kte), INTENT(IN):: cfr, Rho, dz
+        REAL, DIMENSION(kts:kte), INTENT(INOUT):: qc, qi
+        REAL:: lwp, iwp, xfac
+        INTEGER:: k
+
+        lwp = 0.
+        iwp = 0.
+        do k = kts, kte
+            if (cfr(k).gt.0.0) then
+                lwp = lwp + qc(k)*Rho(k)*dz(k)
+                iwp = iwp + qi(k)*Rho(k)*dz(k)
+            endif
+        enddo
+
+        if (lwp .gt. 1.5) then
+            xfac = 1.5/lwp
+            do k = kts, kte
+                if (cfr(k).gt.0.0 .and. cfr(k).lt.1.0) then
+                    qc(k) = qc(k)*xfac
+                endif
+            enddo
+        endif
+
+        if (iwp .gt. 1.5) then
+            xfac = 1.5/iwp
+                do k = kts, kte
+                    if (cfr(k).gt.0.0 .and. cfr(k).lt.1.0) then
+                        qi(k) = qi(k)*xfac
+                    endif
+                enddo
+        endif
+
+    END SUBROUTINE adjust_cloudFinal
+
 end module mod_atm_utilities

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -824,12 +824,12 @@ contains
     86  continue
         k_tropo = MAX(kts+2, MIN(k+2, kte-1))
 
-        if (k_tropo.gt.kte-2) then
-            WRITE (*,*) 'DEBUG-GT: CAUTION, tropopause appears to be very high up: ', k_tropo
-            do k = kte, kts, -1
-                WRITE (*,*) 'DEBUG-GT,   P, T : ', k,P1d(k)*0.01,T1d(k)-273.16
-            enddo
-        endif
+        !if (k_tropo.gt.kte-2) then
+        !    WRITE (*,*) 'DEBUG-GT: CAUTION, tropopause appears to be very high up: ', k_tropo
+        !    do k = kte, kts, -1
+        !        WRITE (*,*) 'DEBUG-GT,   P, T : ', k,P1d(k)*0.01,T1d(k)-273.16
+        !    enddo
+        !endif
 
        !..Eliminate possible fractional clouds above supposed tropopause.
         DO k = k_tropo+1, kte
@@ -939,7 +939,7 @@ contains
         do k = k1, k2
             tdz = tdz + dz(k)
         enddo
-        ax_iwc = ABS(qvs(k2)-qvs(k1))
+        max_iwc = ABS(qvs(k2)-qvs(k1))
 
         do k = k1, k2
             max_iwc = MAX(1.E-6, max_iwc - (qi(k)+qs(k)))


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cloud interaction with radiation, added namelist options, added calculation of 3d cloud fraction 

SOURCE: Trude Eidhammer

DESCRIPTION OF CHANGES: 1) Fixed a bug which caused RRTMG short wave code to not interact with clouds. 
2) User can now chose the iCloud option to use and the time step between RRTMG update in the namelist. 
3) Added the Thompson routine of calculating 3D cloud fraction from WRF
 
TESTS CONDUCTED: 

Compared the updates with the simple radiation scheme, and with icloud = 0 (icloud=0 means no cloud impact on radiation) 

![Screen Shot 2022-02-24 at 2 52 24 PM](https://user-images.githubusercontent.com/16106613/155613843-7821e6d0-6c00-4409-9e2b-26c738438ab6.png)

Figure shows 2m average daily temperature difference (in Kelvin). Left plot is the difference between RRTMG icloud =3 and the simple radiation scheme. Right plot is the difference between RRTMG icloud=3 and RRTMG icloud=0 


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [X ] Closes issue #xxxx n/a 
 - [X] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [X] Requires new files? No
 - [X] Fully documented
