### PR TITLE
Changed advect.f90 winds check, cleaned up wind.f90 smooth_height references

### DIFF
--- a/src/physics/adv_mpdata.f90
+++ b/src/physics/adv_mpdata.f90
@@ -14,152 +14,162 @@ module adv_mpdata
     private
     real,dimension(:,:,:),allocatable::U_m,V_m,W_m
     integer :: order
-
+    
     public:: mpdata, mpdata_init
     public:: advect3d ! for test_mpdata testing only!
-
+    
 
 contains
 
     subroutine flux1(l,r,U,f)
     !     Calculate the donor cell flux function
-    !     l = left gridcell scalar
+    !     l = left gridcell scalar 
     !     r = right gridcell scalar
     !     U = Courant number (u*dt/dx)
-    !
+    !     
     !     If U is positive, return l*U if U is negative return r*U
-    !     By using the mathematical form instead of the logical form,
+    !     By using the mathematical form instead of the logical form, 
     !     we can run on the entire grid simultaneously, and avoid branches
 
     !   arguments
         implicit none
         real, dimension(:), intent(in) :: l,r,U
         real, dimension(:), intent(inout) :: f
-
+        
         !   main code
         f= ((U+ABS(U)) * l + (U-ABS(U)) * r)/2
 
     end subroutine flux1
-
-    subroutine upwind_advection(qin, u, v, w, q, dx,dz,nx,nz,ny,jaco)
+    
+    subroutine upwind_advection(qin, u, v, w, rho, q, dz, ims,ime,kms,kme,jms,jme,jaco)
         implicit none
-        real,dimension(1:nx,1:nz,1:ny),  intent(in) :: qin
-        real,dimension(1:nx-1,1:nz,1:ny),intent(in) :: u
-        real,dimension(1:nx,1:nz,1:ny-1),intent(in) :: v
-        real,dimension(1:nx,1:nz,1:ny),  intent(in) :: w
-        real,dimension(1:nx,1:nz,1:ny),  intent(inout) :: q
-        real,dimension(1:nx,1:nz,1:ny),  intent(in) :: jaco
-        real,dimension(1:nx,1:nz,1:ny),  intent(in) :: dz
-        integer, intent(in) :: ny,nz,nx
-        real, intent(in) :: dx
-
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in) :: qin
+        real, dimension(ims+1:ime,  kms:kme,jms:jme),  intent(in) :: u
+        real, dimension(ims:ime,  kms:kme,jms+1:jme),  intent(in) :: v
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in) :: w
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in) :: rho
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(inout) :: q
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in) :: jaco, dz
+        integer, intent(in) :: ims,ime,kms,kme,jms,jme
+        
         ! interal parameters
         integer :: i
-        real, dimension(1:nx-1,1:nz) :: f1 ! there used to be an f2 to store f[x+1]
-        real, dimension(1:nx-2,1:nz) :: f3,f4
-        real, dimension(1:nx-2,1:nz-1) ::f5
-        !$omp parallel shared(qin,q,u,v,w) firstprivate(nx,ny,nz) private(i,f1,f3,f4,f5)
-        !$omp do schedule(static)
-        do i=1,ny
+        real, dimension(ims:ime-1,kms:kme)    :: f1
+        real, dimension(ims:ime-2,kms:kme)    :: f3,f4
+        real, dimension(ims:ime-2,kms:kme-1)  :: f5
+        
+        ! !$omp parallel shared(qin,q,u,v,w) firstprivate(nx,ny,nz) private(i,f1,f3,f4,f5)
+        ! !$omp do schedule(static)
+        do i=jms,jme
             q(:,:,i)=qin(:,:,i)
         enddo
-        !$omp end do
-        !$omp barrier
-        !$omp do schedule(static)
-        do i=2,ny-1
+        
+        ! !$omp end do
+        ! !$omp barrier
+        ! !$omp do schedule(static)
+        do i=jms+1,jme-1
             ! by manually inlining the flux2 call we should remove extra array copies that the compiler doesn't remove.
             ! equivalent flux2 calls are left in for reference (commented) to restore recall that f1,f3,f4... arrays should be 3D : n x m x 1
-            ! calculate fluxes between grid cells
-            ! call flux2(qin(1:nx-1,:,i),     qin(2:nx,:,i),     u(1:nx-1,:,i),     nx-1,nz,  1,f1)  ! f1 = Ux0 and Ux1
-            ! call flux2(qin(2:nx-1,:,i),     qin(2:nx-1,:,i+1), v(2:nx-1,:,i),     nx-2,nz,  1,f3)  ! f3 = Vy1
-            ! call flux2(qin(2:nx-1,:,i-1),   qin(2:nx-1,:,i),   v(2:nx-1,:,i-1),   nx-2,nz,  1,f4)  ! f4 = Vy0
-            ! call flux2(qin(2:nx-1,1:nz-1,i),qin(2:nx-1,2:nz,i),w(2:nx-1,1:nz-1,i),nx-2,nz-1,1,f5)  ! f5 = Wz0 and Wz1
-            f1= ((u(1:nx-1,:,i)      + ABS(u(1:nx-1,:,i)))      * qin(1:nx-1,:,i)    + &
-                 (u(1:nx-1,:,i)      - ABS(u(1:nx-1,:,i)))      * qin(2:nx,:,i))     / 2
 
-            f3= ((v(2:nx-1,:,i)      + ABS(v(2:nx-1,:,i)))      * qin(2:nx-1,:,i)    + &
-                 (v(2:nx-1,:,i)      - ABS(v(2:nx-1,:,i)))      * qin(2:nx-1,:,i+1)) / 2
+            f1= ((u(ims+1:ime,:,i)      + ABS(u(ims+1:ime,:,i)))      * qin(ims:ime-1,:,i)    + &
+                 (u(ims+1:ime,:,i)      - ABS(u(ims+1:ime,:,i)))      * qin(ims+1:ime,:,i))     / 2
 
-            f4= ((v(2:nx-1,:,i-1)    + ABS(v(2:nx-1,:,i-1)))    * qin(2:nx-1,:,i-1)  + &
-                 (v(2:nx-1,:,i-1)    - ABS(v(2:nx-1,:,i-1)))    * qin(2:nx-1,:,i))   / 2
+            f3= ((v(ims+1:ime-1,:,i+1)      + ABS(v(ims+1:ime-1,:,i+1)))      * qin(ims+1:ime-1,:,i)  + &
+                 (v(ims+1:ime-1,:,i+1)      - ABS(v(ims+1:ime-1,:,i+1)))      * qin(ims+1:ime-1,:,i+1)) / 2
 
-            f5= ((w(2:nx-1,1:nz-1,i) + ABS(w(2:nx-1,1:nz-1,i))) * qin(2:nx-1,1:nz-1,i) + &
-                 (w(2:nx-1,1:nz-1,i) - ABS(w(2:nx-1,1:nz-1,i))) * qin(2:nx-1,2:nz,i))  / 2
+            f4= ((v(ims+1:ime-1,:,i)    + ABS(v(ims+1:ime-1,:,i)))    * qin(ims+1:ime-1,:,i-1) + &
+                (v(ims+1:ime-1,:,i)    - ABS(v(ims+1:ime-1,:,i)))    * qin(ims+1:ime-1,:,i))  / 2
 
-           ! if (options%parameters%advect_density) then
-           !     ! perform horizontal advection
-           !     q(2:nx-1,:,i)      = q(2:nx-1,:,i)      - ((f1(2:nx-1,:) - f1(1:nx-2,:)) + (f3 - f4)) &
-           !                          / rho(2:nx-1,:,i) / dz(2:nx-1,:,i)
-           !     ! then vertical
-           !     ! (order doesn't matter because fluxes f1-6 are calculated before applying them)
-           !     ! add fluxes to middle layers
-           !     q(2:nx-1,2:nz-1,i) = q(2:nx-1,2:nz-1,i) - (f5(:,2:nz-1) - f5(:,1:nz-2))                       &
-           !                          / rho(2:nx-1,2:nz-1,i) / dz(2:nx-1,2:nz-1,i)
-           !     ! add fluxes to bottom layer
-           !     q(2:nx-1,1,i)      = q(2:nx-1,1,i)      - f5(:,1)                                             &
-           !                          / rho(2:nx-1,1,i) / dz(2:nx-1,1,i)
-           !     ! add fluxes to top layer
-           !     q(2:nx-1,nz,i)     = q(2:nx-1,nz,i)     - (qin(2:nx-1,nz,i) * w(2:nx-1,nz,i)-f5(:,nz-1))      &
-           !                          / rho(2:nx-1,nz,i) / dz(2:nx-1,nz,i)
-           ! else
+            f5= ((w(ims+1:ime-1,kms:kme-1,i) + ABS(w(ims+1:ime-1,kms:kme-1,i))) * qin(ims+1:ime-1,kms:kme-1,i) + &
+                 (w(ims+1:ime-1,kms:kme-1,i) - ABS(w(ims+1:ime-1,kms:kme-1,i))) * qin(ims+1:ime-1,kms+1:kme,i))  / 2
+
+
                ! perform horizontal advection, from difference terms
-               q(2:nx-1,:,i)      = q(2:nx-1,:,i)       - ((f1(2:nx-1,:) - f1(1:nx-2,:)) + (f3 - f4)) /(dx*dz(2:nx-1,:,i)*jaco(2:nx-1,:,i))
+               q(ims+1:ime-1,:,i)      = q(ims+1:ime-1,:,i)       - ((f1(ims+1:ime-1,:) - f1(ims:ime-2,:)) + (f3 - f4)) &
+                                   / (jaco(ims+1:ime-1,:,i)*rho(ims+1:ime-1,:,i))                      
                ! then vertical (order doesn't matter because fluxes f1-6 are calculated before applying them)
                ! add fluxes to middle layers
-               q(2:nx-1,2:nz-1,i) = q(2:nx-1,2:nz-1,i)  - (f5(:,2:nz-1) - f5(:,1:nz-2)) / (dz(2:nx-1,2:nz-1,i)*jaco(2:nx-1,2:nz-1,i))
+               q(ims+1:ime-1,kms+1:kme-1,i) = q(ims+1:ime-1,kms+1:kme-1,i)  - (f5(:,kms+1:kme-1) - f5(:,kms:kme-2)) &
+                                   / (dz(ims+1:ime-1,kms+1:kme-1,i)*jaco(ims+1:ime-1,kms+1:kme-1,i)*rho(ims+1:ime-1,kms+1:kme-1,i))
                ! add fluxes to bottom layer
-               q(2:nx-1,1,i)      = q(2:nx-1,1,i)       - f5(:,1) / (dz(2:nx-1,1,i)*jaco(2:nx-1,1,i))
+               q(ims+1:ime-1,kms,i)      = q(ims+1:ime-1,kms,i)       - f5(:,kms) &
+                                   / (dz(ims+1:ime-1,kms,i)*jaco(ims+1:ime-1,kms,i) * rho(ims+1:ime-1,kms,i) )
                ! add fluxes to top layer
-               q(2:nx-1,nz,i)     = q(2:nx-1,nz,i)      - (qin(2:nx-1,nz,i) * w(2:nx-1,nz,i) - f5(:,nz-1)) / (dz(2:nx-1,nz,i)*jaco(2:nx-1,nz,i))
-           ! endif
-        enddo
-        !$omp end do
-        !$omp end parallel
+               q(ims+1:ime-1,kme,i)     = q(ims+1:ime-1,kme,i)     - (qin(ims+1:ime-1,kme,i) * w(ims+1:ime-1,kme,i) - f5(:,kme-1)) &
+                                   / (dz(ims+1:ime-1,kme,i)*jaco(ims+1:ime-1,kme,i)*rho(ims+1:ime-1,kme,i))
 
+        enddo
+        ! !$omp end do
+        ! !$omp end parallel
+        
     end subroutine upwind_advection
 
-    subroutine mpdata_fluxes(q,u,v,w,u2,v2,w2, nx,nz,ny)
+    subroutine mpdata_fluxes(q,u,v,w,u2,v2,w2, ims,ime,kms,kme,jms,jme,G)
         implicit none
-        real, dimension(nx,nz,ny),   intent(in) :: q,w
-        real, dimension(nx-1,nz,ny), intent(in) :: u
-        real, dimension(nx,nz,ny-1), intent(in) :: v
-        real, dimension(nx-1,nz,ny), intent(out) :: u2
-        real, dimension(nx,nz,ny-1), intent(out) :: v2
-        real, dimension(nx,nz,ny),   intent(out) :: w2
-        integer, intent(in) :: nx,ny,nz
-
-        real, dimension(nx-1) :: rx, lx, denomx
-        real, dimension(nx) :: r, l, denom
+        real, dimension(ims:ime,kms:kme,jms:jme),   intent(in) :: q,w
+        real, dimension(ims+1:ime,kms:kme,jms:jme), intent(in) :: u
+        real, dimension(ims:ime,kms:kme,jms+1:jme), intent(in) :: v
+        real, dimension(ims+1:ime,kms:kme,jms:jme), intent(out) :: u2
+        real, dimension(ims:ime,kms:kme,jms+1:jme), intent(out) :: v2
+        real, dimension(ims:ime,kms:kme,jms:jme),   intent(out) :: w2
+        real, dimension(ims:ime,kms:kme,jms:jme),   intent(in) :: G  ! Notation kept from SMOLARKIEWICZ AND MARGOLIN 1998
+        integer, intent(in) :: ims, ime, kms, kme, jms, jme
+        
+        real, dimension(ims+1:ime) :: rx, lx, denomx
+        real, dimension(ims:ime) :: r, l, denom, edge_v, edge_q
         integer :: i, j
-
-        ! This might run faster if tiled over x and y to be more cache friendly.
-        !$omp parallel shared(q,u,v,w,u2,v2,w2) firstprivate(nx,ny,nz) &
-        !$omp private(i,j, rx,lx,r,l, denomx,denom)
-        !$omp do schedule(static)
-        do i=1,ny
-            do j=1,nz
+        
+        u2 = 0
+        v2 = 0
+        w2 = 0
+        ! This might run faster if tiled over x and y to be more cache friendly. 
+        ! !$omp parallel shared(q,u,v,w,u2,v2,w2) firstprivate(nx,ny,nz) &
+        ! !$omp private(i,j, rx,lx,r,l, denomx,denom)
+        ! !$omp do schedule(static)
+        do i=jms,jme
+            do j=kms,kme
                 ! -----------------------
                 ! First compute the U component
                 ! -----------------------
-                if ((i>1).and.(i<ny)) then
-                    rx=q(2:nx,j,i)
-                    lx=q(1:nx-1,j,i)
+                if (i > 0) then !((i>jms).and.(i<jme)) then
+                    rx=q(ims+1:ime,j,i)
+                    lx=q(ims:ime-1,j,i)
                     ! In MPDATA papers (r-l)/(r+l) is usually refered to as "A"
                     ! compute the denomenator first so we can check that it is not zero
-                    denomx=(rx + lx)
-                    where(denomx==0) denomx=1e-10
+                    denomx=(rx + lx + 1e-10)
+                    !where(denomx==0) denomx=1e-10
                     ! U2 is the diffusive pseudo-velocity
-                    u2(:,j,i) = abs(u(:,j,i)) - u(:,j,i)**2
+                    u2(:,j,i) = abs(u(:,j,i))*(1-abs(u(:,j,i))/(0.5* ( G(ims+1:ime,j,i) + G(ims:ime-1,j,i) )))
                     u2(:,j,i) = u2(:,j,i) * (rx-lx) / denomx
-                else
-                    u2(:,j,i)=0
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    ! UxV terms
+                    if ( (i > jms) .and. (i < jme) ) then
+                        edge_q(ims+1:ime) = (q(ims+1:ime,j,i+1) - q(ims+1:ime,j,i-1) + &
+                             q(ims:ime-1,j,i+1) - q(ims:ime-1,j,i-1)) / &
+                            (q(ims+1:ime,j,i+1) + q(ims+1:ime,j,i-1) + &
+                             q(ims:ime-1,j,i+1) + q(ims:ime-1,j,i-1)+ 1e-10)
+                        edge_v(ims+1:ime) = (1/4.0)*(v(ims+1:ime,j,i) + v(ims+1:ime,j,i+1) + v(ims:ime-1,j,i) + v(ims:ime-1,j,i+1))
+                        u2(:,j,i) = u2(:,j,i) - 0.5*u(:,j,i)*edge_v(ims+1:ime)*edge_q(ims+1:ime)/( G(ims+1:ime,j,i) + G(ims:ime-1,j,i) )
+                    endif
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    ! UxW terms
+                    if ( (j > kms) .and. (j < kme) ) then
+                        edge_q(ims+1:ime) = (q(ims+1:ime,j+1,i) - q(ims+1:ime,j-1,i) + &
+                             q(ims:ime-1,j+1,i) - q(ims:ime-1,j-1,i)) / &
+                            (q(ims+1:ime,j+1,i) + q(ims+1:ime,j-1,i) + &
+                             q(ims:ime-1,j+1,i) + q(ims:ime-1,j-1,i)+ 1e-10)
+                        edge_v(ims+1:ime) = (1/4.0)*(w(ims+1:ime,j,i) + w(ims+1:ime,j-1,i) + w(ims:ime-1,j,i) + w(ims:ime-1,j-1,i))
+                        u2(:,j,i) = u2(:,j,i) - 0.5*u(:,j,i)*edge_v(ims+1:ime)*edge_q(ims+1:ime)/( G(ims+1:ime,j,i) + G(ims:ime-1,j,i) )
+                    endif
                 endif
-
+                
 
                 ! next compute the V and W components
-                if (i==1) then
-                    w2(:,j,i)=0
-                else
+                if (i>jms) then
                     ! -----------------------
                     ! compute the V component
                     ! -----------------------
@@ -167,40 +177,81 @@ contains
                     l=q(:,j,i-1)
                     ! In MPDATA papers A = (r-l)/(r+l)
                     ! compute the denomenator first so we can check that it is not zero
-                    denom=(r + l)
-                    where(denom==0) denom=1e-10
+                    denom=(r + l + 1e-10)
+                    !where(denom==0) denom=1e-10
                     ! U2 is the diffusive pseudo-velocity
-                    v2(:,j,i-1) = abs(v(:,j,i-1)) - v(:,j,i-1)**2
-                    v2(:,j,i-1) = v2(:,j,i-1) * (r-l) / denom
-
-
-                    ! -----------------------
-                    ! compute the w component
-                    ! -----------------------
-                    if (i==ny) then
-                        w2(:,j,i)=0
-                    else
-                        if (j<nz) then
-                            r=q(:,j+1,i)
-                            l=q(:,j,i)
-                            ! In MPDATA papers A = (r-l)/(r+l)
-                            ! compute the denomenator first so we can check that it is not zero
-                            denom=(r + l)
-                            where(denom==0) denom=1e-10
-                            ! U2 is the diffusive pseudo-velocity
-                            w2(:,j,i) = abs(w(:,j,i)) - w(:,j,i)**2
-                            w2(:,j,i) = w2(:,j,i) * (r-l) / denom
-                        else
-                            w2(:,j,i) = 0
-                        endif
+                    v2(:,j,i) = abs(v(:,j,i))*(1-abs(v(:,j,i))/(0.5* ( G(:,j,i) + G(:,j,i-1) )))
+                    v2(:,j,i) = v2(:,j,i) * (r-l) / denom
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    !VxU terms
+                    edge_q(ims+1:ime-1) = (q(ims+2:ime,j,i-1) - q(ims:ime-2,j,i) + &
+                             q(ims+2:ime,j,i) - q(ims:ime-2,j,i-1)) / &
+                            (q(ims+2:ime,j,i) + q(ims+2:ime,j,i-1) + &
+                             q(ims:ime-2,j,i) + q(ims:ime-2,j,i-1)+ 1e-10)
+                    edge_v(ims+1:ime-1) = (1/4.0)* &
+                                        (u(ims+2:ime,j,i) + u(ims+2:ime,j,i-1) + u(ims+1:ime-1,j,i) + u(ims+1:ime-1,j,i-1))
+                    v2(:,j,i) = v2(:,j,i) - 0.5*v(:,j,i)*edge_v*edge_q/( G(:,j,i) + G(:,j,i-1) )
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    ! VxW terms
+                    if ( (j > kms) .and. (j < kme) ) then
+                        edge_q = (q(:,j+1,i-1) - q(:,j-1,i) + &
+                             q(:,j+1,i) - q(:,j-1,i-1)) / &
+                            (q(:,j+1,i-1) + q(:,j-1,i) + &
+                             q(:,j+1,i) + q(:,j-1,i-1)+ 1e-10)
+                        edge_v = (1/4.0)*(w(:,j,i) + w(:,j-1,i) + w(:,j,i-1) + w(:,j-1,i-1))
+                        v2(:,j,i) = v2(:,j,i) - 0.5*v(:,j,i)*edge_v*edge_q/( G(:,j,i) + G(:,j,i-1) )
                     endif
-
+                endif
+                
+                
+                ! -----------------------
+                ! compute the w component
+                ! -----------------------
+                if (j==kme) then
+                    w2(:,j,i)=0
+                else
+                    r=q(:,j+1,i)
+                    l=q(:,j,i)
+                    ! In MPDATA papers A = (r-l)/(r+l)
+                    ! compute the denomenator first so we can check that it is not zero
+                    denom=(r + l + 1e-10)
+                    !where(denom==0) denom=1e-10
+                    ! U2 is the diffusive pseudo-velocity
+                    w2(:,j,i) = abs(w(:,j,i))*(1-abs(w(:,j,i))/(0.5* ( G(:,j+1,i) + G(:,j,i) )))
+                    w2(:,j,i) = w2(:,j,i) * (r-l) / denom
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    !WxU terms
+                    edge_q(ims+1:ime-1) = (q(ims+2:ime,j+1,i) - q(ims:ime-2,j,i) + &
+                             q(ims+2:ime,j,i) - q(ims:ime-2,j+1,i)) / &
+                            (q(ims+2:ime,j,i) + q(ims+2:ime,j+1,i) + &
+                             q(ims:ime-2,j,i) + q(ims:ime-2,j+1,i)+ 1e-10)
+                    edge_v(ims+1:ime-1) = (1/4.0)* &
+                                        (u(ims+2:ime,j,i) + u(ims+2:ime,j+1,i) + u(ims+1:ime-1,j,i) + u(ims+1:ime-1,j+1,i))
+                    w2(:,j,i) = w2(:,j,i) - 0.5*w(:,j,i)*edge_v*edge_q/( G(:,j+1,i) + G(:,j,i) )
+                    
+                    edge_v = 0
+                    edge_q = 0
+                    ! WxV terms
+                    if ( (i > jms) .and. (i < jme) ) then
+                        edge_q = (q(:,j+1,i+1) - q(:,j,i-1) + &
+                             q(:,j,i+1) - q(:,j+1,i-1)) / &
+                            (q(:,j,i+1) + q(:,j+1,i-1) + &
+                             q(:,j+1,i+1) + q(:,j,i-1)+ 1e-10)
+                        edge_v = (1/4.0)*(v(:,j,i) + v(:,j+1,i) + v(:,j,i+1) + v(:,j+1,i+1))
+                        w2(:,j,i) = w2(:,j,i) - 0.5*w(:,j,i)*edge_v*edge_q/( G(:,j+1,i) + G(:,j,i) )
+                    endif
                 endif
             end do
         end do
-        !$omp end do
-        !$omp end parallel
-
+        ! !$omp end do
+        ! !$omp end parallel
+        
     end subroutine mpdata_fluxes
 
     subroutine flux_limiter(q, q2, u,v,w, nx,nz,ny)
@@ -210,7 +261,7 @@ contains
         real,dimension(1:nx,1:nz,1:ny-1),intent(inout) :: v
         real,dimension(1:nx,1:nz,1:ny),  intent(inout) :: w
         integer, intent(in) :: nx,nz,ny
-
+        
         integer :: i,j,k,n
         real, dimension(:), pointer :: q1, U2, l, f
         ! q1 = q after applying previous iteration advection
@@ -224,12 +275,12 @@ contains
         real, dimension(nz),   target :: q1z,lz
         real, dimension(nz-1), target :: fz, U2z
         logical :: flux_is_w
-
+        
         real :: qmax_i,qmin_i,qmax_i2,qmin_i2
         real :: beta_in_i, beta_out_i, beta_in_i2, beta_out_i2
         real :: fin_i, fout_i, fin_i2, fout_i2
-
-        ! NOTE: before inclusion of FCT_core the following variables must be setup:
+        
+        ! NOTE: before inclusion of FCT_core the following variables must be setup: 
         ! q1 and l (l=q0)
         !$omp parallel shared(q2,q,u,v,w) firstprivate(nx,ny,nz) default(private)
         !$omp do schedule(static)
@@ -246,11 +297,11 @@ contains
                 U2=u(:,k,j)
                 l =q(:,k,j)
                 call flux1(q1(1:n-1),q1(2:n),U2,f)
-
+                
                 include "adv_mpdata_FCT_core.f90"
                 u(:,k,j)=U2
             end do
-
+            
             n=nz
             q1=>q1z
             l =>lz
@@ -268,10 +319,10 @@ contains
                 w(k,1:n-1,j)=U2
                 w(k,n,j)=0
             end do
-
+            
         end do
         !$omp end do
-
+        
         flux_is_w=.False.
         n=ny
         q1=>q1y
@@ -289,99 +340,126 @@ contains
                 U2=v(j,k,:)
                 l =q(j,k,:)
                 call flux1(q1(1:n-1),q1(2:n),U2,f)
-
+                
                 include "adv_mpdata_FCT_core.f90"
                 v(j,k,:)=U2
             end do
         end do
         !$omp end do
         !$omp end parallel
-
+        
     end subroutine flux_limiter
 
-    subroutine advect3d(q,u,v,w,rho,dz,dx,nx,nz,ny,jaco,options,err)
+    subroutine advect3d(q,rho,ims,ime,kms,kme,jms,jme,jaco,dz,options)
         implicit none
-        real,dimension(1:nx,1:nz,1:ny), intent(inout) :: q
-        real,dimension(1:nx-1,1:nz,1:ny),intent(in) :: u
-        real,dimension(1:nx,1:nz,1:ny-1),intent(in) :: v
-        real,dimension(1:nx,1:nz,1:ny), intent(in) :: w
-        real,dimension(1:nx,1:nz,1:ny), intent(in) :: rho
-        real,dimension(1:nx,1:nz,1:ny), intent(in) :: dz
-        integer, intent(in) :: ny,nz,nx
-        real,dimension(1:nx,1:nz,1:ny), intent(in) :: jaco
+        real,dimension(ims:ime,kms:kme,jms:jme), intent(inout) :: q
+        real,dimension(ims:ime,kms:kme,jms:jme), intent(in) :: rho
+        integer, intent(in) :: ims,ime,kms,kme,jms,jme
+        real,dimension(ims:ime,kms:kme,jms:jme), intent(in) :: jaco,dz
         type(options_t), intent(in)::options
-        integer, intent(inout) :: err
-        real, intent(in) :: dx
 
         ! used for intermediate values in the mpdata calculation
-        real,dimension(1:nx,1:nz,1:ny)   :: q2
-        real,dimension(1:nx-1,1:nz,1:ny) :: u2
-        real,dimension(1:nx,1:nz,1:ny-1) :: v2
-        real,dimension(1:nx,1:nz,1:ny)   :: w2
-
+        real,dimension(ims:ime,kms:kme,jms:jme)   :: q2
+        real,dimension(ims+1:ime,kms:kme,jms:jme) :: u2
+        real,dimension(ims:ime,kms:kme,jms+1:jme) :: v2
+        real,dimension(ims:ime,kms:kme,jms:jme)   :: w2
+        
         integer :: iord, i
-
+                
         do iord=1,options%adv_options%mpdata_order
             if (iord==1) then
-                call upwind_advection(q, u, v, w, q2, dx,dz,nx,nz,ny,jaco)
+                call upwind_advection(q, U_m, V_m, W_m, rho, q2,dz,ims,ime,kms,kme,jms,jme,jaco)
             else
-                call mpdata_fluxes(q2, u, v, w, u2,v2,w2, nx,nz,ny)
-                if (this_image()==100) write(*,*) maxval(u2)
-                if ( (sum(abs(u2))+sum(abs(v2))+sum(abs(w2)) < 0.01)) write(*,*) "no ADV corr--1"
-
-                if (options%adv_options%flux_corrected_transport) then
-                    call flux_limiter(q, q2, u2,v2,w2, nx,nz,ny)
-                endif
-                if ( (sum(abs(u2))+sum(abs(v2))+sum(abs(w2)) < 0.01)) write(*,*) "no ADV corr--2"
-                call upwind_advection(q2, u2, v2, w2, q, dx,dz,nx,nz,ny,jaco)
+                ! Due to an uneven vertical grid spacing, W_m is not normalized by dz, because this causes problems in
+                ! advection code. However, pseudo-velocity expects, all velocities normalized by time and dx/z
+                ! so do that here before passing to pseudo-velocity calculations
+                call mpdata_fluxes(q2, U_m, V_m, (W_m/dz), u2,v2,w2, ims,ime,kms,kme,jms,jme,(jaco*rho))
+                ! and un-normalize, since upwind advection scheme includes dz
+                ! Since pseudo-velocities cannot be gaurenteed to be non-divergent, we assume worst-case and multiply by 0.5 to
+                ! ensure stability (from Smolarkiewicz 1984, after Eq. 24)
+                call upwind_advection(q2, 0.5*u2, 0.5*v2, 0.5*(w2*dz), rho, q,dz,ims,ime,kms,kme,jms,jme,jaco)
             endif
-
-            !
+            
+            !  
             if (iord/=options%adv_options%mpdata_order) then
                 if (iord>1) then
-                    !$omp parallel shared(q,q2) firstprivate(ny) private(i)
-                    !$omp do schedule(static)
-                    do i=1,ny
+                    ! !$omp parallel shared(q,q2) firstprivate(ny) private(i)
+                    ! !$omp do schedule(static)
+                    do i=jms,jme
                         q2(:,:,i)=q(:,:,i)
                     enddo
-                    !$omp end do
-                    !$omp end parallel
+                    ! !$omp end do
+                    ! !$omp end parallel
                 endif
-            else
+            else 
                 if (iord==1) then
-                    !$omp parallel shared(q,q2) firstprivate(ny) private(i)
-                    !$omp do schedule(static)
-                    do i=1,ny
+                    ! !$omp parallel shared(q,q2) firstprivate(ny) private(i)
+                    ! !$omp do schedule(static)
+                    do i=jms,jme
                         q(:,:,i)=q2(:,:,i)
                     enddo
-                    !$omp end do
-                    !$omp end parallel
+                    ! !$omp end do
+                    ! !$omp end parallel
                 endif
-
+                
             endif
         end do
-
+        
 
     end subroutine advect3d
-
+    
     subroutine mpdata_init(domain,options)
         type(domain_t), intent(in) :: domain
         type(options_t), intent(in) :: options
-
+        
         ! originally used to permit the order of dimensions in advection to be rotated
         order    = 0
     end subroutine mpdata_init
+    
+    
+    subroutine test_divergence(dz, ims, ime, kms, kme, jms, jme)
+        implicit none
+        real, intent(in) :: dz(ims:ime,kms:kme,jms:jme)
+        integer, intent(in) :: ims, ime, jms, jme, kms, kme
 
+        real, allocatable :: du(:,:), dv(:,:), dw(:,:)
+        integer :: i,j,k
+
+        allocate(du(ims+1:ime-1,jms+1:jme-1))
+        allocate(dv(ims+1:ime-1,jms+1:jme-1))
+        allocate(dw(ims+1:ime-1,jms+1:jme-1))
+
+        do i=ims+1,ime-1
+            do j=jms+1,jme-1
+                do k=kms,kme
+                    du(i,j) = (U_m(i+1,k,j)-U_m(i,k,j))
+                    dv(i,j) = (V_m(i,k,j+1)-V_m(i,k,j))
+                    if (k==kms) then
+                        dw(i,j) = (W_m(i,k,j))/dz(i,k,j)
+                    else
+                        dw(i,j) = (W_m(i,k,j)-W_m(i,k-1,j))/dz(i,k,j)
+                    endif
+                    if (abs(du(i,j) + dv(i,j) + dw(i,j)) > 1e-3) then
+                        print*, this_image(), i,k,j , abs(du(i,j) + dv(i,j) + dw(i,j))
+                        print*, "Winds are not balanced on entry to advect"
+                        !error stop
+                    endif
+                enddo
+            enddo
+        enddo
+
+    end subroutine test_divergence
+    
 !   primary entry point, advect all scalars in domain
     subroutine mpdata(domain,options,dt)
         implicit none
         type(domain_t),intent(inout)::domain
         type(options_t), intent(in)::options
         real,intent(in)::dt
-
+        
+        real, allocatable, dimension(:,:,:)   :: rho
         real::dx
-        integer::nx,nz,ny,i, error
-        integer :: ims, ime, jms, jme, kms, kme
+        integer :: i, ims, ime, jms, jme, kms, kme
 
         ims = domain%grid%ims
         ime = domain%grid%ime
@@ -391,9 +469,6 @@ contains
         kme = domain%grid%kme
 
         dx=domain%dx
-        nx = domain%grid%nx
-        nz = domain%grid%nz
-        ny = domain%grid%ny
 
         if (.not.allocated(domain%advection_dz)) then
             allocate(domain%advection_dz(ims:ime,kms:kme,jms:jme))
@@ -401,45 +476,41 @@ contains
                 domain%advection_dz(:,i,:) = options%parameters%dz_levels(i)
             enddo
         endif
-
+        
 !       if this if the first time we are called, we need to allocate the module level arrays
         if (.not.allocated(U_m)) then
-            allocate(U_m(nx-1,nz,ny))
-            allocate(V_m(nx,nz,ny-1))
-            allocate(W_m(nx,nz,ny))
+            allocate(U_m     (ims+1:ime,kms:kme,jms:jme  ))
+            allocate(V_m     (ims:ime,  kms:kme,jms+1:jme))
+            allocate(W_m     (ims:ime,  kms:kme,jms:jme  ))
+        endif
+        
+        allocate(rho(ims:ime,  kms:kme,jms:jme  ))
+        rho = 1
+        if (options%parameters%advect_density) rho = domain%density%data_3d
+        
+        U_m = domain%u%data_3d(ims+1:ime,:,:) * dt * (rho(ims+1:ime,:,:)+rho(ims:ime-1,:,:))*0.5 * &
+                    domain%jacobian_u(ims+1:ime,:,:) / dx
+        V_m = domain%v%data_3d(:,:,jms+1:jme) * dt * (rho(:,:,jms+1:jme)+rho(:,:,jms:jme-1))*0.5 * &
+                    domain%jacobian_v(:,:,jms+1:jme) / dx
+        W_m(:,kms:kme-1,:) = domain%w%data_3d(:,kms:kme-1,:) * dt * domain%jacobian_w(:,kms:kme-1,:) * &
+                    (rho(:,kms+1:kme,:)+rho(:,kms:kme-1,:)) * 0.5
+        W_m(:,kme,:) = domain%w%data_3d(:,kme,:) * dt * domain%jacobian_w(:,kme,:) * rho(:,kme,:)
+
+        if (options%parameters%debug) then
+            call test_divergence(domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme)
         endif
 
-!       calculate U,V,W normalized for dt/dx
-        !if (options%advect_density) then
-        !    U_m=domain%ur(2:nx,:,:)*(dt/dx**2)
-        !    V_m=domain%vr(:,:,2:ny)*(dt/dx**2)
-!           note, even though dz!=dx, W is computed from the divergence in U/V so it is scaled by dx/dz already
-        !    W_m=domain%wr*(dt/dx**2)
-        !else
-            U_m = domain%u%data_3d(ims+1:ime,:,:) * ((domain%advection_dz(ims:ime-1,:,:)+domain%advection_dz(ims+1:ime,:,:))/2 * dt) * domain%jacobian_u(ims+1:ime,:,:)
-            V_m = domain%v%data_3d(:,:,jms+1:jme) * ((domain%advection_dz(:,:,jms:jme-1)+domain%advection_dz(:,:,jms+1:jme))/2 * dt) * domain%jacobian_v(:,:,jms+1:jme)
-            W_m = domain%w%data_3d * dt
-            !Because Jacobian is defined on mass-grid, need to make assumption about first level (ground)
-            W_m(:,kms,:) = W_m(:,kms,:) * domain%jacobian(:,kms,:)
-            W_m(:,kms+1:kme,:) = W_m(:,kms+1:kme,:) * (domain%jacobian(:,kms:kme-1,:) + domain%jacobian(:,kms+1:kme,:))/2
-        !endif
-
-        error=0
-
-        if (options%vars_to_advect(kVARS%water_vapor)>0)                  call advect3d(domain%water_vapor%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%cloud_water)>0)                  call advect3d(domain%cloud_water_mass%data_3d,        U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%rain_in_air)>0)                  call advect3d(domain%rain_mass%data_3d,               U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%snow_in_air)>0)                  call advect3d(domain%snow_mass%data_3d,               U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%potential_temperature)>0)        call advect3d(domain%potential_temperature%data_3d,   U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%cloud_ice)>0)                    call advect3d(domain%cloud_ice_mass%data_3d,          U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%graupel_in_air)>0)               call advect3d(domain%graupel_mass%data_3d,            U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%ice_number_concentration)>0)     call advect3d(domain%cloud_ice_number%data_3d,        U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%rain_number_concentration)>0)    call advect3d(domain%rain_number%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%snow_number_concentration)>0)    call advect3d(domain%snow_number%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-        if (options%vars_to_advect(kVARS%graupel_number_concentration)>0) call advect3d(domain%graupel_number%data_3d,          U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options,error)
-
-
-        order=mod(order+1,3)
+        if (options%vars_to_advect(kVARS%water_vapor)>0)                  call advect3d(domain%water_vapor%data_3d,             rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%cloud_water)>0)                  call advect3d(domain%cloud_water_mass%data_3d,        rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%rain_in_air)>0)                  call advect3d(domain%rain_mass%data_3d,               rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%snow_in_air)>0)                  call advect3d(domain%snow_mass%data_3d,               rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%potential_temperature)>0)        call advect3d(domain%potential_temperature%data_3d,   rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%cloud_ice)>0)                    call advect3d(domain%cloud_ice_mass%data_3d,          rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%graupel_in_air)>0)               call advect3d(domain%graupel_mass%data_3d,            rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%ice_number_concentration)>0)     call advect3d(domain%cloud_ice_number%data_3d,        rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%rain_number_concentration)>0)    call advect3d(domain%rain_number%data_3d,             rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%snow_number_concentration)>0)    call advect3d(domain%snow_number%data_3d,             rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
+        if (options%vars_to_advect(kVARS%graupel_number_concentration)>0) call advect3d(domain%graupel_number%data_3d,          rho, ims, ime, kms, kme, jms, jme, domain%jacobian, domain%advection_dz, options)
 
     end subroutine mpdata
 end module adv_mpdata

--- a/src/physics/adv_mpdata_FCT_core.f90
+++ b/src/physics/adv_mpdata_FCT_core.f90
@@ -9,7 +9,7 @@
 !
 ! It is stored in a separate file so that the same code can
 ! be used for advect_u, advect_v, and advect_w after l, r, etc. are set up
-!
+! 
 !     ! First Calculate the standard upwind advection
 !     call flux1(l,r,U2,f)
 !
@@ -40,14 +40,14 @@
 
 ! Fluxes are added to the original scalar field in the advect_u and advect_v subroutines
 
-! This is the Flux Corrected Transport option described in :
+! This is the Flux Corrected Transport option described in : 
 ! Smolarkiewicz and Grabowski (1990) J. of Comp. Phys. v86 p355-375
 
-! for now at least this is in a loop instead of vectorized.  I'm not sure how easy this would be to vectorize.
-    do i=1,n-1
+! for now at least this is in a loop instead of vectorized.  I'm not sure how easy this would be to vectorize. 
+    do i=n_s,n-1
         ! first find the min and max values allowable in the final field based on the initial (stored in l) and upwind (q1) fields
         ! min and max are taken from the grid cells on either side of the flux cell wall to be corrected
-        if (i==1) then
+        if (i==n_s) then
             ! l still equals q0
             qmax_i=max(q1(i),q1(i+1),l(i),l(i+1))
             qmin_i=min(q1(i),q1(i+1),l(i),l(i+1))
@@ -66,10 +66,10 @@
             qmax_i2=max(q1(i),q1(i+1),l(i))
             qmin_i2=min(q1(i),q1(i+1),l(i))
         endif
-
+        
         ! next compute the total fluxes into and out of the upwind and downwind cells
         ! these are the fluxes into and out of the "left-hand" cell (which is just the previous "right-hand" cell)
-        if (i/=1) then
+        if (i/=n_s) then
             fin_i  = fin_i2
             fout_i = fout_i2
         else
@@ -81,9 +81,9 @@
                 fin_i  = 0
                 fout_i = 0
             endif
-
+                
         endif
-
+        
         ! these are the fluxes into and out of the "right-hand" cell
         if (i/=(n-1)) then
             fin_i2 = max(0.,f(i)) - min(0.,f(i+1))
@@ -98,19 +98,20 @@
                 fout_i2 = 0
             endif
         endif
-
+        
         ! if wind is left to right we limit based on flow out of the left cell and into the right cell
         if (U2(i)>0) then
             beta_out_i = (q1(i)-qmin_i) / (fout_i+1e-15)
             beta_in_i2 = (qmax_i2-q1(i+1)) / (fin_i2+1e-15)
-
+            
             U2(i) = min(1.,beta_in_i2, beta_out_i) * U2(i)
-
+            
         ! if wind is right to left we limit based on flow out of the right cell and into the left cell
         elseif (U2(i)<0) then
             beta_in_i = (qmax_i-q1(i)) / (fin_i+1e-15)
             beta_out_i2 = (q1(i+1)-qmin_i2) / (fout_i2+1e-15)
-
+            
             U2(i) = min(1.,beta_in_i, beta_out_i2) * U2(i)
         endif
     end do
+    

--- a/src/physics/advect.f90
+++ b/src/physics/advect.f90
@@ -27,11 +27,14 @@ contains
         type(domain_t), intent(in) :: domain
         type(options_t),intent(in) :: options
 
-        integer :: nx, nz, ny
+        integer :: ims, ime, jms, jme, kms, kme
 
-        nx = domain%grid%nx
-        nz = domain%grid%nz
-        ny = domain%grid%ny
+        ims = domain%grid%ims
+        ime = domain%grid%ime
+        jms = domain%grid%jms
+        jme = domain%grid%jme
+        kms = domain%grid%kms
+        kme = domain%grid%kme
 
         ! if module level arrays are already allocated for some reason, deallocate them first
         if (allocated(U_m)) deallocate(U_m)
@@ -40,10 +43,10 @@ contains
         if (allocated(lastqv_m)) deallocate(lastqv_m)
 
         ! allocate the module level arrays
-        allocate(U_m     (nx-1,nz,ny  ))
-        allocate(V_m     (nx,  nz,ny-1))
-        allocate(W_m     (nx,  nz,ny  ))
-        allocate(lastqv_m(nx,  nz,ny  ))
+        allocate(U_m     (ims+1:ime,kms:kme,jms:jme  ))
+        allocate(V_m     (ims:ime,  kms:kme,jms+1:jme))
+        allocate(W_m     (ims:ime,  kms:kme,jms:jme  ))
+        allocate(lastqv_m(ims:ime,  kms:kme,jms:jme  ))
 
         !     if (.not.allocated(U_4cu_u)) then
         !         allocate(U_4cu_u(nx,  nz, ny))
@@ -100,37 +103,40 @@ contains
 !
 !     end subroutine flux2
 
-    subroutine advect3d(q,u,v,w,rho,dz,dx,nx,nz,ny,jaco,options)
+    subroutine advect3d(q,rho_in,dz,ims,ime,kms,kme,jms,jme,jaco,options)
+
         implicit none
-        real, dimension(1:nx,  1:nz,1:ny),  intent(inout)   :: q
-        real, dimension(1:nx,  1:nz,1:ny),  intent(in)      :: w
-        real, dimension(1:nx-1,1:nz,1:ny),  intent(in)      :: u
-        real, dimension(1:nx,  1:nz,1:ny-1),intent(in)      :: v
-        real, dimension(:, :, :),           intent(in)      :: rho
-        real, dimension(:, :, :),           intent(in)      :: dz
-        real,                               intent(in)      :: dx
-        integer,                            intent(in)      :: ny, nz, nx
-        real, dimension(:, :, :),           intent(in)      :: jaco
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(inout)   :: q
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in)      :: rho_in
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in)      :: dz
+        integer,                            intent(in)      :: ims, ime, kms, kme, jms, jme
+        real, dimension(ims:ime,  kms:kme,jms:jme),  intent(in)      :: jaco
         type(options_t), intent(in)::options
 
         ! interal parameters
         integer                         :: err, i, j, k
-        real, dimension(1:nx,1:nz,1:ny) :: qin
-        real, dimension(1:nx-1,1:nz)    :: f1   ! historical note, there used to be an f2 to store f[x+1]
-        real, dimension(1:nx-2,1:nz)    :: f3,f4
-        real, dimension(1:nx-2,1:nz-1)  :: f5
-
-        ! Multiply dz by jacobian so that all advection terms will be divided by mass-centered jacobian
-
-        !$omp parallel shared(qin,q,u,v,w,rho,dz,jaco) firstprivate(nx,ny,nz) private(i,f1,f3,f4,f5)
-        !$omp do schedule(static)
-        do i=1,ny
+        real, dimension(ims:ime-1,kms:kme)    :: f1   ! historical note, there used to be an f2 to store f[x+1]
+        real, dimension(ims:ime-2,kms:kme)    :: f3,f4
+        real, dimension(ims:ime-2,kms:kme-1)  :: f5
+        real, dimension(ims:ime,kms:kme,jms:jme) :: qin, rho
+        
+        rho = 1
+        
+        do i=jms,jme
             qin(:,:,i)=q(:,:,i)
         enddo
-        !$omp end do
-        !$omp barrier
-        !$omp do schedule(static)
-        do i=2,ny-1
+        
+        if (options%parameters%advect_density) rho = rho_in
+        
+        
+        ! !$omp parallel shared(qin,q,u,v,w,rho,dz,jaco) firstprivate(ims,ime,kms,kme,jms,jme) private(i,f1,f3,f4,f5)
+        ! !$omp do schedule(static)
+
+
+        ! !$omp end do
+        ! !$omp barrier
+        ! !$omp do schedule(static)
+        do i=jms+1,jme-1
             ! by manually inlining the flux2 call we should remove extra array copies that the compiler doesn't remove.
             ! equivalent flux2 calls are left in for reference (commented) to restore recall that f1,f3,f4... arrays should be 3D : n x m x 1
             ! calculate fluxes between grid cells
@@ -138,47 +144,37 @@ contains
             ! call flux2(qin(2:nx-1,:,i),     qin(2:nx-1,:,i+1), v(2:nx-1,:,i),     nx-2,nz,  1,f3)  ! f3 = Vy1
             ! call flux2(qin(2:nx-1,:,i-1),   qin(2:nx-1,:,i),   v(2:nx-1,:,i-1),   nx-2,nz,  1,f4)  ! f4 = Vy0
             ! call flux2(qin(2:nx-1,1:nz-1,i),qin(2:nx-1,2:nz,i),w(2:nx-1,1:nz-1,i),nx-2,nz-1,1,f5)  ! f5 = Wz0 and Wz1
-            f1= ((u(1:nx-1,:,i)      + ABS(u(1:nx-1,:,i)))      * qin(1:nx-1,:,i)    + &
-                 (u(1:nx-1,:,i)      - ABS(u(1:nx-1,:,i)))      * qin(2:nx,:,i))     / 2
+            f1= ((U_m(ims+1:ime,:,i)      + ABS(U_m(ims+1:ime,:,i)))      * qin(ims:ime-1,:,i)    + &
+                 (U_m(ims+1:ime,:,i)      - ABS(U_m(ims+1:ime,:,i)))      * qin(ims+1:ime,:,i))     / 2
 
-            f3= ((v(2:nx-1,:,i)      + ABS(v(2:nx-1,:,i)))      * qin(2:nx-1,:,i)    + &
-                 (v(2:nx-1,:,i)      - ABS(v(2:nx-1,:,i)))      * qin(2:nx-1,:,i+1)) / 2
+            f3= ((V_m(ims+1:ime-1,:,i+1)      + ABS(V_m(ims+1:ime-1,:,i+1)))      * qin(ims+1:ime-1,:,i)  + &
+                 (V_m(ims+1:ime-1,:,i+1)      - ABS(V_m(ims+1:ime-1,:,i+1)))      * qin(ims+1:ime-1,:,i+1)) / 2
 
-            f4= ((v(2:nx-1,:,i-1)    + ABS(v(2:nx-1,:,i-1)))    * qin(2:nx-1,:,i-1)  + &
-                 (v(2:nx-1,:,i-1)    - ABS(v(2:nx-1,:,i-1)))    * qin(2:nx-1,:,i))   / 2
+            f4= ((V_m(ims+1:ime-1,:,i)    + ABS(V_m(ims+1:ime-1,:,i)))    * qin(ims+1:ime-1,:,i-1) + &
+                (V_m(ims+1:ime-1,:,i)    - ABS(V_m(ims+1:ime-1,:,i)))    * qin(ims+1:ime-1,:,i))  / 2
 
-            f5= ((w(2:nx-1,1:nz-1,i) + ABS(w(2:nx-1,1:nz-1,i))) * qin(2:nx-1,1:nz-1,i) + &
-                 (w(2:nx-1,1:nz-1,i) - ABS(w(2:nx-1,1:nz-1,i))) * qin(2:nx-1,2:nz,i))  / 2
+            f5= ((W_m(ims+1:ime-1,kms:kme-1,i) + ABS(W_m(ims+1:ime-1,kms:kme-1,i))) * qin(ims+1:ime-1,kms:kme-1,i) + &
+                 (W_m(ims+1:ime-1,kms:kme-1,i) - ABS(W_m(ims+1:ime-1,kms:kme-1,i))) * qin(ims+1:ime-1,kms+1:kme,i))  / 2
 
-           ! if (options%parameters%advect_density) then
-           !     ! perform horizontal advection
-           !     q(2:nx-1,:,i)      = q(2:nx-1,:,i)      - ((f1(2:nx-1,:) - f1(1:nx-2,:)) + (f3 - f4)) &
-           !                          / rho(2:nx-1,:,i) / dz(2:nx-1,:,i)
-           !     ! then vertical
-           !     ! (order doesn't matter because fluxes f1-6 are calculated before applying them)
-           !     ! add fluxes to middle layers
-           !     q(2:nx-1,2:nz-1,i) = q(2:nx-1,2:nz-1,i) - (f5(:,2:nz-1) - f5(:,1:nz-2))                       &
-           !                          / rho(2:nx-1,2:nz-1,i) / dz(2:nx-1,2:nz-1,i)
-           !     ! add fluxes to bottom layer
-           !     q(2:nx-1,1,i)      = q(2:nx-1,1,i)      - f5(:,1)                                             &
-           !                          / rho(2:nx-1,1,i) / dz(2:nx-1,1,i)
-           !     ! add fluxes to top layer
-           !     q(2:nx-1,nz,i)     = q(2:nx-1,nz,i)     - (qin(2:nx-1,nz,i) * w(2:nx-1,nz,i)-f5(:,nz-1))      &
-           !                          / rho(2:nx-1,nz,i) / dz(2:nx-1,nz,i)
-           ! else
+                
                ! perform horizontal advection, from difference terms
-               q(2:nx-1,:,i)      = q(2:nx-1,:,i)       - ((f1(2:nx-1,:) - f1(1:nx-2,:)) + (f3 - f4)) /(dx*dz(2:nx-1,:,i)*jaco(2:nx-1,:,i))
+               q(ims+1:ime-1,:,i)      = q(ims+1:ime-1,:,i)       - ((f1(ims+1:ime-1,:) - f1(ims:ime-2,:)) + (f3 - f4)) &
+                                   / (jaco(ims+1:ime-1,:,i)*rho(ims+1:ime-1,:,i))                      
                ! then vertical (order doesn't matter because fluxes f1-6 are calculated before applying them)
                ! add fluxes to middle layers
-               q(2:nx-1,2:nz-1,i) = q(2:nx-1,2:nz-1,i)  - (f5(:,2:nz-1) - f5(:,1:nz-2)) / (dz(2:nx-1,2:nz-1,i)*jaco(2:nx-1,2:nz-1,i))
+               q(ims+1:ime-1,kms+1:kme-1,i) = q(ims+1:ime-1,kms+1:kme-1,i)  - (f5(:,kms+1:kme-1) - f5(:,kms:kme-2)) &
+                                   / (dz(ims+1:ime-1,kms+1:kme-1,i)*jaco(ims+1:ime-1,kms+1:kme-1,i)*rho(ims+1:ime-1,kms+1:kme-1,i))
                ! add fluxes to bottom layer
-               q(2:nx-1,1,i)      = q(2:nx-1,1,i)       - f5(:,1) / (dz(2:nx-1,1,i)*jaco(2:nx-1,1,i))
+               q(ims+1:ime-1,kms,i)      = q(ims+1:ime-1,kms,i)       - f5(:,kms) &
+                                   / (dz(ims+1:ime-1,kms,i)*jaco(ims+1:ime-1,kms,i) * rho(ims+1:ime-1,kms,i) )
                ! add fluxes to top layer
-               q(2:nx-1,nz,i)     = q(2:nx-1,nz,i)      - (qin(2:nx-1,nz,i) * w(2:nx-1,nz,i) - f5(:,nz-1)) / (dz(2:nx-1,nz,i)*jaco(2:nx-1,nz,i))
-           ! endif
+               q(ims+1:ime-1,kme,i)     = q(ims+1:ime-1,kme,i)     - (qin(ims+1:ime-1,kme,i) * W_m(ims+1:ime-1,kme,i) - f5(:,kme-1)) &
+                                   / (dz(ims+1:ime-1,kme,i)*jaco(ims+1:ime-1,kme,i)*rho(ims+1:ime-1,kme,i))
+
+
         enddo
-        !$omp end do
-        !$omp end parallel
+        ! !$omp end do
+        ! !$omp end parallel
     end subroutine advect3d
 
     ! subroutine setup_cu_winds(domain, options, dt)
@@ -274,37 +270,30 @@ contains
     ! end subroutine advect_cu_winds
 
 
-    subroutine test_divergence(u, v, w, dz, dx, jaco_u, jaco_v, jaco_w, ims, ime, jms, jme, kms, kme)
+    subroutine test_divergence(dz, ims, ime, kms, kme, jms, jme)
         implicit none
-        real, intent(in) :: u(ims:ime+1,kms:kme,jms:jme), jaco_u(ims:ime+1,kms:kme,jms:jme)
-        real, intent(in) :: v(ims:ime,kms:kme,jms:jme+1), jaco_v(ims:ime,kms:kme,jms:jme+1)
-        real, intent(in) :: w(ims:ime,kms:kme,jms:jme), jaco_w(ims:ime,kms:kme,jms:jme)
         real, intent(in) :: dz(ims:ime,kms:kme,jms:jme)
-        real, intent(in) :: dx
         integer, intent(in) :: ims, ime, jms, jme, kms, kme
 
-        real, allocatable :: du(:,:), dv(:,:), dzu(:,:,:), dzv(:,:,:)
+        real, allocatable :: du(:,:), dv(:,:), dw(:,:)
         integer :: i,j,k
 
         allocate(du(ims+1:ime-1,jms+1:jme-1))
         allocate(dv(ims+1:ime-1,jms+1:jme-1))
-        allocate(dzv(ims:ime,kms:kme,jms:jme))
-        allocate(dzu(ims:ime,kms:kme,jms:jme))
-
-        dzv = 0
-        dzu = 0
-
-        dzv(:,:,jms+1:jme) = (dz(:,:,jms+1:jme) + dz(:,:,jms:jme-1)) / 2
-        dzu(ims+1:ime,:,:) = (dz(ims+1:ime,:,:) + dz(ims:ime-1,:,:)) / 2
+        allocate(dw(ims+1:ime-1,jms+1:jme-1))
 
         do i=ims+1,ime-1
             do j=jms+1,jme-1
-                do k=kms+1,kme
-                    dv(i,j) = (v(i,k,j+1) * jaco_v(i,k,j+1) - v(i,k,j) * jaco_v(i,k,j))/dx
-                    du(i,j) = (u(i+1,k,j) * jaco_u(i+1,k,j) - u(i,k,j) * jaco_u(i,k,j))/dx
-
-                    if (abs(du(i,j) + dv(i,j) + (w(i,k,j)*jaco_w(i,k,j)-w(i,k-1,j)*jaco_w(i,k-1,j))/(dz(i,k,j))) > 1e-3) then
-                        print*, this_image(), i,j,k , abs(du(i,j) + dv(i,j) + (w(i,k,j)*jaco_w(i,k,j)-w(i,k-1,j)*jaco_w(i,k-1,j))/(dz(i,k,j)))
+                do k=kms,kme
+                    du(i,j) = (U_m(i+1,k,j)-U_m(i,k,j))
+                    dv(i,j) = (V_m(i,k,j+1)-V_m(i,k,j))
+                    if (k==kms) then
+                        dw(i,j) = (W_m(i,k,j))/dz(i,k,j)
+                    else
+                        dw(i,j) = (W_m(i,k,j)-W_m(i,k-1,j))/dz(i,k,j)
+                    endif
+                    if (abs(du(i,j) + dv(i,j) + dw(i,j)) > 1e-3) then
+                        print*, this_image(), i,k,j , abs(du(i,j) + dv(i,j) + dw(i,j))
                         print*, "Winds are not balanced on entry to advect"
                         !error stop
                     endif
@@ -314,62 +303,57 @@ contains
 
     end subroutine test_divergence
 
-    subroutine setup_module_winds(u,v,w, dz, dx, options, dt,jaco,jaco_u,jaco_v, jaco_w)
+    subroutine setup_module_winds(u,v,w, dx, options, dt,jaco_u,jaco_v, jaco_w,rho_in,ims, ime, kms, kme, jms, jme)
         implicit none
-        real,               intent(in)  :: u(:,:,:)
-        real,               intent(in)  :: v(:,:,:)
-        real,               intent(in)  :: w(:,:,:)
-        real,               intent(in)  :: dz(:,:,:)
+        real,               intent(in)  :: u(ims:ime+1,kms:kme,jms:jme), v(ims:ime,kms:kme,jms:jme+1)
+        real,               intent(in)  :: w(ims:ime,kms:kme,jms:jme)
         real,               intent(in)  :: dx
         type(options_t),    intent(in)  :: options
         real,               intent(in)  :: dt
-        real,               intent(in)  :: jaco(:, :, :)
-        real,               intent(in)  :: jaco_u(:, :, :)
-        real,               intent(in)  :: jaco_v(:, :, :)
-        real,               intent(in)  :: jaco_w(:, :, :)
+        real,               intent(in)  :: jaco_u(ims:ime+1,kms:kme,jms:jme)
+        real,               intent(in)  :: jaco_v(ims:ime,kms:kme,jms:jme+1), jaco_w(ims:ime,kms:kme,jms:jme)
+        real,               intent(in)  :: rho_in(ims:ime,kms:kme,jms:jme)
+        integer, intent(in) :: ims, ime, jms, jme, kms, kme
 
-        integer :: nx, nz, ny, i
-
-        nx = size(w,1)
-        nz = size(w,2)
-        ny = size(w,3)
+        real, dimension(ims:ime,kms:kme,jms:jme) :: rho
+        integer :: i
+        
 
         ! if this if the first time we are called, we need to allocate the module level arrays
         ! Could/should be put in an init procedure
         if (.not.allocated(U_m)) then
-            allocate(U_m     (nx-1,nz,ny  ))
-            allocate(V_m     (nx,  nz,ny-1))
-            allocate(W_m     (nx,  nz,ny  ))
-            allocate(lastqv_m(nx,  nz,ny  ))
+            allocate(U_m     (ims+1:ime,kms:kme,jms:jme  ))
+            allocate(V_m     (ims:ime,  kms:kme,jms+1:jme))
+            allocate(W_m     (ims:ime,  kms:kme,jms:jme  ))
+            allocate(lastqv_m(ims:ime,  kms:kme,jms:jme  ))
         endif
+        
+        rho = 1
+        if (options%parameters%advect_density) rho = rho_in
 
-        ! calculate U,V,W normalized for dt/dx (dx**2 for density advection so we can skip a /dx in the actual advection code)
-        ! if (options%parameters%advect_density) then
-        !     U_m = domain%ur(2:nx,:,:) * (dt/dx**2)
-        !     V_m = domain%vr(:,:,2:ny) * (dt/dx**2)
-        !     W_m = domain%wr           * (dt/dx**2)
+        ! if (options%physics%convection > 0) then
+            ! print*, "Advection of convective winds not enabled in ICAR >=1.5 yet"
+            ! stop
+            ! U_m = (domain%u_cu(2:nx,:,:) + domain%u(2:nx,:,:)) * (dt/dx)
+            ! V_m = (domain%v_cu(:,:,2:ny) + domain%v(:,:,2:ny)) * (dt/dx)
+            ! W_m = (domain%w_cu + domain%w)                     * (dt/dx)
+            ! call rebalance_cu_winds(U_m,V_m,W_m)
         ! else
-            ! if (options%physics%convection > 0) then
-                ! print*, "Advection of convective winds not enabled in ICAR >=1.5 yet"
-                ! stop
-                ! U_m = (domain%u_cu(2:nx,:,:) + domain%u(2:nx,:,:)) * (dt/dx)
-                ! V_m = (domain%v_cu(:,:,2:ny) + domain%v(:,:,2:ny)) * (dt/dx)
-                ! W_m = (domain%w_cu + domain%w)                     * (dt/dx)
-                ! call rebalance_cu_winds(U_m,V_m,W_m)
-            ! else
-                U_m = u(2:nx,:,:) * ((dz(1:nx-1,:,:)+dz(2:nx,:,:))/2 * dt) * jaco_u(2:nx,:,:)
-                V_m = v(:,:,2:ny) * ((dz(:,:,1:ny-1)+dz(:,:,2:ny))/2 * dt) * jaco_v(:,:,2:ny)
-                W_m = w * dt * jaco_w
-            ! endif
-        ! endif
+             ! Divide only U and V by dx. This minimizes the number of operations per advection step. W cannot be divided by dz,
+             ! since non-uniform dz spacing does not allow for the same spacing to be assumed on either side of a k+1/2 interface,
+             ! as is required for the upwind scheme.
+             U_m = u(ims+1:ime,:,:) * dt * jaco_u(ims+1:ime,:,:) * (rho(ims+1:ime,:,:)+rho(ims:ime-1,:,:))*0.5 / dx
+             V_m = v(:,:,jms+1:jme) * dt * jaco_v(:,:,jms+1:jme) * (rho(:,:,jms+1:jme)+rho(:,:,jms:jme-1))*0.5 / dx
+             W_m(:,kms:kme-1,:) = w(:,kms:kme-1,:) * dt * jaco_w(:,kms:kme-1,:) * (rho(:,kms+1:kme,:)+rho(:,kms:kme-1,:))*0.5
+             W_m(:,kme,:) = w(:,kme,:) * dt * jaco_w(:,kme,:) * rho(:,kme,:)
+         ! endif
 
     end subroutine setup_module_winds
 
-    subroutine setup_advection_dz(domain, options, nx, ny, nz)
+    subroutine setup_advection_dz(domain, options)
         implicit none
         type(domain_t),  intent(inout) :: domain
         type(options_t), intent(in)    :: options
-        integer,         intent(in)    :: nx, ny, nz
         integer :: i, ims, ime, jms, jme, kms, kme
 
         ims = domain%grid%ims
@@ -385,13 +369,9 @@ contains
             return
         endif
 
-        if (options%parameters%fixed_dz_advection) then
-            do i=kms,kme
-                domain%advection_dz(:,i,:) = options%parameters%dz_levels(i)
-            enddo
-        else
-            domain%advection_dz = domain%dz_interface%data_3d
-        endif
+        do i=kms,kme
+            domain%advection_dz(:,i,:) = options%parameters%dz_levels(i)
+        enddo
 
     end subroutine setup_advection_dz
 
@@ -404,34 +384,30 @@ contains
         real,            intent(in)    :: dt
 
         real    :: dx
-        integer :: nx, nz, ny, i
+        integer :: i
 
-        nx = domain%grid%nx
-        nz = domain%grid%nz
-        ny = domain%grid%ny
-
-        call setup_advection_dz(domain, options, nx,ny,nz)
+        call setup_advection_dz(domain, options)
 
         ! calculate U,V,W normalized for dt/dx (dx**2 for density advection so we can skip a /dx in the actual advection code)
-        call setup_module_winds(domain%u%data_3d, domain%v%data_3d, domain%w%data_3d, domain%advection_dz, domain%dx, options, dt,domain%jacobian,domain%jacobian_u,domain%jacobian_v,domain%jacobian_w)
+        call setup_module_winds(domain%u%data_3d, domain%v%data_3d, domain%w%data_3d, domain%dx, options, dt,domain%jacobian_u,domain%jacobian_v,domain%jacobian_w,domain%density%data_3d, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme)
 
         ! lastqv_m=domain%qv
 
         if (options%parameters%debug) then
-            call test_divergence(domain%u%data_3d, domain%v%data_3d, domain%w%data_3d, domain%advection_dz, domain%dx, domain%jacobian_u, domain%jacobian_v, domain%jacobian_w, domain%ims, domain%ime, domain%jms, domain%jme, domain%kms, domain%kme)
+            call test_divergence(domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme)
         endif
 
-        if (options%vars_to_advect(kVARS%water_vapor)>0)                  call advect3d(domain%water_vapor%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%cloud_water)>0)                  call advect3d(domain%cloud_water_mass%data_3d,        U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%rain_in_air)>0)                  call advect3d(domain%rain_mass%data_3d,               U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%snow_in_air)>0)                  call advect3d(domain%snow_mass%data_3d,               U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%potential_temperature)>0)        call advect3d(domain%potential_temperature%data_3d,   U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%cloud_ice)>0)                    call advect3d(domain%cloud_ice_mass%data_3d,          U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%graupel_in_air)>0)               call advect3d(domain%graupel_mass%data_3d,            U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%ice_number_concentration)>0)     call advect3d(domain%cloud_ice_number%data_3d,        U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%rain_number_concentration)>0)    call advect3d(domain%rain_number%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%snow_number_concentration)>0)    call advect3d(domain%snow_number%data_3d,             U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
-        if (options%vars_to_advect(kVARS%graupel_number_concentration)>0) call advect3d(domain%graupel_number%data_3d,          U_m,V_m,W_m, domain%density%data_3d, domain%advection_dz, domain%dx, nx,nz,ny, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%water_vapor)>0)                  call advect3d(domain%water_vapor%data_3d,             domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%cloud_water)>0)                  call advect3d(domain%cloud_water_mass%data_3d,        domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%rain_in_air)>0)                  call advect3d(domain%rain_mass%data_3d,               domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%snow_in_air)>0)                  call advect3d(domain%snow_mass%data_3d,               domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%potential_temperature)>0)        call advect3d(domain%potential_temperature%data_3d,   domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%cloud_ice)>0)                    call advect3d(domain%cloud_ice_mass%data_3d,          domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%graupel_in_air)>0)               call advect3d(domain%graupel_mass%data_3d,            domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%ice_number_concentration)>0)     call advect3d(domain%cloud_ice_number%data_3d,        domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%rain_number_concentration)>0)    call advect3d(domain%rain_number%data_3d,             domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%snow_number_concentration)>0)    call advect3d(domain%snow_number%data_3d,             domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
+        if (options%vars_to_advect(kVARS%graupel_number_concentration)>0) call advect3d(domain%graupel_number%data_3d,          domain%density%data_3d, domain%advection_dz, domain%ims, domain%ime, domain%kms, domain%kme, domain%jms, domain%jme, domain%jacobian, options)
 
         ! if (options%physics%convection > 0) then
         !     call advect_cu_winds(domain, options, dt)


### PR DESCRIPTION
TYPE: No impact (refactoring)

KEYWORDS: Advection, coordinate-transform, refactoring

SOURCE: Dylan Reynolds, SLF

DESCRIPTION OF CHANGES: As requested by Ethan, ensured that references to jacobian of coordinate transform are minimized throughout the code, and that the check in advection of winds is guaranteed the same as what is used in the actual advection. The indexing of arrays in the advection code has also been changed to image-scope indexing (ims:ime, etc) to be consistent with rest of v2 code.
