### PR TITLE
Fix for potential temperature & relative humidity forcing combination

### DIFF
--- a/src/objects/boundary_obj.f90
+++ b/src/objects/boundary_obj.f90
@@ -570,7 +570,12 @@ contains
             qvar%data_3d = qvar%data_3d/100.0
         endif
 
-        qvar%data_3d = rh_to_mr(qvar%data_3d, tvar%data_3d, pvar%data_3d)
+        if (options%parameters%t_is_potential) then
+            qvar%data_3d = rh_to_mr(qvar%data_3d, tvar%data_3d * exner_function(pvar%data_3d), pvar%data_3d)
+        else
+            qvar%data_3d = rh_to_mr(qvar%data_3d, tvar%data_3d, pvar%data_3d)
+        endif
+
 
     end subroutine compute_mixing_ratio_from_rh
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: forcing, computed variables, relative humidity

SOURCE: Ethan Gutmann, NCAR

DESCRIPTION OF CHANGES: 
Fix a problem that occurs if forcing data are provided with relative humidity and potential temperature.  Previously ICAR would not convert potential temperature to real temperature before computing water vapor mixing ratio from relative humidity.  This lead to some crazy results, not it checks what the form of temperature is before calculating humidity. 

ISSUE: none

TESTS CONDUCTED: 
Ideal test case was run before and after change and output mixing ratios make sense now. 

### Checklist

 - [X] Backwards compatible
