### PR TITLE
bugfix: adding NETCDFF variable in makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -106,9 +106,15 @@ ifndef NETCDF
 		NETCDF=${NETCDF_DIR}
 	endif
 endif
+
 NCDF_PATH = ${NETCDF}
 LIBNETCDF = -L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
 INCNETCDF = -I$(NCDF_PATH)/include
+
+ifdef NETCDFF
+       LIBNETCDF += -L$(NETCDFF)/lib
+       INCNETCDF += -I$(NETCDFF)/include
+endif
 
 USE_ASSERTIONS:=.false.
 


### PR DESCRIPTION

TYPE: bugfix

KEYWORDS: NetCDF, makefile, library paths

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Some installations of NetCDF has different locations for the C library and the Fortran library. If the environmental variable NETCDFF is defined, that path will also be searched when building.

TESTS CONDUCTED: Built and ran full test domain on NERSC's Cori in parallel.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
