### PR TITLE
 flat model height <0 is now possible with SLEVE

### DIFF
--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -936,17 +936,18 @@ contains
             zr_u                  => this%zr_u,                           &
             zr_v                  => this%zr_v)
 
-            ! Still not 100% convinced this works well in cases other than flat_z_height = 0 (w sleve). So for now best to keep at 0 when using sleve?
+            
             max_level = find_flat_model_level(options, nz, dz)
 
-            if(max_level /= nz) then
-                if (this_image()==1) then
-                    print*, "    flat z height ", options%parameters%flat_z_height
-                    print*, "    flat z height set to 0 to comply with SLEVE coordinate calculation "
-                    print*, "    flat z height now", nz
-                end if
-                max_level = nz
-            end if
+            ! Still not 100% convinced this works well in cases other than flat_z_height = 0 (w sleve). So for now best to keep at 0 when using sleve?
+            ! if(max_level /= nz) then
+            !     if (this_image()==1) then
+            !         print*, "    flat z height ", options%parameters%flat_z_height
+            !         print*, "    flat z height set to 0 to comply with SLEVE coordinate calculation "
+            !         print*, "    flat z height now", nz
+            !     end if
+            !     max_level = nz
+            ! end if
 
             smooth_height = sum(dz(1:max_level)) !sum(global_terrain) / size(global_terrain) + sum(dz(1:max_level))
 


### PR DESCRIPTION
flat model height <0 is now possible with SLEVE again (this was accidentally turned off in commit  d5a70131d374932b555a7e44f0785e4a06af5f4e )


TYPE: bug fix
bug fix of earlier 'error' in pr 108, where setting flat dz != 0 was overwritten to flat_dz_height=0 (with output warnings)

SOURCE: Bert Kruyt, NCAR

DESCRIPTION OF CHANGES: 
See lines 942-950 in domain_obj, commented out lines that forced max_level to be equal to nz.

