### PR TITLE
Added the posibility to read in greenhouse gas files when using RRTMG

### DIFF
--- a/src/objects/opt_types.f90
+++ b/src/objects/opt_types.f90
@@ -147,6 +147,8 @@ module options_types
        integer :: update_interval_rrtmg                ! how ofen to update the radiation in seconds.
                                                        ! RRTMG scheme is expensive. Default is 1800s (30 minutes)
        integer :: icloud                               ! How RRTMG interact with clouds
+       logical :: read_ghg                             ! Eihter use default green house gas mixing ratio, or read the in from file
+
     end type rad_options_type
 
     ! ------------------------------------------------

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -1761,7 +1761,6 @@ contains
     !! Initialize the radiation model options
     !!
     !! Reads the rad_parameters namelist or sets default values
-    !! Perhaps not use this subroutine, since icloud and update_interval_rrtmg is set in icar_options
     !! -------------------------------
     subroutine rad_parameters_namelist(filename, options)
         implicit none
@@ -1773,9 +1772,9 @@ contains
 
         integer :: update_interval_rrtmg             ! minimum number of seconds between RRTMG updates
         integer :: icloud                            ! how RRTMG interacts with clouds
-
+        logical :: read_ghg
         ! define the namelist
-        namelist /rad_parameters/ update_interval_rrtmg, icloud
+        namelist /rad_parameters/ update_interval_rrtmg, icloud, read_ghg
 
 
          ! because adv_options could be in a separate file
@@ -1789,6 +1788,7 @@ contains
         ! set default values
         update_interval_rrtmg = 1800 ! 30 minutes
         icloud          = 3    ! effective radius from microphysics scheme
+        read_ghg        = .false.
 
         ! read the namelist options
         if (options%parameters%use_rad_options) then
@@ -1800,6 +1800,7 @@ contains
         ! store everything in the radiation_options structure
         rad_options%update_interval_rrtmg = update_interval_rrtmg
         rad_options%icloud                = icloud
+        rad_options%read_ghg              = read_ghg
 
         ! copy the data back into the global options data structure
         options%rad_options = rad_options

--- a/src/physics/ra_driver.f90
+++ b/src/physics/ra_driver.f90
@@ -467,8 +467,9 @@ contains
                             mp_physics=0,                                          &
                             ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,  &
                             ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,  &
-                            its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1 &
-!                           lwupflx, lwupflxc, lwdnflx, lwdnflxc                   &
+                            its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1,&
+!                           lwupflx, lwupflxc, lwdnflx, lwdnflxc,                  &
+                            read_ghg=options%rad_options%read_ghg                  &
                             )
             endif
             domain%temperature%data_3d = domain%temperature%data_3d+domain%tend%th_lwrad*dt+domain%tend%th_swrad*dt

--- a/src/physics/ra_rrtmg_lw.f90
+++ b/src/physics/ra_rrtmg_lw.f90
@@ -11523,8 +11523,9 @@ CONTAINS
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte,                 &
-                       lwupflx, lwupflxc, lwdnflx, lwdnflxc       &
-                                                                  )
+                       lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
+                       read_ghg                                   &
+                       )
 !------------------------------------------------------------------
 !ccc To use clWRF time varying trace gases
    USE MODULE_RA_CLWRF_SUPPORT, ONLY : read_CAMgases
@@ -11643,7 +11644,9 @@ CONTAINS
          OPTIONAL, INTENT(OUT) ::                                 &
                                LWUPFLX,LWUPFLXC,LWDNFLX,LWDNFLXC
 
-!  LOCAL VARS
+   LOGICAL, INTENT(IN) ::  read_ghg
+
+   !  LOCAL VARS
  
    REAL, DIMENSION( kts:kte+1 ) ::                          Pw1D, &
                                                             Tw1D
@@ -11754,19 +11757,19 @@ CONTAINS
 
 ! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
 ! carbon dioxide (379 ppmv) - this is being replaced by an annual function in v4.2
-    real :: co2
+    real(8) :: co2
 !   data co2 / 379.e-6 / 
 ! methane (1774 ppbv)
-    real :: ch4
+    real(8) :: ch4
     data ch4 / 1774.e-9 / 
 ! nitrous oxide (319 ppbv)
-    real :: n2o
+    real(8) :: n2o
     data n2o / 319.e-9 / 
 ! cfc-11 (251 ppt)
-    real :: cfc11
+    real(8) :: cfc11
     data cfc11 / 0.251e-9 / 
 ! cfc-12 (538 ppt)
-    real :: cfc12
+    real(8) :: cfc12
     data cfc12 / 0.538e-9 / 
 #endif
 ! cfc-22 (169 ppt)
@@ -11902,8 +11905,8 @@ CONTAINS
 
 !ccc Read time-varying trace gases concentrations and interpolate them to run date.
 !
-#ifdef CLWRFGHG
-
+!#ifdef CLWRFGHG
+if (read_ghg) then
    CALL read_CAMgases(yr,julian,"RRTMG",co2,n2o,ch4,cfc11,cfc12)
 
 !   IF ( wrf_dm_on_monitor() ) THEN
@@ -11915,8 +11918,8 @@ CONTAINS
      !call wrf_debug( 100, message)
      write(*,*) message
    ENDIF
-
-#endif
+endif
+!#endif
 !ccc
 
 ! latitude loop


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: Greenhouse Gas, CMIPs 

SOURCE: Trude Eidhammer, NCAR

DESCRIPTION OF CHANGES: There is now a namelist option for RRTMG where the user can choose to read in projected greenhouse gas mixing ratio for several different CMIP scenarios. The files are located in icar_supporting_files/rrtmg_support and labeled as CAMtr_volume_mixing_ratio.xxx

In the run directory, the user should create a link CAMtr_volume_mixing_ratio that links to the desired CAMtr_volume_mixing_ratio.xxx file. 

To run this new capability, the user need to set the namelist parameter 
run_ghg = .true.

TESTS CONDUCTED: Compiled and run


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx  N/A
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [X] Requires new files? New files are located in icar_supporting_files/rrtmg_support
 - [X] Fully documented
