### PR TITLE
BMJ and NSAS convection

### DIFF
--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -22,6 +22,7 @@
     ! fixed_dz_advection = .True.
 
     ! Use a SLEVE vertical coordinate, where the decay of the large- and small-scale terrain influence towards model top is controlled by the decay_rate_L_topo and decay_rate_S_topo respectively (=H/s1 and H/s2), and the exponential factor n that controls compression across the z column. For higher n values, the terrain compression happens more in the mid to upper z levels (but always below flat_z_height), whereas for n=1 it is mainly at the lower levels, which may cause numerical issues if these are very thin. By setting s1=s2 a standard hybrid coordinate is obtained.
+    ! For many atmospheric applications it appears optimal to choose s1 ~10 km and, subsequently, to minimize s2     for a specified value of gamma > 0"
 
     sleve = .True.
     terrain_smooth_windowsize = 4    ! Terrain is smoothed to obtain the large-scale terrain features
@@ -94,7 +95,7 @@
     water=2,  ! 1=use prescribed (w/lsm=1) 2=Simple sea surface fluxes
     mp  = 1,  ! 1=Thompson                 2=Simple (SB04)              3=Morrison                  4=WSM6      5=Thompson-Eidhammer
     rad = 0,  ! 1=use prescribed fluxes    2=Simple (empirical)         3=RRTMG
-    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch
+    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch (N/A)        4=NSAS      5=BMJ
     adv = 1,  ! 1=Upwind                   2=MPDATA                     3=Adams-Bashforth (wishlist)
     wind= 1   ! 1=Linear Theory
 /
@@ -380,8 +381,8 @@
 !   Optionally specified convection parameters
 !---------------------------------------------------------
 &cu_parameters
-    stochastic_cu = 0
-    tendency_fraction = 1.0
+    stochastic_cu = 0            ! disturbes the W field (randomly; higher value=more disturbance). Triggers convection (?)
+    tendency_fraction = 1.0      ! scales the q[v/c/i]/th fractions (relative to 1). Lower values lead to more cu_precip(?)
     tend_qv_fraction = 1.0
     tend_qc_fraction = 1.0
     tend_th_fraction = 1.0

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -22,7 +22,6 @@
     ! fixed_dz_advection = .True.
 
     ! Use a SLEVE vertical coordinate, where the decay of the large- and small-scale terrain influence towards model top is controlled by the decay_rate_L_topo and decay_rate_S_topo respectively (=H/s1 and H/s2), and the exponential factor n that controls compression across the z column. For higher n values, the terrain compression happens more in the mid to upper z levels (but always below flat_z_height), whereas for n=1 it is mainly at the lower levels, which may cause numerical issues if these are very thin. By setting s1=s2 a standard hybrid coordinate is obtained.
-    ! For many atmospheric applications it appears optimal to choose s1 ~10 km and, subsequently, to minimize s2     for a specified value of gamma > 0"
 
     sleve = .True.
     terrain_smooth_windowsize = 4    ! Terrain is smoothed to obtain the large-scale terrain features
@@ -95,7 +94,7 @@
     water=2,  ! 1=use prescribed (w/lsm=1) 2=Simple sea surface fluxes
     mp  = 1,  ! 1=Thompson                 2=Simple (SB04)              3=Morrison                  4=WSM6      5=Thompson-Eidhammer
     rad = 0,  ! 1=use prescribed fluxes    2=Simple (empirical)         3=RRTMG
-    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch (N/A)        4=NSAS      5=BMJ
+    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch
     adv = 1,  ! 1=Upwind                   2=MPDATA                     3=Adams-Bashforth (wishlist)
     wind= 1   ! 1=Linear Theory
 /
@@ -381,8 +380,8 @@
 !   Optionally specified convection parameters
 !---------------------------------------------------------
 &cu_parameters
-    stochastic_cu = 0            ! disturbes the W field (randomly; higher value=more disturbance). Triggers convection (?)
-    tendency_fraction = 1.0      ! scales the q[v/c/i]/th fractions (relative to 1). Lower values lead to more cu_precip(?)
+    stochastic_cu = 0
+    tendency_fraction = 1.0
     tend_qv_fraction = 1.0
     tend_qc_fraction = 1.0
     tend_th_fraction = 1.0

--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -21,7 +21,11 @@
 
     ! fixed_dz_advection = .True.
 
-    ! Use a SLEVE vertical coordinate, where the decay of the large- and small-scale terrain influence towards model top is controlled by the decay_rate_L_topo and decay_rate_S_topo respectively (=H/s1 and H/s2), and the exponential factor n that controls compression across the z column. For higher n values, the terrain compression happens more in the mid to upper z levels (but always below flat_z_height), whereas for n=1 it is mainly at the lower levels, which may cause numerical issues if these are very thin. By setting s1=s2 a standard hybrid coordinate is obtained.
+    ! Use a SLEVE vertical coordinate, where the decay of the large- and small-scale terrain influence towards model top is controlled by the 
+    !   decay_rate_L_topo and decay_rate_S_topo respectively (=H/s1 and H/s2), and the exponential factor n that controls compression across the z column. 
+    !   For higher n values, the terrain compression happens more in the mid to upper z levels (but always below flat_z_height), 
+    !   whereas for n=1 it is mainly at the lower levels, which may cause numerical issues if these are very thin. By setting s1=s2 a standard hybrid coordinate is obtained.
+    !   For many atmospheric applications it appears optimal to choose s1 ~10 km and, subsequently, to minimize s2     for a specified value of gamma > 0"
 
     sleve = .True.
     terrain_smooth_windowsize = 4    ! Terrain is smoothed to obtain the large-scale terrain features
@@ -94,7 +98,7 @@
     water=2,  ! 1=use prescribed (w/lsm=1) 2=Simple sea surface fluxes
     mp  = 1,  ! 1=Thompson                 2=Simple (SB04)              3=Morrison                  4=WSM6      5=Thompson-Eidhammer
     rad = 0,  ! 1=use prescribed fluxes    2=Simple (empirical)         3=RRTMG
-    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch
+    conv= 0,  ! 1=Tiedke Scheme            2=Simple Scheme (wishlist)   3=Kain-Fritsch (N/A)        4=NSAS      5=BMJ
     adv = 1,  ! 1=Upwind                   2=MPDATA                     3=Adams-Bashforth (wishlist)
     wind= 1   ! 1=Linear Theory
 /
@@ -380,8 +384,8 @@
 !   Optionally specified convection parameters
 !---------------------------------------------------------
 &cu_parameters
-    stochastic_cu = 0
-    tendency_fraction = 1.0
+    stochastic_cu = 0            ! disturbes the W field (randomly; higher value=more disturbance). Triggers convection.
+    tendency_fraction = 1.0      ! scales the q[v/c/i]/th fractions (relative to 1). Lower values lead to more cu_precip.
     tend_qv_fraction = 1.0
     tend_qc_fraction = 1.0
     tend_th_fraction = 1.0

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -300,6 +300,7 @@ module icar_constants
     integer, parameter :: kCU_TIEDTKE    = 1
     integer, parameter :: kCU_SIMPLE     = 2
     integer, parameter :: kCU_KAINFR     = 3
+    integer, parameter :: kCU_NSAS       = 4
 
     integer, parameter :: kMP_THOMPSON   = 1
     integer, parameter :: kMP_SB04       = 2

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -301,7 +301,6 @@ module icar_constants
     integer, parameter :: kCU_SIMPLE     = 2
     integer, parameter :: kCU_KAINFR     = 3
     integer, parameter :: kCU_NSAS       = 4
-    integer, parameter :: kCU_BMJ        = 5
 
     integer, parameter :: kMP_THOMPSON   = 1
     integer, parameter :: kMP_SB04       = 2

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -301,6 +301,7 @@ module icar_constants
     integer, parameter :: kCU_SIMPLE     = 2
     integer, parameter :: kCU_KAINFR     = 3
     integer, parameter :: kCU_NSAS       = 4
+    integer, parameter :: kCU_BMJ        = 5
 
     integer, parameter :: kMP_THOMPSON   = 1
     integer, parameter :: kMP_SB04       = 2

--- a/src/constants/wrf_constants.f90
+++ b/src/constants/wrf_constants.f90
@@ -76,7 +76,7 @@
    ! REAL    , PARAMETER ::  SVP2=17.67
    ! REAL    , PARAMETER ::  SVP3=29.65
    ! REAL    , PARAMETER ::  SVPT0=273.15
-   REAL    , PARAMETER ::  EP_1=R_v/R_d-1.
+   ! REAL    , PARAMETER ::  EP_1=R_v/R_d-1.
    ! REAL    , PARAMETER ::  EP_2=R_d/R_v
    ! REAL    , PARAMETER ::  KARMAN=0.4
    REAL    , PARAMETER ::  EOMEG=7.2921E-5

--- a/src/constants/wrf_constants.f90
+++ b/src/constants/wrf_constants.f90
@@ -76,7 +76,7 @@
    ! REAL    , PARAMETER ::  SVP2=17.67
    ! REAL    , PARAMETER ::  SVP3=29.65
    ! REAL    , PARAMETER ::  SVPT0=273.15
-   ! REAL    , PARAMETER ::  EP_1=R_v/R_d-1.
+   REAL    , PARAMETER ::  EP_1=R_v/R_d-1.
    ! REAL    , PARAMETER ::  EP_2=R_d/R_v
    ! REAL    , PARAMETER ::  KARMAN=0.4
    REAL    , PARAMETER ::  EOMEG=7.2921E-5

--- a/src/makefile
+++ b/src/makefile
@@ -397,6 +397,7 @@ OBJS=	\
 		$(BUILD)mp_wsm6.o		\
 		$(BUILD)cu_driver.o			\
 		$(BUILD)cu_tiedtke.o		\
+		$(BUILD)cu_nsas.o		\
 		$(BUILD)advection_driver.o	\
 		$(BUILD)advect.o			\
 		$(BUILD)adv_mpdata.o                        \
@@ -539,7 +540,7 @@ caf_no_forcing_test: $(BUILD)test_caf_no_forcing.o							\
 					$(BUILD)pbl_driver.o     $(BUILD)pbl_simple.o		\
 					$(BUILD)mp_driver.o      $(BUILD)mp_simple.o		\
 					$(BUILD)mp_thompson.o	 $(BUILD)mp_thompson_aer.o   $(BUILD)mp_wsm6.o\
-					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o		\
+					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o		\
 					$(BUILD)advection_driver.o $(BUILD)geo_reader.o		\
 					$(BUILD)advect.o		 $(BUILD)data_structures.o	\
 					$(BUILD)vinterp.o		 $(BUILD)array_utilities.o	\
@@ -771,12 +772,14 @@ $(BUILD)mp_simple.o:$(PHYS)mp_simple.f90 $(BUILD)data_structures.o $(BUILD)optio
 ###################################################################
 #	Convection code
 ###################################################################
-$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o  \
+$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o $(BUILD)cu_nsas.o  \
 					$(BUILD)data_structures.o $(BUILD)icar_constants.o $(BUILD)domain_h.o
 
 $(BUILD)cu_tiedtke.o:$(PHYS)cu_tiedtke.f90
 
 $(BUILD)cu_kf.o:$(PHYS)cu_kf.f90
+
+$(BUILD)cu_nsas.o:$(PHYS)cu_nsas.f90
 
 ###################################################################
 #	Radiation code

--- a/src/makefile
+++ b/src/makefile
@@ -398,7 +398,6 @@ OBJS=	\
 		$(BUILD)cu_driver.o			\
 		$(BUILD)cu_tiedtke.o		\
 		$(BUILD)cu_nsas.o		\
-		$(BUILD)cu_bmj.o		\
 		$(BUILD)advection_driver.o	\
 		$(BUILD)advect.o			\
 		$(BUILD)adv_mpdata.o                        \
@@ -541,7 +540,7 @@ caf_no_forcing_test: $(BUILD)test_caf_no_forcing.o							\
 					$(BUILD)pbl_driver.o     $(BUILD)pbl_simple.o		\
 					$(BUILD)mp_driver.o      $(BUILD)mp_simple.o		\
 					$(BUILD)mp_thompson.o	 $(BUILD)mp_thompson_aer.o   $(BUILD)mp_wsm6.o\
-					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o	$(BUILD)cu_bmj.o			\
+					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o		\
 					$(BUILD)advection_driver.o $(BUILD)geo_reader.o		\
 					$(BUILD)advect.o		 $(BUILD)data_structures.o	\
 					$(BUILD)vinterp.o		 $(BUILD)array_utilities.o	\
@@ -773,7 +772,7 @@ $(BUILD)mp_simple.o:$(PHYS)mp_simple.f90 $(BUILD)data_structures.o $(BUILD)optio
 ###################################################################
 #	Convection code
 ###################################################################
-$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o $(BUILD)cu_nsas.o $(BUILD)cu_bmj.o  \
+$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o $(BUILD)cu_nsas.o  \
 					$(BUILD)data_structures.o $(BUILD)icar_constants.o $(BUILD)domain_h.o
 
 $(BUILD)cu_tiedtke.o:$(PHYS)cu_tiedtke.f90
@@ -781,8 +780,6 @@ $(BUILD)cu_tiedtke.o:$(PHYS)cu_tiedtke.f90
 $(BUILD)cu_kf.o:$(PHYS)cu_kf.f90
 
 $(BUILD)cu_nsas.o:$(PHYS)cu_nsas.f90
-
-$(BUILD)cu_bmj.o:$(PHYS)cu_bmj.f90
 
 ###################################################################
 #	Radiation code

--- a/src/makefile
+++ b/src/makefile
@@ -398,6 +398,7 @@ OBJS=	\
 		$(BUILD)cu_driver.o			\
 		$(BUILD)cu_tiedtke.o		\
 		$(BUILD)cu_nsas.o		\
+		$(BUILD)cu_bmj.o		\
 		$(BUILD)advection_driver.o	\
 		$(BUILD)advect.o			\
 		$(BUILD)adv_mpdata.o                        \
@@ -540,7 +541,7 @@ caf_no_forcing_test: $(BUILD)test_caf_no_forcing.o							\
 					$(BUILD)pbl_driver.o     $(BUILD)pbl_simple.o		\
 					$(BUILD)mp_driver.o      $(BUILD)mp_simple.o		\
 					$(BUILD)mp_thompson.o	 $(BUILD)mp_thompson_aer.o   $(BUILD)mp_wsm6.o\
-					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o		\
+					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o	$(BUILD)cu_bmj.o			\
 					$(BUILD)advection_driver.o $(BUILD)geo_reader.o		\
 					$(BUILD)advect.o		 $(BUILD)data_structures.o	\
 					$(BUILD)vinterp.o		 $(BUILD)array_utilities.o	\
@@ -772,7 +773,7 @@ $(BUILD)mp_simple.o:$(PHYS)mp_simple.f90 $(BUILD)data_structures.o $(BUILD)optio
 ###################################################################
 #	Convection code
 ###################################################################
-$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o $(BUILD)cu_nsas.o  \
+$(BUILD)cu_driver.o:$(PHYS)cu_driver.f90 $(BUILD)cu_tiedtke.o $(BUILD)cu_nsas.o $(BUILD)cu_bmj.o  \
 					$(BUILD)data_structures.o $(BUILD)icar_constants.o $(BUILD)domain_h.o
 
 $(BUILD)cu_tiedtke.o:$(PHYS)cu_tiedtke.f90
@@ -780,6 +781,8 @@ $(BUILD)cu_tiedtke.o:$(PHYS)cu_tiedtke.f90
 $(BUILD)cu_kf.o:$(PHYS)cu_kf.f90
 
 $(BUILD)cu_nsas.o:$(PHYS)cu_nsas.f90
+
+$(BUILD)cu_bmj.o:$(PHYS)cu_bmj.f90
 
 ###################################################################
 #	Radiation code

--- a/src/physics/cu_bmj.f90
+++ b/src/physics/cu_bmj.f90
@@ -1,0 +1,2194 @@
+!-----------------------------------------------------------------------
+!
+!WRF:MODEL_LAYER:PHYSICS
+!
+!-----------------------------------------------------------------------
+!
+    MODULE MODULE_CU_BMJ
+    !
+    !-----------------------------------------------------------------------
+            USE MODULE_MODEL_CONSTANTS
+    !-----------------------------------------------------------------------
+    !
+            REAL,PARAMETER ::                                                 &
+            &                  DSPC=-3000.                                     &
+            &                 ,DTTOP=0.,EFIFC=5.0,EFIMN=0.20,EFMNT=0.70        & 
+            &                 ,ELIWV=2.683E6,ENPLO=20000.,ENPUP=15000.         &
+            &                 ,EPSDN=1.05,EPSDT=0.                             &
+            &                 ,EPSNTP=.0001,EPSNTT=.0001,EPSPR=1.E-7           &
+            &                 ,EPSUP=1.00                                      &
+            &                 ,FR=1.00,FSL=0.85,FSS=0.85,GAM=0.5,PEPS=1./2.5   &
+            &                 ,FUP=0.,FCC=5.00,CRMN=0.14,CRMX=85.0             &
+            &                 ,PBM=13000.,PFRZ=15000.,PNO=1000.                &
+            &                 ,PONE=2500.,PQM=20000.                           &
+            &                 ,PSH=20000.,PSHU=45000.                          &
+            &                 ,RENDP=1./(ENPLO-ENPUP)                          &
+            &                 ,RHLSC=0.00,RHHSC=1.10                           &
+            &                 ,ROW=1.E3                                        &
+            &                 ,STABDF=0.90,STABDS=0.90                         &
+            &                 ,STABS=1.0,STRESH=1.10                           &
+            &                 ,DTSHAL=-1.0,TREL=2400.
+    !
+            REAL,PARAMETER :: DTtrigr=-0.0                                    &
+                            ,DTPtrigr=DTtrigr*PONE      !<-- Average parcel virtual temperature deficit over depth PONE.
+                                                        !<-- NOTE: CAPEtrigr is scaled by the cloud base temperature (see below)
+    !
+            REAL,PARAMETER :: DSPBFL=-3875.*FR                                &
+            &                 ,DSP0FL=-5875.*FR                                &
+            &                 ,DSPTFL=-1875.*FR                                &
+            &                 ,DSPBFS=-3875.                                   &
+            &                 ,DSP0FS=-5875.                                   &
+            &                 ,DSPTFS=-1875.
+    !
+            REAL,PARAMETER :: PL=2500.,PLQ=70000.,PH=105000.                  &
+            &                 ,THL=210.,THH=365.,THHQ=325.
+    !
+            INTEGER,PARAMETER :: ITB=76,JTB=134,ITBQ=152,JTBQ=440
+    !
+            INTEGER,PARAMETER :: ITREFI_MAX=3
+    !
+    !***  ARRAYS FOR LOOKUP TABLES
+    !
+            REAL,DIMENSION(ITB),PRIVATE,SAVE :: STHE,THE0
+            REAL,DIMENSION(JTB),PRIVATE,SAVE :: QS0,SQS
+            REAL,DIMENSION(ITBQ),PRIVATE,SAVE :: STHEQ,THE0Q
+            REAL,DIMENSION(ITB,JTB),PRIVATE,SAVE :: PTBL
+            REAL,DIMENSION(JTB,ITB),PRIVATE,SAVE :: TTBL
+            REAL,DIMENSION(JTBQ,ITBQ),PRIVATE,SAVE :: TTBLQ
+    
+    !***  SHARE COPIES FOR MODULE_BL_MYJPBL
+    !
+            REAL,DIMENSION(JTB) :: QS0_EXP,SQS_EXP
+            REAL,DIMENSION(ITB,JTB) :: PTBL_EXP
+    !
+            REAL,PARAMETER :: RDP=(ITB-1.)/(PH-PL),RDPQ=(ITBQ-1.)/(PH-PLQ)  &
+            &                 ,RDQ=ITB-1,RDTH=(JTB-1.)/(THH-THL)             &
+            &                 ,RDTHE=JTB-1.,RDTHEQ=JTBQ-1.                   &
+            &                 ,RSFCP=1./101300.
+    !
+            REAL,PARAMETER :: AVGEFI=(EFIMN+1.)*0.5
+    !
+    !-----------------------------------------------------------------------
+    !
+    CONTAINS
+    !
+    !-----------------------------------------------------------------------
+            SUBROUTINE BMJDRV(                                                &
+            &                  IDS,IDE,JDS,JDE,KDS,KDE                         &
+            &                 ,IMS,IME,JMS,JME,KMS,KME                         &
+            &                 ,ITS,ITE,JTS,JTE,KTS,KTE                         &
+            &                 ,DT,ITIMESTEP,STEPCU,CCLDFRA,CONVCLD             &
+            &                 ,RAINCV,PRATEC,CUTOP,CUBOT,KPBL                  &
+            &                 ,TH,T,QV,QCCONV,QICONV,BMJ_RAD_FEEDBACK          &
+            &                 ,PINT,PMID,PI,RHO,DZ8W                           &
+            &                 ,CP,R,ELWV,ELIV,G,TFRZ,D608                      &
+            &                 ,CLDEFI,LOWLYR,XLAND,CU_ACT_FLAG                 &
+                            ! optional
+            &                 ,RTHCUTEN,RQVCUTEN                               &
+            &                                                                  )
+    !-----------------------------------------------------------------------
+            IMPLICIT NONE
+    !-----------------------------------------------------------------------
+            INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE                     &
+            &                     ,IMS,IME,JMS,JME,KMS,KME                     & 
+            &                     ,ITS,ITE,JTS,JTE,KTS,KTE
+    !
+            INTEGER,INTENT(IN) :: ITIMESTEP,STEPCU
+    !
+            INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) :: KPBL,LOWLYR
+    !
+            REAL,INTENT(IN) :: CP,DT,ELIV,ELWV,G,R,TFRZ,D608
+    !
+            REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) :: XLAND
+    !
+            REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(IN) :: DZ8W        &
+            &                                                     ,PI,PINT     &
+            &                                                     ,PMID,QV     &
+            &                                                     ,RHO,T,TH
+    ! 
+            REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: CCLDFRA  &
+                                                                    ,QCCONV   &
+                                                                    ,QICONV
+    !
+            REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME)                           &
+            &    ,OPTIONAL                                                     &
+            &    ,INTENT(INOUT) ::                        RQVCUTEN,RTHCUTEN
+    ! 
+            REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: CLDEFI,RAINCV,   &
+                PRATEC,CONVCLD
+    !
+            REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(OUT) :: CUBOT,CUTOP
+    !
+            LOGICAL,INTENT(IN) :: bmj_rad_feedback
+            LOGICAL,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: CU_ACT_FLAG
+    
+    !
+    !-----------------------------------------------------------------------
+    !***
+    !***  LOCAL VARIABLES
+    !***
+    !-----------------------------------------------------------------------
+            INTEGER :: LBOT,LPBL,LTOP
+    !
+            REAL :: DTCNVC,LANDMASK,PCPCOL,PSFC,PTOP
+            REAL :: PAVG,PWCOL,DQCOL,DQCOLMIN
+            REAL :: CUMX,QCIS,RRP,PRRT,MCOL,MPVPR,FACTL
+            INTEGER :: BBOT,TTOP
+    ! 
+            REAL,DIMENSION(KTS:KTE) :: DPCOL,DQDT,DTDT,PCOL,QCOL,TCOL
+            REAL,DIMENSION(KTS:KTE) :: PVPR,JPR
+    !
+            INTEGER :: I,J,K,KFLIP,LMH
+    
+    !***  Begin debugging convection
+            REAL :: DELQ,DELT,PLYR
+            INTEGER :: IMD,JMD
+            LOGICAL :: PRINT_DIAG
+    !***  End debugging convection
+    !
+    !-----------------------------------------------------------------------
+    !*********************************************************************** 
+    !-----------------------------------------------------------------------
+    !
+    !***  PREPARE TO CALL BMJ CONVECTION SCHEME
+    !
+    !-----------------------------------------------------------------------
+    
+    !***  Begin debugging convection
+            IMD=(IMS+IME)/2
+            JMD=(JMS+JME)/2
+            PRINT_DIAG=.FALSE.
+    !***  End debugging convection
+    
+    !
+            DO J=JTS,JTE
+            DO I=ITS,ITE
+                CU_ACT_FLAG(I,J)=.TRUE.
+            ENDDO
+            ENDDO
+    
+    !
+            DTCNVC=DT*STEPCU
+    !
+            DO J=JTS,JTE  
+            DO I=ITS,ITE
+    !
+                DO K=KTS,KTE
+                DQDT(K)=0.
+                DTDT(K)=0.
+                JPR(K)=0.
+                PVPR(K)=0.
+                QCCONV(I,K,J)=0.
+                QICONV(I,K,J)=0.
+                CCLDFRA(I,K,J)=0.
+                ENDDO
+    !
+                DQCOL=0.
+                PWCOL=0.
+                PCPCOL=0.
+                DQCOLMIN=0.
+                RAINCV(I,J)=0.
+                PRATEC(I,J)=0.
+                CONVCLD(I,J)=0.
+                PSFC=PINT(I,LOWLYR(I,J),J)
+                PTOP=PINT(I,KTE+1,J)      ! KTE+1=KME
+    !
+    !***  CONVERT TO BMJ LAND MASK (1.0 FOR SEA; 0.0 FOR LAND)
+    !
+                LANDMASK=XLAND(I,J)-1.
+    !
+    !***  FILL 1-D VERTICAL ARRAYS 
+    !***  AND FLIP DIRECTION SINCE BMJ SCHEME 
+    !***  COUNTS DOWNWARD FROM THE DOMAIN'S TOP
+    !
+                DO K=KTS,KTE
+                KFLIP=KTE+1-K
+    !
+    !***  CONVERT FROM MIXING RATIO TO SPECIFIC HUMIDITY
+    !
+                QCOL(K)=MAX(EPSQ,QV(I,KFLIP,J)/(1.+QV(I,KFLIP,J)))
+                TCOL(K)=T(I,KFLIP,J)
+                PCOL(K)=PMID(I,KFLIP,J)
+    !           DPCOL(K)=PINT(I,KFLIP,J)-PINT(I,KFLIP+1,J)
+                DPCOL(K)=RHO(I,KFLIP,J)*G*DZ8W(I,KFLIP,J)
+                ENDDO
+    !
+    !***  LOWEST LAYER ABOVE GROUND MUST ALSO BE FLIPPED
+    !
+                LMH=KTE+1-LOWLYR(I,J)
+                LPBL=KTE+1-KPBL(I,J)
+    !-----------------------------------------------------------------------
+    !***
+    !***  CALL CONVECTION
+    !***
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+    !         PRINT_DIAG=.FALSE.
+    !         IF(I==IMD.AND.J==JMD)PRINT_DIAG=.TRUE.
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+                CALL BMJ(ITIMESTEP,I,J,DTCNVC,LMH,LANDMASK,CLDEFI(I,J)        &
+            &            ,DPCOL,PCOL,QCOL,TCOL,PSFC,PTOP                       &
+            &            ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                      &
+            &            ,PWCOL,DQCOL,DQCOLMIN                                 &
+            &            ,CP,R,ELWV,ELIV,G,TFRZ,D608                           &   
+            &            ,PRINT_DIAG                                           &   
+            &            ,IDS,IDE,JDS,JDE,KDS,KDE                              &     
+            &            ,IMS,IME,JMS,JME,KMS,KME                              &
+            &            ,ITS,ITE,JTS,JTE,KTS,KTE)
+    !-----------------------------------------------------------------------
+    ! 
+    !***  COMPUTE HEATING AND MOISTENING TENDENCIES
+    !
+                IF ( PRESENT( RTHCUTEN ) .AND. PRESENT( RQVCUTEN )) THEN
+                DO K=KTS,KTE
+                    KFLIP=KTE+1-K
+                    RTHCUTEN(I,K,J)=DTDT(KFLIP)/PI(I,K,J)
+    !
+    !***  CONVERT FROM SPECIFIC HUMIDTY BACK TO MIXING RATIO
+    !
+                    RQVCUTEN(I,K,J)=DQDT(KFLIP)/(1.-QCOL(KFLIP))**2
+                ENDDO
+                ENDIF
+    !
+    !***  ALL UNITS IN BMJ SCHEME ARE MKS, THUS CONVERT PRECIP FROM METERS
+    !***  TO MILLIMETERS PER STEP FOR OUTPUT.
+    !
+                RAINCV(I,J)=PCPCOL*1.E3/STEPCU
+                PRATEC(I,J)=PCPCOL*1.E3/(STEPCU * DT)
+    !
+    !***  CONVECTIVE CLOUD TOP AND BOTTOM FROM THIS CALL
+    !
+                CUTOP(I,J)=REAL(KTE+1-LTOP)
+                CUBOT(I,J)=REAL(KTE+1-LBOT)
+    !
+            IF ( bmj_rad_feedback ) THEN
+    !
+                IF (DQCOL.GT.DQCOLMIN) THEN
+    !
+    !***  CONVECTIVE CLOUD FRACTION: BASED ON SLINGO (1987) WITH A POISSON 
+    !***  VERTICAL PROFILE. PLEASE NOTE THAT THE BMJ PRECIPITATION RATE
+    !***  (PRATEC) HAS TO BE CONVERTED FROM MMS-1 TO MMDAY-1.
+    !
+                    TTOP=0
+                    BBOT=0
+                    PAVG=0.
+                    CUMX=0.
+                    MPVPR=0.
+                    FACTL=0.
+    !
+                    PRRT=(PRATEC(I,J)*86400.0)/CRMN
+                    RRP=0.8/(LOG(CRMX/CRMN))
+                    IF (PRRT<CRMX/CRMN) THEN
+                    CUMX=RRP*LOG(PRRT)
+                    ELSE
+                    CUMX=0.8
+                    ENDIF
+    !
+    !***  COMPUTE THE CONVECTIVE CLOUD FRACTION (CCLDFRA) AT EACH MODEL LEVEL.
+    !***  FOR N>=17 USE THE STERLING APPROXIMATION AS FOR N=17 IT GIVES A RELATIVE
+    !***  ERROR OF ~9.4x10E-8.
+    !
+                    TTOP=NINT(CUTOP(I,J))
+                    BBOT=NINT(CUBOT(I,J))
+                    PAVG=1./(PEPS*3.)**2
+                    DO K=KTS,KTE
+                    IF (K.GE.BBOT.AND.K.LE.TTOP) THEN
+                    JPR(K)=(1./PEPS)*((PMID(I,K,J)-PMID(I,TTOP,J))/(PMID(I,BBOT,J)-PMID(I,TTOP,J)))
+                    ELSE
+                    JPR(K)=0.0
+                    ENDIF
+                    ENDDO
+    !
+                    DO K=KTS,KTE
+                    PVPR(K)=0.
+                    ENDDO
+                    IF (JPR(BBOT).LT.17) THEN
+                    DO K=BBOT,TTOP
+                    PVPR(K)=(PAVG)**(JPR(K))/GAMMA(JPR(K)+1.)
+                    ENDDO 
+                    ELSE
+                    DO K=BBOT,TTOP
+                    FACTL=JPR(K)*LOG(JPR(K))-JPR(K)+1./2.*LOG(2.*JPR(K)*ACOS(-1.))+ &
+                            LOG(1.+1./(12.*JPR(K))+1./(288.*JPR(K)**2))
+                    PVPR(K)=EXP((JPR(K))*LOG(1.*PAVG)-FACTL)
+                    ENDDO
+                    ENDIF
+                    MPVPR=MAXVAL(PVPR)
+                    DO K=BBOT,TTOP
+                    PVPR(K)=PVPR(K)/MPVPR
+                    ENDDO
+                    DO K=KTS,KTE
+                    CCLDFRA(I,K,J)=CUMX*PVPR(K)
+                    ENDDO
+    !
+    !***  COMPUTE THE CONVECTIVE CLOUD CONDENSATES (QCCONV,QICONV). PLEASE NOTE THAT
+    !***  THE EQUATION FOR QCIS IS VALID FOR PRRTs IN THE RANGE 10**(-7) TO 10**3.
+    !
+                    QCIS=0.
+                    MCOL=0.
+                    DO K=CUBOT(I,J),CUTOP(I,J)
+                    KFLIP=KTE+1-K
+                    MCOL=RHO(I,K,J)*DZ8W(I,K,J)*QCOL(KFLIP)*CCLDFRA(I,K,J)+MCOL
+                    ENDDO
+                    CONVCLD(I,J)=PWCOL**GAM*(DQCOL-DQCOLMIN)**(1.-GAM)
+                    QCIS=CONVCLD(I,J)/MCOL
+                    DO K=KTS,KTE
+                    KFLIP=KTE+1-K
+                    IF (TCOL(KFLIP)>=TFRZ) THEN
+                    QICONV(I,K,J)=0.
+                    QCCONV(I,K,J)=(QCIS*QCOL(KFLIP)*CCLDFRA(I,K,J))/(1.-QCOL(KFLIP))
+                    ELSE
+                    QICONV(I,K,J)=(QCIS*QCOL(KFLIP)*CCLDFRA(I,K,J))/(1.-QCOL(KFLIP))
+                    QCCONV(I,K,J)=0.
+                    ENDIF
+                    ENDDO
+    !
+                ENDIF
+    !
+            ENDIF
+    !
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+                IF(PRINT_DIAG)THEN
+                DELT=0.
+                DELQ=0.
+                PLYR=0.
+                IF(LBOT>0.AND.LTOP<LBOT)THEN
+                    DO K=LTOP,LBOT
+                    PLYR=PLYR+DPCOL(K)
+                    DELQ=DELQ+DPCOL(K)*DTCNVC*ABS(DQDT(K))
+                    DELT=DELT+DPCOL(K)*DTCNVC*ABS(DTDT(K))
+                    ENDDO
+                    DELQ=DELQ/PLYR
+                    DELT=DELT/PLYR
+                ENDIF
+    !
+                WRITE(6,"(2a,2i4,3e12.4,f7.2,4i3)") &
+                        '{cu3 i,j,PCPCOL,DTavg,DQavg,PLYR,'  &
+                        ,'LBOT,LTOP,CUBOT,CUTOP = '  &
+                        ,i,j, PCPCOL,DELT,1000.*DELQ,.01*PLYR  &
+                        ,LBOT,LTOP,NINT(CUBOT(I,J)),NINT(CUTOP(I,J))
+    !
+                IF(PLYR> 0.)THEN
+                    DO K=LBOT,LTOP,-1
+                    KFLIP=KTE+1-K
+                    WRITE(6,"(a,i3,2e12.4,f7.2)") '{cu3a KFLIP,DT,DQ,DP = ' &
+                            ,KFLIP,DTCNVC*DTDT(K),1000.*DTCNVC*DQDT(K),.01*DPCOL(K)
+                    ENDDO
+                ENDIF
+                ENDIF
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+    !
+            ENDDO
+            ENDDO
+    !
+            END SUBROUTINE BMJDRV
+    !-----------------------------------------------------------------------
+    !XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    !-----------------------------------------------------------------------
+                                SUBROUTINE BMJ                                &
+    !-----------------------------------------------------------------------
+            & (ITIMESTEP,I,J,DTCNVC,LMH,SM,CLDEFI                              &
+            & ,DPRS,PRSMID,Q,T,PSFC,PT                                         &
+            & ,DQDT,DTDT,PCPCOL,LBOT,LTOP,LPBL                                 &
+            & ,PWCOL,DQCOL,DQCOLMIN                                            &
+            & ,CP,R,ELWV,ELIV,G,TFRZ,D608                                      &
+            & ,PRINT_DIAG                                                      &   
+            & ,IDS,IDE,JDS,JDE,KDS,KDE                                         &
+            & ,IMS,IME,JMS,JME,KMS,KME                                         &
+            & ,ITS,ITE,JTS,JTE,KTS,KTE)
+    !-----------------------------------------------------------------------
+            IMPLICIT NONE
+    !-----------------------------------------------------------------------
+            INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE                     &
+                                ,IMS,IME,JMS,JME,KMS,KME                     &
+                                ,ITS,ITE,JTS,JTE,KTS,KTE                     &
+                                ,I,J,ITIMESTEP
+    ! 
+            INTEGER,INTENT(IN) :: LMH,LPBL
+    !
+            INTEGER,INTENT(OUT) :: LBOT,LTOP
+    !
+            REAL,INTENT(IN) :: CP,D608,DTCNVC,ELIV,ELWV,G,PSFC,PT,R,SM,TFRZ
+    !
+            REAL,DIMENSION(KTS:KTE),INTENT(IN) :: DPRS,PRSMID,Q,T
+    !
+            REAL,INTENT(INOUT) :: CLDEFI,PCPCOL,PWCOL,DQCOL,DQCOLMIN
+    !
+            REAL,DIMENSION(KTS:KTE),INTENT(INOUT) :: DQDT,DTDT
+    !
+    !-----------------------------------------------------------------------
+    !***  DEFINE LOCAL VARIABLES
+    !-----------------------------------------------------------------------
+    !                                                            
+            REAL,DIMENSION(KTS:KTE) :: APEK,APESK,EL,FPK                      &
+                                    ,PK,PSK,QK,QREFK,QSATK                  &
+                                    ,THERK,THEVRF,THSK                      &
+                                    ,THVMOD,THVREF,TK,TREFK
+            REAL,DIMENSION(KTS:KTE) :: APE,DIFQ,DIFT,THEE,THES,TREF
+    !
+            REAL,DIMENSION(KTS:KTE) :: CPE,CPEcnv,DTV,DTVcnv,THEScnv    !<-- CPE for shallow convection buoyancy check (24 Aug 2006)
+    !
+            LOGICAL :: DEEP,SHALLOW
+    !
+    !***  Begin debugging convection
+            LOGICAL :: PRINT_DIAG
+    !***  End debugging convection
+    !
+    !-----------------------------------------------------------------------
+    !***
+    !***  LOCAL SCALARS
+    !***
+    !-----------------------------------------------------------------------
+            REAL :: APEKL,APEKXX,APEKXY,APES,APESTS                           &
+            &            ,AVRGT,AVRGTL,BQ,BQK,BQS00K,BQS10K                    &
+            &            ,CAPA,CUP,DEN,DENTPY,DEPMIN,DEPTH                     &
+            &            ,DEPWL,DHDT,DIFQL,DIFTL,DP,DPKL,DPLO,DPMIX,DPOT       &
+            &            ,DPUP,DQREF,DRHDP,DRHEAT,DSP                          &
+            &            ,DSP0,DSP0K,DSPB,DSPBK,DSPT,DSPTK                     &
+            &            ,DSQ,DST,DSTQ,DTHEM,DTDP,EFI                          &
+            &            ,FEFI,FFUP,FPRS,FPTK,HCORR                            &
+            &            ,OTSUM,P,P00K,P01K,P10K,P11K                          &
+            &            ,PART1,PART2,PART3,PBOT,PBOTFC,PBTK                   &
+            &            ,PK0,PKB,PKL,PKT,PKXXXX,PKXXXY                        &
+            &            ,PLMH,PELEVFC,PBTmx,plo,POTSUM,PP1,PPK,PRECK          &
+            &            ,PRWD,PDQD,PRESK,PSP,PSUM,PTHRS,PTOP,PTPK,PUP         &
+            &            ,QBT,QKL,QNEW,QOTSUM,QQ1,QQK,QRFKL                    &
+            &            ,QRFTP,QSP,QSUM,QUP,RDP0T                             &
+            &            ,RDPSUM,RDTCNVC,RHH,RHL,RHMAX,ROTSUM,RTBAR,RHAVG      &
+            &            ,SM1,SMIX,SQ,SQK,SQS00K,SQS10K,STABDL,SUMDE,SUMDP     &
+            &            ,SUMDT,TAUK,TAUKSC,TCORR,THBT,THERKX,THERKY           &
+            &            ,THESP,THSKL,THTPK,THVMKL,TKL,TNEW                    &
+            &            ,TQ,TQK,TREFKX,TRFKL,trmlo,trmup,TSKL,tsp,TTH         &
+            &            ,TTHK,TUP                                             &
+            &            ,CAPEcnv,PSPcnv,THBTcnv,CAPEtrigr,CAPE                &
+            &            ,TLEV2,QSAT1,QSAT2,RHSHmax
+    !
+            INTEGER :: IQ,IQTB,IT,ITER,ITREFI,ITTB,ITTBK,KB,KNUMH,KNUML       &
+            &          ,L,L0,L0M1,LB,LBM1,LCOR,LPT1                            &
+            &          ,LQM,LSHU,LTP1,LTP2,LTSH, LBOTcnv,LTOPcnv,LMID
+    !-----------------------------------------------------------------------
+    !
+            REAL,PARAMETER :: DSPBSL=DSPBFL*FSL,DSP0SL=DSP0FL*FSL             &
+            &                 ,DSPTSL=DSPTFL*FSL                               &
+            &                 ,DSPBSS=DSPBFS*FSS,DSP0SS=DSP0FS*FSS             &
+            &                 ,DSPTSS=DSPTFS*FSS
+    !
+            REAL,PARAMETER :: ELEVFC=0.6,STEFI=1.
+    !
+            REAL,PARAMETER :: SLOPBL=(DSPBFL-DSPBSL)/(1.-EFIMN)               &
+            &                 ,SLOP0L=(DSP0FL-DSP0SL)/(1.-EFIMN)               &
+            &                 ,SLOPTL=(DSPTFL-DSPTSL)/(1.-EFIMN)               &
+            &                 ,SLOPBS=(DSPBFS-DSPBSS)/(1.-EFIMN)               &
+            &                 ,SLOP0S=(DSP0FS-DSP0SS)/(1.-EFIMN)               &
+            &                 ,SLOPTS=(DSPTFS-DSPTSS)/(1.-EFIMN)               &
+            &                 ,SLOPST=(STABDF-STABDS)/(1.-EFIMN)               &
+            &                 ,SLOPE=(1.-EFMNT)/(1.-EFIMN)
+    !
+            REAL :: A23M4L,CPRLG,ELOCP,RCP,QWAT
+    !-----------------------------------------------------------------------
+    !***********************************************************************
+    !-----------------------------------------------------------------------
+            CAPA=R/CP
+            CPRLG=CP/(ROW*G*ELWV)
+            ELOCP=ELIWV/CP
+            RCP=1./CP
+            A23M4L=A2*(A3-A4)*ELWV
+            RDTCNVC=1./DTCNVC
+            DEPMIN=PSH*PSFC*RSFCP
+    !
+            DEEP=.FALSE.
+            SHALLOW=.FALSE.
+    !
+            DSP0=0.
+            DSPB=0.
+            DSPT=0.
+    !-----------------------------------------------------------------------
+            TAUK=DTCNVC/TREL
+            TAUKSC=DTCNVC/(1.0*TREL) 
+    !-----------------------------------------------------------------------
+    !-----------------------------PREPARATIONS------------------------------
+    !-----------------------------------------------------------------------
+            LBOT=LMH
+            DQCOL=0.
+            PWCOL=0.
+            PCPCOL=0.
+            DQCOLMIN=0.
+            TREF(KTS)=T(KTS)
+    !
+            DO L=KTS,LMH
+            APESTS=PRSMID(L)
+            APE(L)=(1.E5/APESTS)**CAPA
+            CPEcnv(L)=0.
+            DTVcnv(L)=0.
+            THEScnv(L)=0.
+            ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !----------------SEARCH FOR MAXIMUM BUOYANCY LEVEL----------------------
+    !-----------------------------------------------------------------------
+    !
+            PLMH=PRSMID(LMH)
+            PELEVFC=PLMH*ELEVFC
+            PBTmx=PRSMID(LMH)-PONE
+            CAPEcnv=0.
+            PSPcnv=0.
+            THBTcnv=0.
+            LBOTcnv=LBOT
+            LTOPcnv=LBOT
+    !
+    !-----------------------------------------------------------------------
+    !----------------TRIAL MAXIMUM BUOYANCY LEVEL VARIABLES-----------------
+    !-----------------------------------------------------------------------
+    !
+            max_buoy_loop: DO KB=LMH,1,-1
+    !
+    !-----------------------------------------------------------------------
+    !
+            PKL=PRSMID(KB)
+    !       IF (PKL<PELEVFC .OR. T(KB)<=TFRZ) EXIT
+            IF (PKL<PELEVFC) EXIT
+            LBOT=LMH
+            LTOP=LMH
+    !
+    !-----------------------------------------------------------------------
+    !***  SEARCH OVER A SCALED DEPTH IN FINDING THE PARCEL
+    !***  WITH THE MAX THETA-E 
+    !-----------------------------------------------------------------------
+    !
+            QBT=Q(KB)
+            THBT=T(KB)*APE(KB)
+            TTH=(THBT-THL)*RDTH
+            QQ1=TTH-AINT(TTH)
+            ITTB=INT(TTH)+1
+    !----------------KEEPING INDICES WITHIN THE TABLE-----------------------
+            IF(ITTB<1)THEN
+                ITTB=1
+                QQ1=0.
+            ELSE IF(ITTB>=JTB)THEN
+                ITTB=JTB-1
+                QQ1=0.
+            ENDIF
+    !--------------BASE AND SCALING FACTOR FOR SPEC. HUMIDITY---------------
+            ITTBK=ITTB
+            BQS00K=QS0(ITTBK)
+            SQS00K=SQS(ITTBK)
+            BQS10K=QS0(ITTBK+1)
+            SQS10K=SQS(ITTBK+1)
+    !--------------SCALING SPEC. HUMIDITY & TABLE INDEX---------------------
+            BQ=(BQS10K-BQS00K)*QQ1+BQS00K
+            SQ=(SQS10K-SQS00K)*QQ1+SQS00K
+            TQ=(QBT-BQ)/SQ*RDQ
+            PP1=TQ-AINT(TQ)
+            IQTB=INT(TQ)+1
+    !----------------KEEPING INDICES WITHIN THE TABLE-----------------------
+            IF(IQTB<1)THEN
+                IQTB=1
+                PP1=0.
+            ELSE IF(IQTB>=ITB)THEN
+                IQTB=ITB-1
+                PP1=0.
+            ENDIF
+    !--------------SATURATION PRESSURE AT FOUR SURROUNDING TABLE PTS.-------
+            IQ=IQTB
+            IT=ITTB
+            P00K=PTBL(IQ  ,IT  )
+            P10K=PTBL(IQ+1,IT  )
+            P01K=PTBL(IQ  ,IT+1)
+            P11K=PTBL(IQ+1,IT+1)
+    !
+    !--------------SATURATION POINT VARIABLES AT THE BOTTOM-----------------
+    !
+            PSP=P00K+(P10K-P00K)*PP1+(P01K-P00K)*QQ1                        &
+            &          +(P00K-P10K-P01K+P11K)*PP1*QQ1
+            APES=(1.E5/PSP)**CAPA
+            THESP=THBT*EXP(ELOCP*QBT*APES/THBT)
+    !
+    !-----------------------------------------------------------------------
+    !-----------CHOOSE CLOUD BASE AS MODEL LEVEL JUST BELOW PSP-------------
+    !-----------------------------------------------------------------------
+    !
+            DO L=KTS,LMH-1
+                P=PRSMID(L)
+                IF(P<PSP.AND.P>=PQM)LBOT=L+1
+            ENDDO
+    !***
+    !*** WARNING: LBOT MUST NOT BE > LMH-1 IN SHALLOW CONVECTION
+    !*** MAKE SURE CLOUD BASE IS AT LEAST PONE ABOVE THE SURFACE
+    !***
+            PBOT=PRSMID(LBOT)
+            IF(PBOT>=PBTmx.OR.LBOT>=LMH)THEN
+                DO L=KTS,LMH-1
+                P=PRSMID(L)
+                IF(P<PBTmx)LBOT=L
+                ENDDO
+                PBOT=PRSMID(LBOT)
+            ENDIF 
+    !
+    !-----------------------------------------------------------------------
+    !----------------CLOUD TOP COMPUTATION----------------------------------
+    !-----------------------------------------------------------------------
+    !
+            LTOP=LBOT
+            PTOP=PBOT
+            DO L=LMH,KTS,-1
+                THES(L)=THESP
+            ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !### BEGIN: ###########  WARNING  ###########  WARNING  ###########
+    !-----------------------------------------------------------------------
+    !
+    !### IMPORTANT: THIS "DO KB=LMH,1,-1" loop must be broken up into two
+    !    separate loops in order for entrainment as programmed below to work
+    !    properly.  
+    !
+    !---------------  ENTRAINMENT DURING PARCEL ASCENT  --------------------
+    !
+    !        DO L=LMH,KB,-1
+    !          THES(L)=THESP
+    !        ENDDO
+    !
+    !        DO L=KTS,LMH
+    !          THEE(L)=THES(L)
+    !        ENDDO
+    !!
+    !        FEFI=(CLDEFI-EFIMN)*SLOPE+EFMNT
+    !        FFUP=FUP/(FEFI*FEFI)
+    !!
+    !        IF(PBOT>ENPLO)THEN
+    !          FPRS=1.
+    !        ELSEIF(PBOT>ENPUP)THEN
+    !          FPRS=(PBOT-ENPUP)*RENDP
+    !        ELSE
+    !          FPRS=0.
+    !        ENDIF
+    !!
+    !        FFUP=FFUP*FPRS*FPRS*0.5
+    !        DPUP=DPRS(KB)
+    !!
+    !        DO L=KB-1,KTS,-1
+    !          DPLO=DPUP
+    !          DPUP=DPRS(L)
+    !!
+    !          THES(L)=((-FFUP*DPLO+1.)*THES(L+1)                           &
+    !     &            +(THEE(L)*DPUP+THEE(L+1)*DPLO)*FFUP)                 &
+    !     &           /(FFUP*DPUP+1.)
+    !      ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !### END: ###########  WARNING  ###########  WARNING  ###########
+    !-----------------------------------------------------------------------
+    !!
+    !-----------------------------------------------------------------------
+    !!***  COMPUTE PARCEL TEMPERATURE ALONG THE ASCENT TRAJECTORY
+    !!***  SCALING PRESSURE & TT TABLE INDEX.
+    !-----------------------------------------------------------------------
+    !!
+    !!
+    !       DO L=LMH,KTS,-1
+    !!
+    !         PRESK=PRSMID(L)
+    !!
+    !         IF(PRESK<PLQ)THEN
+    !           CALL TTBLEX(ITB,JTB,PL,PRESK,RDP,RDTHE                      &
+    !     &                ,STHE,THE0,THES(L),TTBL,TREF(L))
+    !         ELSE
+    !           CALL TTBLEX(ITBQ,JTBQ,PLQ,PRESK,RDPQ,RDTHEQ                 &
+    !     &                ,STHEQ,THE0Q,THES(L),TTBLQ,TREF(L))
+    !         ENDIF
+    !!
+    !       ENDDO
+    !!
+    !!-----------------------------------------------------------------------
+    !!----------------BUOYANCY CHECK-----------------------------------------
+    !!-----------------------------------------------------------------------
+    !!
+    !       DO L=LMH,KTS,-1
+    !         IF(TREF(L)>T(L)-DTTOP)LTOP=L
+    !       ENDDO
+    !!
+    !!***  CLOUD TOP PRESSURE
+    !!
+    !       PTOP=PRSMID(LTOP)
+    !
+    !------------------FIRST ENTROPY CHECK----------------------------------
+    !
+            DO L=KTS,LMH
+                CPE(L)=0.
+                DTV(L)=0.
+            ENDDO
+    !-----------------------------------------------------------------------
+    !       lbot_ltop: IF(LBOT>LTOP)THEN
+    !-----------------------------------------------------------------------
+    !-- Begin: Buoyancy check including deep convection (24 Aug 2006) 
+    !-----------------------------------------------------------------------
+                DENTPY=0.
+                L=KB
+                PLO=PRSMID(L)
+                TRMLO=0.
+                CAPEtrigr=DTPtrigr/T(LBOT)
+    !
+    !--- Below cloud base
+    !
+                IF(KB>LBOT) THEN
+                DO L=KB-1,LBOT+1,-1
+                    PUP=PRSMID(L)
+                    TUP=THBT/APE(L)
+                    DP=PLO-PUP
+                    TRMUP=(TUP*(QBT*0.608+1.)                                 &
+            &            -T(L)*(Q(L)*0.608+1.))*0.5                            &
+            &             /(T(L)*(Q(L)*0.608+1.))
+                    DTV(L)=TRMLO+TRMUP
+                    DENTPY=DTV(L)*DP+DENTPY
+                    CPE(L)=DENTPY
+                    IF (DENTPY < CAPEtrigr) GO TO 170
+                    PLO=PUP
+                    TRMLO=TRMUP
+                ENDDO
+                ELSE
+                L=LBOT+1
+                PLO=PRSMID(L)
+                TUP=THBT/APE(L)
+                TRMLO=(TUP*(QBT*0.608+1.)                                   &
+            &            -T(L)*(Q(L)*0.608+1.))*0.5                            &
+            &             /(T(L)*(Q(L)*0.608+1.))
+                ENDIF  ! IF(KB>LBOT) THEN
+    !
+    !--- At cloud base
+    !
+                L=LBOT
+                PUP=PSP
+                TUP=THBT/APES
+                TSP=(T(L+1)-T(L))/(PLO-PBOT)                                  &
+            &       *(PUP-PBOT)+T(L)
+                QSP=(Q(L+1)-Q(L))/(PLO-PBOT)                                  &
+            &       *(PUP-PBOT)+Q(L)
+                DP=PLO-PUP
+                TRMUP=(TUP*(QBT*0.608+1.)                                     &
+            &          -TSP*(QSP*0.608+1.))*0.5                                &
+            &         /(TSP*(QSP*0.608+1.))
+                DTV(L)=TRMLO+TRMUP
+                DENTPY=DTV(L)*DP+DENTPY
+                CPE(L)=DENTPY
+                DTV(L)=DTV(L)*DP
+                PLO=PUP
+                TRMLO=TRMUP
+                PUP=PRSMID(L)
+    !
+    !--- Calculate updraft temperature along moist adiabat (TUP)
+    !
+                IF(PUP<PLQ)THEN
+                CALL TTBLEX(ITB,JTB,PL,PUP,RDP,RDTHE                        &
+            &                 ,STHE,THE0,THES(L),TTBL,TUP)
+                ELSE
+                CALL TTBLEX(ITBQ,JTBQ,PLQ,PUP,RDPQ,RDTHEQ                   &
+            &                 ,STHEQ,THE0Q,THES(L),TTBLQ,TUP)
+                ENDIF
+    !
+                QUP=PQ0/PUP*EXP(A2*(TUP-A3)/(TUP-A4))
+                QWAT=QBT-QUP  !-- Water loading effects, reversible adiabat
+                DP=PLO-PUP
+                TRMUP=(TUP*(QUP*0.608+1.-QWAT)                                &
+            &          -T(L)*(Q(L)*0.608+1.))*0.5                              &
+            &         /(T(L)*(Q(L)*0.608+1.))
+                DENTPY=(TRMLO+TRMUP)*DP+DENTPY
+                CPE(L)=DENTPY
+                DTV(L)=(DTV(L)+(TRMLO+TRMUP)*DP)/(PRSMID(LBOT+1)-PRSMID(LBOT))
+    !
+                IF (DENTPY < CAPEtrigr) GO TO 170
+    !
+                PLO=PUP
+                TRMLO=TRMUP
+    !
+    !-----------------------------------------------------------------------
+    !--- In cloud above cloud base
+    !-----------------------------------------------------------------------
+    !
+                DO L=LBOT-1,KTS,-1
+                PUP=PRSMID(L)
+    !
+    !--- Calculate updraft temperature along moist adiabat (TUP)
+    !
+                IF(PUP<PLQ)THEN
+                    CALL TTBLEX(ITB,JTB,PL,PUP,RDP,RDTHE                      &
+            &                 ,STHE,THE0,THES(L),TTBL,TUP)
+                ELSE
+                    CALL TTBLEX(ITBQ,JTBQ,PLQ,PUP,RDPQ,RDTHEQ                 &
+            &                 ,STHEQ,THE0Q,THES(L),TTBLQ,TUP)
+                ENDIF
+    !
+                QUP=PQ0/PUP*EXP(A2*(TUP-A3)/(TUP-A4))
+                QWAT=QBT-QUP  !-- Water loading effects, reversible adiabat
+                DP=PLO-PUP
+                TRMUP=(TUP*(QUP*0.608+1.-QWAT)                              &
+            &            -T(L)*(Q(L)*0.608+1.))*0.5                            &
+            &           /(T(L)*(Q(L)*0.608+1.))
+                DTV(L)=TRMLO+TRMUP
+                DENTPY=DTV(L)*DP+DENTPY
+                CPE(L)=DENTPY
+    !
+                IF (DENTPY < CAPEtrigr) GO TO 170
+    !
+                PLO=PUP
+                TRMLO=TRMUP
+                ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !
+    170       LTP1=KB
+                CAPE=0.
+    !
+    !-----------------------------------------------------------------------
+    !--- Cloud top level (LTOP) is located where CAPE is a maximum
+    !--- Exit cloud-top search if CAPE < CAPEtrigr
+    !-----------------------------------------------------------------------
+    !
+                DO L=KB,KTS,-1
+                IF (CPE(L) < CAPEtrigr) THEN
+                    EXIT
+                ELSE IF (CPE(L) > CAPE) THEN
+                    LTP1=L
+                    CAPE=CPE(L)
+                ENDIF
+                ENDDO      !-- End DO L=KB,KTS,-1
+    !
+                LTOP=MIN(LTP1,LBOT)
+    ! 
+    !-----------------------------------------------------------------------
+    !--------------- CHECK FOR MAXIMUM INSTABILITY  ------------------------
+    !-----------------------------------------------------------------------
+                IF(CAPE > CAPEcnv) THEN
+                CAPEcnv=CAPE
+                PSPcnv=PSP
+                THBTcnv=THBT
+                LBOTcnv=LBOT
+                LTOPcnv=LTOP
+                DO L=LMH,KTS,-1
+                    CPEcnv(L)=CPE(L)
+                    DTVcnv(L)=DTV(L)
+                    THEScnv(L)=THES(L)
+                ENDDO
+                ENDIF    ! End IF(CAPE > CAPEcnv) THEN
+    !
+    !       ENDIF lbot_ltop
+    !
+    !-----------------------------------------------------------------------
+    !
+            ENDDO max_buoy_loop
+    !
+    !-----------------------------------------------------------------------
+    !------------------------  MAXIMUM INSTABILITY  ------------------------
+    !-----------------------------------------------------------------------
+    !
+            IF(CAPEcnv > 0.) THEN
+            PSP=PSPcnv
+            THBT=THBTcnv
+            LBOT=LBOTcnv
+            LTOP=LTOPcnv
+            PBOT=PRSMID(LBOT)
+            PTOP=PRSMID(LTOP)
+    !
+            DO L=LMH,KTS,-1
+                CPE(L)=CPEcnv(L)
+                DTV(L)=DTVcnv(L)
+                THES(L)=THEScnv(L)
+            ENDDO
+    !
+            ENDIF
+    !
+    !-----------------------------------------------------------------------
+    !-----  Quick exit if cloud is too thin or no CAPE is present  ---------
+    !-----------------------------------------------------------------------
+    !
+            IF(PTOP>PBOT-PNO.OR.LTOP>LBOT-2.OR.CAPEcnv<=0.)THEN
+            LBOT=0
+            LTOP=KTE
+            PBOT=PRSMID(LMH)
+            PTOP=PBOT
+            CLDEFI=AVGEFI*SM+STEFI*(1.-SM)
+    !       CLDEFI=(EFIMN-0.2)*SM+(1.+0.2)*(1.-SM)
+            GO TO 800
+            ENDIF
+    !
+    !***  DEPTH OF CLOUD REQUIRED TO MAKE THE POINT A DEEP CONVECTION POINT
+    !***  IS A SCALED VALUE OF PSFC.
+    !
+            DEPTH=PBOT-PTOP
+    !
+            IF(DEPTH>=DEPMIN) THEN
+            DEEP=.TRUE.
+            ELSE
+            SHALLOW=.TRUE.
+    !       CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
+            GO TO 600
+            ENDIF
+    !
+    !-----------------------------------------------------------------------
+    !DCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCD
+    !DCDCDCDCDCDCDCDCDCDCDC    DEEP CONVECTION   DCDCDCDCDCDCDCDCDCDCDCDCDCD
+    !DCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCD
+    !-----------------------------------------------------------------------
+    !
+        300 CONTINUE
+    !
+            LB =LBOT
+            EFI=CLDEFI
+    !-----------------------------------------------------------------------
+    !--------------INITIALIZE VARIABLES IN THE CONVECTIVE COLUMN------------
+    !-----------------------------------------------------------------------
+    !***
+    !***  ONE SHOULD NOTE THAT THE VALUES ASSIGNED TO THE ARRAY TREFK
+    !***  IN THE FOLLOWING LOOP ARE REALLY ONLY RELEVANT IN ANCHORING THE
+    !***  REFERENCE TEMPERATURE PROFILE AT LEVEL LB.  WHEN BUILDING THE
+    !***  REFERENCE PROFILE FROM CLOUD BASE, THEN ASSIGNING THE
+    !***  AMBIENT TEMPERATURE TO TREFK IS ACCEPTABLE.  HOWEVER, WHEN
+    !***  BUILDING THE REFERENCE PROFILE FROM SOME OTHER LEVEL (SUCH AS
+    !***  ONE LEVEL ABOVE THE GROUND), THEN TREFK SHOULD BE FILLED WITH
+    !***  THE TEMPERATURES IN TREF(L) WHICH ARE THE TEMPERATURES OF
+    !***  THE MOIST ADIABAT THROUGH CLOUD BASE.  BY THE TIME THE LINE 
+    !***  NUMBERED 450 HAS BEEN REACHED, TREFK ACTUALLY DOES HOLD THE
+    !***  REFERENCE TEMPERATURE PROFILE.
+    !***
+            DO L=KTS,LMH
+            DIFT  (L)=0.
+            DIFQ  (L)=0.
+            TKL      =T(L)
+            TK    (L)=TKL
+            TREFK (L)=TKL
+            QKL      =Q(L)
+            QK    (L)=QKL
+            QREFK (L)=QKL
+            PKL      =PRSMID(L)
+            PK    (L)=PKL
+            PSK   (L)=PKL
+            APEKL    =APE(L)
+            APEK  (L)=APEKL
+    !
+    !--- Calculate temperature along moist adiabat (TREF)
+    !
+            IF(PKL<PLQ)THEN
+                CALL TTBLEX(ITB,JTB,PL,PKL,RDP,RDTHE                          &
+            &               ,STHE,THE0,THES(L),TTBL,TREF(L))
+            ELSE
+                CALL TTBLEX(ITBQ,JTBQ,PLQ,PKL,RDPQ,RDTHEQ                     &
+            &               ,STHEQ,THE0Q,THES(L),TTBLQ,TREF(L))
+            ENDIF
+            THERK (L)=TREF(L)*APEKL
+            ENDDO
+    !
+    !------------DEEP CONVECTION REFERENCE TEMPERATURE PROFILE------------
+    !
+            LTP1=LTOP+1
+            LBM1=LB-1
+            PKB=PK(LB)
+            PKT=PK(LTOP)
+            STABDL=(EFI-EFIMN)*SLOPST+STABDS
+    !
+    !------------TEMPERATURE REFERENCE PROFILE BELOW FREEZING LEVEL-------
+    !
+            EL(LB) = ELWV    
+            L0=LB
+            PK0=PK(LB)
+            TREFKX=TREFK(LB)
+            THERKX=THERK(LB)
+            APEKXX=APEK(LB)
+            THERKY=THERK(LBM1)
+            APEKXY=APEK(LBM1)
+    !
+            DO L=LBM1,LTOP,-1
+            IF(T(L+1)<TFRZ)GO TO 430
+            TREFKX=((THERKY-THERKX)*STABDL                                  &
+            &          +TREFKX*APEKXX)/APEKXY
+            TREFK(L)=TREFKX
+            EL(L)=ELWV
+            APEKXX=APEKXY
+            THERKX=THERKY
+            APEKXY=APEK(L-1)
+            THERKY=THERK(L-1)
+            L0=L
+            PK0=PK(L0)
+            ENDDO
+    !
+    !--------------FREEZING LEVEL AT OR ABOVE THE CLOUD TOP-----------------
+    !
+            GO TO 450
+    !
+    !--------------TEMPERATURE REFERENCE PROFILE ABOVE FREEZING LEVEL-------
+    !
+        430 L0M1=L0-1
+            RDP0T=1./(PK0-PKT)
+            DTHEM=THERK(L0)-TREFK(L0)*APEK(L0)
+    !
+            DO L=LTOP,L0M1
+            TREFK(L)=(THERK(L)-(PK(L)-PKT)*DTHEM*RDP0T)/APEK(L)
+            EL(L)=ELWV !ELIV
+            ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !--------------DEEP CONVECTION REFERENCE HUMIDITY PROFILE---------------
+    !-----------------------------------------------------------------------
+    !
+    !***  DEPWL IS THE PRESSURE DIFFERENCE BETWEEN CLOUD BASE AND
+    !***  THE FREEZING LEVEL
+    !
+        450 CONTINUE
+            DEPWL=PKB-PK0
+            DEPTH=PFRZ*PSFC*RSFCP
+            SM1=1.-SM
+            PBOTFC=1.
+    !
+    !-------------FIRST ADJUSTMENT OF TEMPERATURE PROFILE-------------------
+    !!
+    !      SUMDT=0.
+    !      SUMDP=0.
+    !!
+    !      DO L=LTOP,LB
+    !        SUMDT=(TK(L)-TREFK(L))*DPRS(L)+SUMDT
+    !        SUMDP=SUMDP+DPRS(L)
+    !      ENDDO
+    !!
+    !      TCORR=SUMDT/SUMDP
+    !!
+    !      DO L=LTOP,LB
+    !        TREFK(L)=TREFK(L)+TCORR
+    !      ENDDO
+    !!
+    !-----------------------------------------------------------------------
+    !--------------- ITERATION LOOP FOR CLOUD EFFICIENCY -------------------
+    !-----------------------------------------------------------------------
+    !
+            cloud_efficiency : DO ITREFI=1,ITREFI_MAX  
+    !
+    !-----------------------------------------------------------------------
+            DSPBK=((EFI-EFIMN)*SLOPBS+DSPBSS*PBOTFC)*SM                     &
+            &       +((EFI-EFIMN)*SLOPBL+DSPBSL*PBOTFC)*SM1
+            DSP0K=((EFI-EFIMN)*SLOP0S+DSP0SS*PBOTFC)*SM                     &
+            &       +((EFI-EFIMN)*SLOP0L+DSP0SL*PBOTFC)*SM1
+            DSPTK=((EFI-EFIMN)*SLOPTS+DSPTSS*PBOTFC)*SM                     &
+            &       +((EFI-EFIMN)*SLOPTL+DSPTSL*PBOTFC)*SM1
+    !
+    !-----------------------------------------------------------------------
+    !
+            DO L=LTOP,LB
+    !
+    !***
+    !***  SATURATION PRESSURE DIFFERENCE
+    !***
+                IF(DEPWL>=DEPTH)THEN
+                IF(L<L0)THEN
+                    DSP=((PK0-PK(L))*DSPTK+(PK(L)-PKT)*DSP0K)/(PK0-PKT)
+                ELSE
+                    DSP=((PKB-PK(L))*DSP0K+(PK(L)-PK0)*DSPBK)/(PKB-PK0)
+                ENDIF
+                ELSE
+                DSP=DSP0K
+                IF(L<L0)THEN
+                    DSP=((PK0-PK(L))*DSPTK+(PK(L)-PKT)*DSP0K)/(PK0-PKT)
+                ENDIF
+                ENDIF
+    !***
+    !***  HUMIDITY PROFILE
+    !***
+                PSK(L)=PK(L)+DSP
+                APESK(L)=(1.E5/PSK(L))**CAPA
+    
+                IF(PK(L)>PQM)THEN
+                THSK(L)=TREFK(L)*APEK(L)
+                QREFK(L)=PQ0/PSK(L)*EXP(A2*(THSK(L)-A3*APESK(L))            &
+            &                                /(THSK(L)-A4*APESK(L)))
+                ELSE
+                QREFK(L)=QK(L)
+                ENDIF
+    !
+            ENDDO
+    !-----------------------------------------------------------------------
+    !***
+    !***  ENTHALPY CONSERVATION INTEGRAL
+    !***
+    !-----------------------------------------------------------------------
+            enthalpy_conservation : DO ITER=1,2
+    !
+                SUMDE=0.
+                SUMDP=0.
+                DHDT =0.
+    !
+                DO L=LTOP,LB
+                SUMDE=((TK(L)-TREFK(L))*CP+(QK(L)-QREFK(L))*EL(L))*DPRS(L)  &
+            &            +SUMDE
+                DHDT=(QREFK(L)*A23M4L/((TREFK(L)*APEK(L)/APESK(L))-A4)**2+CP)*DPRS(L) &
+            &            +DHDT
+                SUMDP=SUMDP+DPRS(L)
+                ENDDO
+    !
+                HCORR=SUMDE/(SUMDP-DPRS(LTOP))
+                DHDT=DHDT/(SUMDP-DPRS(LTOP))
+                LCOR=LTOP+1
+    !***
+    !***  FIND LQM
+    !***
+                LQM=1
+                DO L=KTS,LB
+                IF(PK(L)<=PQM)LQM=L
+                ENDDO
+    !***
+    !***  ABOVE LQM CORRECT TEMPERATURE ONLY
+    !***
+                IF(LCOR<=LQM)THEN
+                DO L=LCOR,LQM
+                    TREFK(L)=TREFK(L)+HCORR*RCP
+                ENDDO
+                LCOR=LQM+1
+                ENDIF
+    !***
+    !***  BELOW LQM CORRECT BOTH TEMPERATURE AND MOISTURE
+    !***
+                DO L=LCOR,LB
+                TREFK(L)=HCORR/DHDT+TREFK(L)
+                THSKL=TREFK(L)*APEK(L)
+                QREFK(L)=PQ0/PSK(L)*EXP(A2*(THSKL-A3*APESK(L))              &
+            &                                /(THSKL-A4*APESK(L)))
+                ENDDO
+    !
+            ENDDO  enthalpy_conservation
+    !-----------------------------------------------------------------------
+    !
+    !***  HEATING, MOISTENING, PRECIPITATION
+    !
+    !-----------------------------------------------------------------------
+            AVRGT=0.
+            PRECK=0.
+            PDQD=0.
+            PRWD=0.
+            DSQ=0.
+            DST=0.
+    !
+            DO L=LTOP,LB
+                TKL=TK(L)
+                DIFTL=(TREFK(L)-TKL  )*TAUK
+                DIFQL=(QREFK(L)-QK(L))*TAUK
+                AVRGTL=(TKL+TKL+DIFTL)
+                DPOT=DPRS(L)/AVRGTL
+                DST=DIFTL*DPOT+DST
+                DSQ=DIFQL*EL(L)*DPOT+DSQ
+                AVRGT=AVRGTL*DPRS(L)+AVRGT
+                PRECK=DIFTL*DPRS(L)+PRECK
+                PDQD=(QK(L)-QREFK(L))*DPRS(L)+PDQD
+                PRWD=QK(L)*DPRS(L)+PRWD
+                DIFT(L)=DIFTL
+                DIFQ(L)=DIFQL
+            ENDDO
+    !
+            DST=(DST+DST)*CP
+            DSQ=DSQ+DSQ
+            DENTPY=DST+DSQ
+            AVRGT=AVRGT/(SUMDP+SUMDP)
+    !
+    !        DRHEAT=PRECK*CP/AVRGT
+            DRHEAT=(PRECK*SM+MAX(1.E-7,PRECK)*(1.-SM))*CP/AVRGT !As in Eta!
+            DRHEAT=MAX(DRHEAT,1.E-20)
+            EFI=EFIFC*DENTPY/DRHEAT
+    !-----------------------------------------------------------------------
+            EFI=MIN(EFI,1.)
+            EFI=MAX(EFI,EFIMN)
+    !-----------------------------------------------------------------------
+    !
+            ENDDO  cloud_efficiency
+    !
+    !-----------------------------------------------------------------------
+    !
+    !-----------------------------------------------------------------------
+    !---------------------- DEEP CONVECTION --------------------------------
+    !-----------------------------------------------------------------------
+    !
+            IF(DENTPY>=EPSNTP.AND.PRECK>EPSPR)THEN
+    !
+            CLDEFI=EFI
+            FEFI=EFMNT+SLOPE*(EFI-EFIMN)
+            FEFI=(DENTPY-EPSNTP)*FEFI/DENTPY
+            PRECK=PRECK*FEFI
+    !
+    !***  UPDATE PRECIPITATION AND TENDENCIES OF TEMPERATURE AND MOISTURE
+    !
+            CUP=PRECK*CPRLG
+            PCPCOL=CUP
+            DQCOL=PDQD/G
+            PWCOL=PRWD/G
+            DQCOLMIN=(CRMN*TREL)/(FEFI*86400.)
+    !
+            DO L=LTOP,LB
+                DTDT(L)=DIFT(L)*FEFI*RDTCNVC
+                DQDT(L)=DIFQ(L)*FEFI*RDTCNVC
+            ENDDO
+    !
+            ELSE
+    !
+    !-----------------------------------------------------------------------
+    !***  REDUCE THE CLOUD TOP
+    !-----------------------------------------------------------------------
+    !
+    !        LTOP=LTOP+3
+    !        PTOP=PRSMID(LTOP)
+    !        DEPMIN=PSH*PSFC*RSFCP
+    !        DEPTH=PBOT-PTOP
+    !***
+    !***  ITERATE DEEP CONVECTION PROCEDURE IF NEEDED
+    !***
+    !        IF(DEPTH>=DEPMIN)THEN
+    !          GO TO 300
+    !        ENDIF
+    !
+    !        CLDEFI=AVGEFI
+                CLDEFI=EFIMN*SM+STEFI*(1.-SM)
+    !        CLDEFI=(EFIMN-0.1)*SM+(1.+0.1)*(1.-SM)
+    !***
+    !***  SEARCH FOR SHALLOW CLOUD TOP
+    !***
+    !        LTSH=LBOT
+    !        LBM1=LBOT-1
+    !        PBTK=PK(LBOT)
+    !        DEPMIN=PSH*PSFC*RSFCP
+    !        PTPK=PBTK-DEPMIN
+            PTPK=MAX(PSHU, PK(LBOT)-DEPMIN)
+    !***
+    !***  CLOUD TOP IS THE LEVEL JUST BELOW PBTK-PSH or JUST BELOW PSHU
+    !***
+            DO L=KTS,LMH
+                IF(PK(L)<=PTPK)LTOP=L+1
+            ENDDO
+    !
+    !        PTPK=PK(LTOP)
+    !!***
+    !!***  HIGHEST LEVEL ALLOWED IS LEVEL JUST BELOW PSHU
+    !!***
+    !        IF(PTPK<=PSHU)THEN
+    !!
+    !          DO L=KTS,LMH
+    !            IF(PK(L)<=PSHU)LSHU=L+1
+    !          ENDDO
+    !!
+    !          LTOP=LSHU
+    !          PTPK=PK(LTOP)
+    !        ENDIF
+    !
+    !        if(ltop>=lbot)then
+    !!!!!!     lbot=0
+    !          ltop=lmh
+    !!!!!!     pbot=pk(lbot)
+    !          ptop=pk(ltop)
+    !          pbot=ptop
+    !          go to 600
+    !        endif
+    !
+    !        LTP1=LTOP+1
+    !        LTP2=LTOP+2
+    !!
+    !        DO L=LTOP,LBOT
+    !          QSATK(L)=PQ0/PK(L)*EXP(A2*(TK(L)-A3)/(TK(L)-A4))
+    !        ENDDO
+    !!
+    !        RHH=QK(LTOP)/QSATK(LTOP)
+    !        RHMAX=0.
+    !        LTSH=LTOP
+    !!
+    !        DO L=LTP1,LBM1
+    !          RHL=QK(L)/QSATK(L)
+    !          DRHDP=(RHH-RHL)/(PK(L-1)-PK(L))
+    !!
+    !          IF(DRHDP>RHMAX)THEN
+    !            LTSH=L-1
+    !            RHMAX=DRHDP
+    !          ENDIF
+    !!
+    !          RHH=RHL
+    !        ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !-- Make shallow cloud top a function of virtual temperature excess (DTV)
+    !-----------------------------------------------------------------------
+    !
+            LTP1=LBOT
+            DO L=LBOT-1,LTOP,-1
+                IF (DTV(L) > 0.) THEN
+                LTP1=L
+                ELSE
+                EXIT
+                ENDIF
+            ENDDO
+            LTOP=MIN(LTP1,LBOT)
+    !***
+    !***  CLOUD MUST BE AT LEAST TWO LAYERS THICK
+    !***
+    !        IF(LBOT-LTOP<2)LTOP=LBOT-2  (eliminate this criterion)
+    !
+    !-- End: Buoyancy check (24 Aug 2006)
+    !
+            PTOP=PK(LTOP)
+            SHALLOW=.TRUE.
+            DEEP=.FALSE.
+    !
+            ENDIF
+    !DCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCD
+    !DCDCDCDCDCDCDC          END OF DEEP CONVECTION            DCDCDCDCDCDCD
+    !DCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCD
+    !
+    !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+        600 CONTINUE
+    !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+    !
+    !----------------GATHER SHALLOW CONVECTION POINTS-----------------------
+    !
+    !      IF(PTOP<=PBOT-PNO.AND.LTOP<=LBOT-2)THEN
+    !         DEPMIN=PSH*PSFC*RSFCP
+    !!
+    !!        if(lpbl<lbot)lbot=lpbl
+    !!        if(lbot>lmh-1)lbot=lmh-1
+    !!        pbot=prsmid(lbot)
+    !!
+    !         IF(PTOP+1.>=PBOT-DEPMIN)SHALLOW=.TRUE.
+    !      ELSE
+    !         LBOT=0
+    !         LTOP=KTE
+    !      ENDIF
+    !
+    !***********************************************************************
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+            IF(PRINT_DIAG)THEN
+            WRITE(6,"(a,2i3,L2,3e12.4)")  &
+                    '{cu2a lbot,ltop,shallow,pbot,ptop,depmin = ' &
+                    ,lbot,ltop,shallow,pbot,ptop,depmin
+            ENDIF
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+    !
+            IF(.NOT.SHALLOW)GO TO 800
+    !
+    !-----------------------------------------------------------------------
+    !***********************************************************************
+    !-----------------------------------------------------------------------
+    !SCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCS
+    !SCSCSCSCSCSCSC         SHALLOW CONVECTION          CSCSCSCSCSCSCSCSCSCS
+    !SCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCS
+    !-----------------------------------------------------------------------
+            DO L=KTS,LMH
+            TKL      =T(L)
+            TK   (L) =TKL
+            TREFK(L) =TKL
+            QKL      =Q(L)
+            QK   (L) =QKL
+            QREFK(L) =QKL
+            PKL      =PRSMID(L)
+            PK   (L) =PKL
+            QSATK(L) =PQ0/PK(L)*EXP(A2*(TK(L)-A3)/(TK(L)-A4))
+            APEKL    =APE(L)
+            APEK (L) =APEKL
+            THVMKL   =TKL*APEKL*(QKL*D608+1.)
+            THVREF(L)=THVMKL
+    !
+    !        IF(TKL>=TFRZ)THEN
+                EL(L)=ELWV
+    !        ELSE
+    !          EL(L)=ELIV
+    !        ENDIF
+            ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !-- Begin: Raise cloud top if avg RH>RHSHmax and CAPE>0
+    !   RHSHmax=RH at cloud base associated with a DSP of PONE
+    !-----------------------------------------------------------------------
+    !
+            TLEV2=T(LBOT)*((PK(LBOT)-PONE)/PK(LBOT))**CAPA
+            QSAT1=PQ0/PK(LBOT)*EXP(A2*(T(LBOT)-A3)/(TK(LBOT)-A4))
+            QSAT2=PQ0/(PK(LBOT)-PONE)*EXP(A2*(TLEV2-A3)/(TLEV2-A4))
+            RHSHmax=QSAT2/QSAT1
+            SUMDP=0.
+            RHAVG=0.
+    !
+            DO L=LBOT,LTOP,-1
+            RHAVG=RHAVG+DPRS(L)*QK(L)/QSATK(L)
+            SUMDP=SUMDP+DPRS(L)
+            ENDDO
+    !
+            IF (RHAVG/SUMDP > RHSHmax) THEN
+            LTSH=LTOP
+            DO L=LTOP-1,KTS,-1
+                RHAVG=RHAVG+DPRS(L)*QK(L)/QSATK(L)
+                SUMDP=SUMDP+DPRS(L)
+                IF (CPE(L) > 0.) THEN
+                LTSH=L
+                ELSE
+                EXIT
+                ENDIF
+                IF (RHAVG/SUMDP <= RHSHmax) EXIT
+                IF (PK(L) <= PSHU) EXIT
+            ENDDO
+            LTOP=LTSH
+            ENDIF
+    !
+    !-- End: Raise cloud top if avg RH>RHSHmax and CAPE>0
+    !
+    !---------------------------SHALLOW CLOUD TOP---------------------------
+            LBM1=LBOT-1
+            PTPK=PTOP
+            LTP1=LTOP-1
+            DEPTH=PBOT-PTOP
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+            IF(PRINT_DIAG)THEN
+            WRITE(6,"(a,4e12.4)") '{cu2b PBOT,PTOP,DEPTH,DEPMIN= ' &
+                    ,PBOT,PTOP,DEPTH,DEPMIN
+            ENDIF
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+    !
+    !BSF      IF(DEPTH<DEPMIN)THEN
+    !BSF        GO TO 800
+    !BSF      ENDIF
+    !-----------------------------------------------------------------------
+            IF(PTOP>PBOT-PNO.OR.LTOP>LBOT-2)THEN
+            LBOT=0
+    !!!     LTOP=LBOT
+            LTOP=KTE
+            PTOP=PBOT
+            GO TO 800
+            ENDIF
+    !
+    !--------------SCALING POTENTIAL TEMPERATURE & TABLE INDEX AT TOP-------
+    !
+            THTPK=T(LTP1)*APE(LTP1)
+    !
+            TTHK=(THTPK-THL)*RDTH
+            QQK =TTHK-AINT(TTHK)
+            IT  =INT(TTHK)+1
+    !
+            IF(IT<1)THEN
+            IT=1
+            QQK=0.
+            ENDIF
+    !
+            IF(IT>=JTB)THEN
+            IT=JTB-1
+            QQK=0.
+            ENDIF
+    !
+    !--------------BASE AND SCALING FACTOR FOR SPEC. HUMIDITY AT TOP--------
+    !
+            BQS00K=QS0(IT)
+            SQS00K=SQS(IT)
+            BQS10K=QS0(IT+1)
+            SQS10K=SQS(IT+1)
+    !
+    !--------------SCALING SPEC. HUMIDITY & TABLE INDEX AT TOP--------------
+    !
+            BQK=(BQS10K-BQS00K)*QQK+BQS00K
+            SQK=(SQS10K-SQS00K)*QQK+SQS00K
+    !
+    !     TQK=(Q(LTOP)-BQK)/SQK*RDQ
+            TQK=(Q(LTP1)-BQK)/SQK*RDQ
+    !
+            PPK=TQK-AINT(TQK)
+            IQ =INT(TQK)+1
+    !
+            IF(IQ<1)THEN
+            IQ=1
+            PPK=0.
+            ENDIF
+    !
+            IF(IQ>=ITB)THEN
+            IQ=ITB-1
+            PPK=0.
+            ENDIF
+    !
+    !----------------CLOUD TOP SATURATION POINT PRESSURE--------------------
+    !
+            PART1=(PTBL(IQ+1,IT)-PTBL(IQ,IT))*PPK
+            PART2=(PTBL(IQ,IT+1)-PTBL(IQ,IT))*QQK
+            PART3=(PTBL(IQ  ,IT  )-PTBL(IQ+1,IT  )                            &
+            &      -PTBL(IQ  ,IT+1)+PTBL(IQ+1,IT+1))*PPK*QQK
+            PTPK=PTBL(IQ,IT)+PART1+PART2+PART3
+    !-----------------------------------------------------------------------
+            DPMIX=PTPK-PSP
+            IF(ABS(DPMIX).LT.3000.)DPMIX=-3000.
+    !
+    !----------------TEMPERATURE PROFILE SLOPE------------------------------
+    !
+            SMIX=(THTPK-THBT)/DPMIX*STABS
+    !
+            TREFKX=TREFK(LBOT+1)
+            PKXXXX=PK(LBOT+1)
+            PKXXXY=PK(LBOT)
+            APEKXX=APEK(LBOT+1)
+            APEKXY=APEK(LBOT)
+    !
+            LMID=.5*(LBOT+LTOP)
+    !
+            DO L=LBOT,LTOP,-1
+            TREFKX=((PKXXXY-PKXXXX)*SMIX                                    &
+            &          +TREFKX*APEKXX)/APEKXY
+            TREFK(L)=TREFKX
+            IF(L<=LMID) TREFK(L)=MAX(TREFK(L), TK(L)+DTSHAL)
+            APEKXX=APEKXY
+            PKXXXX=PKXXXY
+            APEKXY=APEK(L-1)
+            PKXXXY=PK(L-1)
+            ENDDO
+    !
+    !----------------TEMPERATURE REFERENCE PROFILE CORRECTION---------------
+    !
+            SUMDT=0.
+            SUMDP=0.
+    !
+            DO L=LTOP,LBOT
+            SUMDT=(TK(L)-TREFK(L))*DPRS(L)+SUMDT
+            SUMDP=SUMDP+DPRS(L)
+            ENDDO
+    !
+            RDPSUM=1./SUMDP
+            FPK(LBOT)=TREFK(LBOT)
+    !
+            TCORR=SUMDT*RDPSUM
+    !
+            DO L=LTOP,LBOT
+            TRFKL   =TREFK(L)+TCORR
+            TREFK(L)=TRFKL
+            FPK  (L)=TRFKL
+            ENDDO
+    !
+    !----------------HUMIDITY PROFILE EQUATIONS-----------------------------
+    !
+            PSUM  =0.
+            QSUM  =0.
+            POTSUM=0.
+            QOTSUM=0.
+            OTSUM =0.
+            DST   =0.
+            FPTK  =FPK(LTOP)
+    !
+            DO L=LTOP,LBOT
+            DPKL  =FPK(L)-FPTK
+            PSUM  =DPKL *DPRS(L)+PSUM
+            QSUM  =QK(L)*DPRS(L)+QSUM
+            RTBAR =2./(TREFK(L)+TK(L))
+            OTSUM =DPRS(L)*RTBAR+OTSUM
+            POTSUM=DPKL    *RTBAR*DPRS(L)+POTSUM
+            QOTSUM=QK(L)   *RTBAR*DPRS(L)+QOTSUM
+            DST   =(TREFK(L)-TK(L))*RTBAR*DPRS(L)/EL(L)+DST
+            ENDDO
+    !
+            PSUM  =PSUM*RDPSUM
+            QSUM  =QSUM*RDPSUM
+            ROTSUM=1./OTSUM
+            POTSUM=POTSUM*ROTSUM
+            QOTSUM=QOTSUM*ROTSUM
+            DST   =DST*ROTSUM*CP
+    !
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+            IF(PRINT_DIAG)THEN
+            WRITE(6,"(a,5e12.4)") '{cu2c DST,PSUM,QSUM,POTSUM,QOTSUM = ' &
+                    ,DST,PSUM,QSUM,POTSUM,QOTSUM
+            ENDIF
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+    !
+    !----------------ENSURE POSITIVE ENTROPY CHANGE-------------------------
+    !
+            IF(DST>0.)THEN
+    !        dstq=dst*epsup
+            LBOT=0
+    !!!!    LTOP=LBOT
+            LTOP=KTE
+            PTOP=PBOT
+            GO TO 800
+            ELSE
+            DSTQ=DST*EPSDN
+            ENDIF
+    !
+    !----------------CHECK FOR ISOTHERMAL ATMOSPHERE------------------------
+    !
+            DEN=POTSUM-PSUM
+    !
+            IF(-DEN/PSUM<5.E-5)THEN
+            LBOT=0
+    !!!!    LTOP=LBOT
+            LTOP=KTE
+            PTOP=PBOT
+            GO TO 800
+    !
+    !----------------SLOPE OF THE REFERENCE HUMIDITY PROFILE----------------
+    !
+            ELSE
+            DQREF=(QOTSUM-DSTQ-QSUM)/DEN
+            ENDIF
+    !
+    !-------------- HUMIDITY DOES NOT INCREASE WITH HEIGHT------------------
+    !
+            IF(DQREF<0.)THEN
+            LBOT=0
+    !!!!    LTOP=LBOT
+            LTOP=KTE
+            PTOP=PBOT
+            GO TO 800
+            ENDIF
+    !
+    !----------------HUMIDITY AT THE CLOUD TOP------------------------------
+    !
+            QRFTP=QSUM-DQREF*PSUM
+    !
+    !----------------HUMIDITY PROFILE---------------------------------------
+    !
+            DO L=LTOP,LBOT
+            QRFKL=(FPK(L)-FPTK)*DQREF+QRFTP
+    !
+    !***  TOO DRY CLOUDS NOT ALLOWED
+    !
+            TNEW=(TREFK(L)-TK(L))*TAUKSC+TK(L)
+            QSATK(L)=PQ0/PK(L)*EXP(A2*(TNEW-A3)/(TNEW-A4))
+            QNEW=(QRFKL-QK(L))*TAUKSC+QK(L)
+    !
+            IF(QNEW<QSATK(L)*RHLSC)THEN
+                LBOT=0
+    !!!!      LTOP=LBOT
+                LTOP=KTE
+                PTOP=PBOT
+                GO TO 800
+            ENDIF
+    !
+    !-------------TOO MOIST CLOUDS NOT ALLOWED------------------------------
+    !
+            IF(QNEW>QSATK(L)*RHHSC)THEN
+                LBOT=0
+    !!!!      LTOP=LBOT
+                LTOP=KTE
+                PTOP=PBOT
+                GO TO 800
+            ENDIF
+    
+    !
+            THVREF(L)=TREFK(L)*APEK(L)*(QRFKL*D608+1.)
+            QREFK(L)=QRFKL
+            ENDDO
+    !
+    !------------------ ELIMINATE CLOUDS WITH BOTTOMS TOO DRY --------------
+    !!
+    !      qnew=(qrefk(lbot)-qk(lbot))*tauksc+qk(lbot)
+    !!
+    !      if(qnew<qk(lbot+1)*stresh)then  !!?? stresh too large!!
+    !        lbot=0
+    !!!!!!   ltop=lbot
+    !        ltop=kte
+    !        ptop=pbot
+    !        go to 800
+    !      endif
+    !!
+    !-------------- ELIMINATE IMPOSSIBLE SLOPES (BETTS,DTHETA/DQ)------------
+    !
+            DO L=LTOP,LBOT
+            DTDP=(THVREF(L-1)-THVREF(L))/(PRSMID(L)-PRSMID(L-1))
+    !
+            IF(DTDP<EPSDT)THEN
+                LBOT=0
+    !!!!!     LTOP=LBOT
+                LTOP=KTE
+                PTOP=PBOT
+                GO TO 800
+            ENDIF
+    !
+            ENDDO
+    !-----------------------------------------------------------------------
+    !--------------RELAXATION TOWARD REFERENCE PROFILES---------------------
+    !-----------------------------------------------------------------------
+    !
+            DO L=LTOP,LBOT
+            DTDT(L)=(TREFK(L)-TK(L))*TAUKSC*RDTCNVC
+            DQDT(L)=(QREFK(L)-QK(L))*TAUKSC*RDTCNVC
+            ENDDO
+    !
+    !-----------------------------------------------------------------------
+    !***  Begin debugging convection
+            IF(PRINT_DIAG)THEN
+            DO L=LBOT,LTOP,-1
+                WRITE(6,"(a,i3,4e12.4)") '{cu2 KFLIP,DT,DTDT,DQ,DQDT = ' &
+                    ,KTE+1-L,TREFK(L)-TK(L),DTDT(L),QREFK(L)-QK(L),DQDT(L)
+            ENDDO
+            ENDIF
+    !***  End debugging convection
+    !-----------------------------------------------------------------------
+    !
+    !-----------------------------------------------------------------------
+    !SCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCS
+    !SCSCSCSCSCSCSC         END OF SHALLOW CONVECTION        SCSCSCSCSCSCSCS
+    !SCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCSCS
+    !-----------------------------------------------------------------------
+        800 CONTINUE
+    !-----------------------------------------------------------------------
+            END SUBROUTINE BMJ
+    !-----------------------------------------------------------------------
+    !XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    !-----------------------------------------------------------------------
+                                SUBROUTINE TTBLEX                            &
+            & (ITBX,JTBX,PLX,PRSMID,RDPX,RDTHEX,STHE                           &
+            & ,THE0,THESP,TTBL,TREF)
+    !-----------------------------------------------------------------------
+    !     ******************************************************************
+    !     *                                                                *
+    !     *           EXTRACT TEMPERATURE OF THE MOIST ADIABAT FROM        *
+    !     *                      THE APPROPRIATE TTBL                      *
+    !     *                                                                *
+    !     ******************************************************************
+    !-----------------------------------------------------------------------
+            IMPLICIT NONE
+    !-----------------------------------------------------------------------
+            INTEGER,INTENT(IN) :: ITBX,JTBX
+    !
+            REAL,INTENT(IN) :: PLX,PRSMID,RDPX,RDTHEX,THESP
+    !
+            REAL,DIMENSION(ITBX),INTENT(IN) :: STHE,THE0
+    !
+            REAL,DIMENSION(JTBX,ITBX),INTENT(IN) :: TTBL
+    !
+            REAL,INTENT(OUT) :: TREF
+    !-----------------------------------------------------------------------
+            REAL :: BTHE00K,BTHE10K,BTHK,PK,PP,QQ,STHE00K,STHE10K,STHK        &
+            &       ,T00K,T01K,T10K,T11K,TPK,TTHK
+    !
+            INTEGER :: IPTB,ITHTB
+    !-----------------------------------------------------------------------
+    !----------------SCALING PRESSURE & TT TABLE INDEX----------------------
+    !-----------------------------------------------------------------------
+            PK=PRSMID
+            TPK=(PK-PLX)*RDPX
+            QQ=TPK-AINT(TPK)
+            IPTB=INT(TPK)+1
+    !----------------KEEPING INDICES WITHIN THE TABLE-----------------------
+            IF(IPTB<1)THEN
+            IPTB=1
+            QQ=0.
+            ENDIF
+    !
+            IF(IPTB>=ITBX)THEN
+            IPTB=ITBX-1
+            QQ=0.
+            ENDIF
+    !----------------BASE AND SCALING FACTOR FOR THETAE---------------------
+            BTHE00K=THE0(IPTB)
+            STHE00K=STHE(IPTB)
+            BTHE10K=THE0(IPTB+1)
+            STHE10K=STHE(IPTB+1)
+    !----------------SCALING THE & TT TABLE INDEX---------------------------
+            BTHK=(BTHE10K-BTHE00K)*QQ+BTHE00K
+            STHK=(STHE10K-STHE00K)*QQ+STHE00K
+            TTHK=(THESP-BTHK)/STHK*RDTHEX
+            PP=TTHK-AINT(TTHK)
+            ITHTB=INT(TTHK)+1
+    !----------------KEEPING INDICES WITHIN THE TABLE-----------------------
+            IF(ITHTB<1)THEN
+            ITHTB=1
+            PP=0.
+            ENDIF
+    !
+            IF(ITHTB>=JTBX)THEN
+            ITHTB=JTBX-1
+            PP=0.
+            ENDIF
+    !----------------TEMPERATURE AT FOUR SURROUNDING TT TABLE PTS.----------
+            T00K=TTBL(ITHTB,IPTB)
+            T10K=TTBL(ITHTB+1,IPTB)
+            T01K=TTBL(ITHTB,IPTB+1)
+            T11K=TTBL(ITHTB+1,IPTB+1)
+    !-----------------------------------------------------------------------
+    !----------------PARCEL TEMPERATURE-------------------------------------
+    !-----------------------------------------------------------------------
+            TREF=(T00K+(T10K-T00K)*PP+(T01K-T00K)*QQ                          &
+            &    +(T00K-T10K-T01K+T11K)*PP*QQ)
+    !-----------------------------------------------------------------------
+            END SUBROUTINE TTBLEX
+    !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+            SUBROUTINE BMJINIT(RTHCUTEN,RQVCUTEN,RQCCUTEN,RQRCUTEN            &
+            &                  ,CLDEFI,LOWLYR,CP,RD,RESTART                    &
+                            ,ALLOWED_TO_READ                                &
+            &                  ,IDS,IDE,JDS,JDE,KDS,KDE                        &
+            &                  ,IMS,IME,JMS,JME,KMS,KME                        &
+            &                  ,ITS,ITE,JTS,JTE,KTS,KTE)
+    !-----------------------------------------------------------------------
+            IMPLICIT NONE
+    !-----------------------------------------------------------------------
+            LOGICAL,INTENT(IN) :: RESTART,ALLOWED_TO_READ
+            INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE                     &
+            &                     ,IMS,IME,JMS,JME,KMS,KME                     &
+            &                     ,ITS,ITE,JTS,JTE,KTS,KTE
+    !
+            REAL,INTENT(IN) :: CP,RD
+    !
+            REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(OUT) ::            &
+            &                                              RTHCUTEN            &
+            &                                             ,RQVCUTEN            &
+            &                                             ,RQCCUTEN            &
+            &                                             ,RQRCUTEN
+    !
+            REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(OUT) :: CLDEFI
+    
+            INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: LOWLYR
+    !
+            REAL,PARAMETER :: EPS=1.E-9
+    !
+            REAL, DIMENSION(JTB) :: APP,APT,AQP,AQT,PNEW,POLD,QSNEW,QSOLD     &
+            &                       ,THENEW,THEOLD,TNEW,TOLD,Y2P,Y2T
+    !
+            REAL,DIMENSION(JTBQ) :: APTQ,AQTQ,THENEWQ,THEOLDQ                 &
+            &                       ,TNEWQ,TOLDQ,Y2TQ
+    !
+            INTEGER :: I,J,K,ITF,JTF,KTF
+            INTEGER :: KTH,KTHM,KTHM1,KP,KPM,KPM1
+    !
+            REAL :: APE,DP,DQS,DTH,DTHE,P,QS,QS0K,SQSK,STHEK                  &
+            &       ,TH,THE0K,DENOM,ELOCP
+    !-----------------------------------------------------------------------
+    
+            ELOCP=ELIWV/CP
+            JTF=MIN0(JTE,JDE-1)
+            KTF=MIN0(KTE,KDE-1)
+            ITF=MIN0(ITE,IDE-1)
+    ! 
+            IF(.NOT.RESTART)THEN
+            DO J=JTS,JTF
+            DO K=KTS,KTF
+            DO I=ITS,ITF
+                RTHCUTEN(I,K,J)=0.
+                RQVCUTEN(I,K,J)=0.
+                RQCCUTEN(I,K,J)=0.
+                RQRCUTEN(I,K,J)=0.
+            ENDDO
+            ENDDO
+            ENDDO
+    !
+            DO J=JTS,JTF
+            DO I=ITS,ITF
+                CLDEFI(I,J)=AVGEFI
+            ENDDO
+            ENDDO
+            ENDIF
+    !
+    !***  FOR NOW, ASSUME SIGMA MODE FOR LOWEST MODEL LAYER
+    !
+            DO J=JTS,JTF
+            DO I=ITS,ITF
+            LOWLYR(I,J)=1
+            ENDDO
+            ENDDO
+    !-----------------------------------------------------------------------
+    !----------------COARSE LOOK-UP TABLE FOR SATURATION POINT--------------
+    !-----------------------------------------------------------------------
+    !
+            KTHM=JTB
+            KPM=ITB
+            KTHM1=KTHM-1
+            KPM1=KPM-1
+    !
+            DTH=(THH-THL)/REAL(KTHM-1)
+            DP =(PH -PL )/REAL(KPM -1)
+    !
+            TH=THL-DTH
+    !-----------------------------------------------------------------------
+            DO 100 KTH=1,KTHM
+    !
+            TH=TH+DTH
+            P=PL-DP
+    !
+            DO KP=1,KPM
+            P=P+DP
+            APE=(100000./P)**(RD/CP)
+            DENOM=TH-A4*APE
+            IF (DENOM>EPS) THEN
+                QSOLD(KP)=PQ0/P*EXP(A2*(TH-A3*APE)/DENOM)
+            ELSE
+                QSOLD(KP)=0.
+            ENDIF
+            POLD(KP)=P
+            ENDDO
+    !
+            QS0K=QSOLD(1)
+            SQSK=QSOLD(KPM)-QSOLD(1)
+            QSOLD(1  )=0.
+            QSOLD(KPM)=1.
+    !
+            DO KP=2,KPM1
+            QSOLD(KP)=(QSOLD(KP)-QS0K)/SQSK
+            IF((QSOLD(KP)-QSOLD(KP-1)).LT.EPS)QSOLD(KP)=QSOLD(KP-1)+EPS
+            ENDDO
+    !
+            QS0(KTH)=QS0K
+            QS0_EXP(KTH)=QS0K
+            SQS(KTH)=SQSK
+            SQS_EXP(KTH)=SQSK
+    !-----------------------------------------------------------------------
+            QSNEW(1  )=0.
+            QSNEW(KPM)=1.
+            DQS=1./REAL(KPM-1)
+    !
+            DO KP=2,KPM1
+            QSNEW(KP)=QSNEW(KP-1)+DQS
+            ENDDO
+    !
+            Y2P(1   )=0.
+            Y2P(KPM )=0.
+    !
+            CALL SPLINE(JTB,KPM,QSOLD,POLD,Y2P,KPM,QSNEW,PNEW,APP,AQP)
+    !
+            DO KP=1,KPM
+            PTBL(KP,KTH)=PNEW(KP)
+            PTBL_EXP(KP,KTH)=PNEW(KP)
+            ENDDO
+    !-----------------------------------------------------------------------
+        100 CONTINUE
+    !-----------------------------------------------------------------------
+    !------------COARSE LOOK-UP TABLE FOR T(P) FROM CONSTANT THE------------
+    !-----------------------------------------------------------------------
+            P=PL-DP
+    !
+            DO 200 KP=1,KPM
+    !
+            P=P+DP
+            TH=THL-DTH
+    !
+            DO KTH=1,KTHM
+            TH=TH+DTH
+            APE=(1.E5/P)**(RD/CP)
+            DENOM=TH-A4*APE
+            IF (DENOM>EPS) THEN
+                QS=PQ0/P*EXP(A2*(TH-A3*APE)/DENOM)
+            ELSE
+                QS=0.
+            ENDIF
+    !        QS=PQ0/P*EXP(A2*(TH-A3*APE)/(TH-A4*APE))
+            TOLD(KTH)=TH/APE
+            THEOLD(KTH)=TH*EXP(ELOCP*QS/TOLD(KTH))
+            ENDDO
+    !
+            THE0K=THEOLD(1)
+            STHEK=THEOLD(KTHM)-THEOLD(1)
+            THEOLD(1   )=0.
+            THEOLD(KTHM)=1.
+    !
+            DO KTH=2,KTHM1
+            THEOLD(KTH)=(THEOLD(KTH)-THE0K)/STHEK
+            IF((THEOLD(KTH)-THEOLD(KTH-1)).LT.EPS)                          &
+            &      THEOLD(KTH)=THEOLD(KTH-1)  +  EPS
+            ENDDO
+    !
+            THE0(KP)=THE0K
+            STHE(KP)=STHEK
+    !-----------------------------------------------------------------------
+            THENEW(1  )=0.
+            THENEW(KTHM)=1.
+            DTHE=1./REAL(KTHM-1)
+    !
+            DO KTH=2,KTHM1
+            THENEW(KTH)=THENEW(KTH-1)+DTHE
+            ENDDO
+    !
+            Y2T(1   )=0.
+            Y2T(KTHM)=0.
+    !
+            CALL SPLINE(JTB,KTHM,THEOLD,TOLD,Y2T,KTHM,THENEW,TNEW,APT,AQT)
+    !
+            DO KTH=1,KTHM
+            TTBL(KTH,KP)=TNEW(KTH)
+            ENDDO
+    !-----------------------------------------------------------------------
+        200 CONTINUE
+    !-----------------------------------------------------------------------
+    !
+    !-----------------------------------------------------------------------
+    !---------------FINE LOOK-UP TABLE FOR SATURATION POINT-----------------
+    !-----------------------------------------------------------------------
+            KTHM=JTBQ
+            KPM=ITBQ
+            KTHM1=KTHM-1
+            KPM1=KPM-1
+    !
+            DTH=(THHQ-THL)/REAL(KTHM-1)
+            DP=(PH-PLQ)/REAL(KPM-1)
+    !
+            TH=THL-DTH
+            P=PLQ-DP
+    !-----------------------------------------------------------------------
+    !---------------FINE LOOK-UP TABLE FOR T(P) FROM CONSTANT THE-----------
+    !-----------------------------------------------------------------------
+            DO 300 KP=1,KPM
+    !
+            P=P+DP
+            TH=THL-DTH
+    !
+            DO KTH=1,KTHM
+            TH=TH+DTH
+            APE=(1.E5/P)**(RD/CP)
+            DENOM=TH-A4*APE
+            IF (DENOM>EPS) THEN
+                QS=PQ0/P*EXP(A2*(TH-A3*APE)/DENOM)
+            ELSE
+                QS=0.
+            ENDIF
+    !        QS=PQ0/P*EXP(A2*(TH-A3*APE)/(TH-A4*APE))
+            TOLDQ(KTH)=TH/APE
+            THEOLDQ(KTH)=TH*EXP(ELOCP*QS/TOLDQ(KTH))
+            ENDDO
+    !
+            THE0K=THEOLDQ(1)
+            STHEK=THEOLDQ(KTHM)-THEOLDQ(1)
+            THEOLDQ(1   )=0.
+            THEOLDQ(KTHM)=1.
+    !
+            DO KTH=2,KTHM1
+            THEOLDQ(KTH)=(THEOLDQ(KTH)-THE0K)/STHEK
+            IF((THEOLDQ(KTH)-THEOLDQ(KTH-1))<EPS)                           &
+            &      THEOLDQ(KTH)=THEOLDQ(KTH-1)+EPS
+            ENDDO
+    !
+            THE0Q(KP)=THE0K
+            STHEQ(KP)=STHEK
+    !-----------------------------------------------------------------------
+            THENEWQ(1  )=0.
+            THENEWQ(KTHM)=1.
+            DTHE=1./REAL(KTHM-1)
+    !
+            DO KTH=2,KTHM1
+            THENEWQ(KTH)=THENEWQ(KTH-1)+DTHE
+            ENDDO
+    !
+            Y2TQ(1   )=0.
+            Y2TQ(KTHM)=0.
+    !
+            CALL SPLINE(JTBQ,KTHM,THEOLDQ,TOLDQ,Y2TQ,KTHM                     &
+            &           ,THENEWQ,TNEWQ,APTQ,AQTQ)
+    !
+            DO KTH=1,KTHM
+            TTBLQ(KTH,KP)=TNEWQ(KTH)
+            ENDDO
+    !-----------------------------------------------------------------------
+        300 CONTINUE
+    !-----------------------------------------------------------------------
+            END SUBROUTINE BMJINIT
+    !-----------------------------------------------------------------------
+    !XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    !-----------------------------------------------------------------------
+            SUBROUTINE SPLINE(JTBX,NOLD,XOLD,YOLD,Y2,NNEW,XNEW,YNEW,P,Q)
+    !   ********************************************************************
+    !   *                                                                  *
+    !   *  THIS IS A ONE-DIMENSIONAL CUBIC SPLINE FITTING ROUTINE          *
+    !   *  PROGRAMED FOR A SMALL SCALAR MACHINE.                           *
+    !   *                                                                  *
+    !   *  PROGRAMER Z. JANJIC                                             *
+    !   *                                                                  *
+    !   *  NOLD - NUMBER OF GIVEN VALUES OF THE FUNCTION.  MUST BE GE 3.   *
+    !   *  XOLD - LOCATIONS OF THE POINTS AT WHICH THE VALUES OF THE       *
+    !   *         FUNCTION ARE GIVEN.  MUST BE IN ASCENDING ORDER.         *
+    !   *  YOLD - THE GIVEN VALUES OF THE FUNCTION AT THE POINTS XOLD.     *
+    !   *  Y2   - THE SECOND DERIVATIVES AT THE POINTS XOLD.  IF NATURAL   *
+    !   *         SPLINE IS FITTED Y2(1)=0. AND Y2(NOLD)=0. MUST BE        *
+    !   *         SPECIFIED.                                               *
+    !   *  NNEW - NUMBER OF VALUES OF THE FUNCTION TO BE CALCULATED.       *
+    !   *  XNEW - LOCATIONS OF THE POINTS AT WHICH THE VALUES OF THE       *
+    !   *         FUNCTION ARE CALCULATED.  XNEW(K) MUST BE GE XOLD(1)     *
+    !   *         AND LE XOLD(NOLD).                                       *
+    !   *  YNEW - THE VALUES OF THE FUNCTION TO BE CALCULATED.             *
+    !   *  P, Q - AUXILIARY VECTORS OF THE LENGTH NOLD-2.                  *
+    !   *                                                                  *
+    !   ********************************************************************
+    !-----------------------------------------------------------------------
+            IMPLICIT NONE
+    !-----------------------------------------------------------------------
+            INTEGER,INTENT(IN) :: JTBX,NNEW,NOLD
+            REAL,DIMENSION(JTBX),INTENT(IN) :: XNEW,XOLD,YOLD
+            REAL,DIMENSION(JTBX),INTENT(INOUT) :: P,Q,Y2
+            REAL,DIMENSION(JTBX),INTENT(OUT) :: YNEW
+    !
+            INTEGER :: K,K1,K2,KOLD,NOLDM1
+            REAL :: AK,BK,CK,DEN,DX,DXC,DXL,DXR,DYDXL,DYDXR                   &
+            &       ,RDX,RTDXC,X,XK,XSQ,Y2K,Y2KP1
+    !-----------------------------------------------------------------------
+            NOLDM1=NOLD-1
+    !
+            DXL=XOLD(2)-XOLD(1)
+            DXR=XOLD(3)-XOLD(2)
+            DYDXL=(YOLD(2)-YOLD(1))/DXL
+            DYDXR=(YOLD(3)-YOLD(2))/DXR
+            RTDXC=0.5/(DXL+DXR)
+    !
+            P(1)= RTDXC*(6.*(DYDXR-DYDXL)-DXL*Y2(1))
+            Q(1)=-RTDXC*DXR
+    !
+            IF(NOLD==3)GO TO 150
+    !-----------------------------------------------------------------------
+            K=3
+    !
+        100 DXL=DXR
+            DYDXL=DYDXR
+            DXR=XOLD(K+1)-XOLD(K)
+            DYDXR=(YOLD(K+1)-YOLD(K))/DXR
+            DXC=DXL+DXR
+            DEN=1./(DXL*Q(K-2)+DXC+DXC)
+    !
+            P(K-1)= DEN*(6.*(DYDXR-DYDXL)-DXL*P(K-2))
+            Q(K-1)=-DEN*DXR
+    !
+            K=K+1
+            IF(K<NOLD)GO TO 100
+    !-----------------------------------------------------------------------
+        150 K=NOLDM1
+    !
+        200 Y2(K)=P(K-1)+Q(K-1)*Y2(K+1)
+    !
+            K=K-1
+            IF(K>1)GO TO 200
+    !-----------------------------------------------------------------------
+            K1=1
+    !
+        300 XK=XNEW(K1)
+    !
+            DO 400 K2=2,NOLD
+    !
+            IF(XOLD(K2)>XK)THEN
+            KOLD=K2-1
+            GO TO 450
+            ENDIF
+    !
+        400 CONTINUE
+    !
+            YNEW(K1)=YOLD(NOLD)
+            GO TO 600
+    !
+        450 IF(K1==1)GO TO 500
+            IF(K==KOLD)GO TO 550
+    !
+        500 K=KOLD
+    !
+            Y2K=Y2(K)
+            Y2KP1=Y2(K+1)
+            DX=XOLD(K+1)-XOLD(K)
+            RDX=1./DX
+    !
+            AK=.1666667*RDX*(Y2KP1-Y2K)
+            BK=0.5*Y2K
+            CK=RDX*(YOLD(K+1)-YOLD(K))-.1666667*DX*(Y2KP1+Y2K+Y2K)
+    !
+        550 X=XK-XOLD(K)
+            XSQ=X*X
+    !
+            YNEW(K1)=AK*XSQ*X+BK*XSQ+CK*X+YOLD(K)
+    !
+        600 K1=K1+1
+            IF(K1<=NNEW)GO TO 300
+    !-----------------------------------------------------------------------
+            END SUBROUTINE SPLINE
+    !-----------------------------------------------------------------------
+    !
+            END MODULE MODULE_CU_BMJ
+    !
+    !-----------------------------------------------------------------------

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -143,7 +143,7 @@ contains
          !                 NCA,W0AVG,1,1,                   & !...,P_QI,P_QS
          !                 0,.false.,.true.,                & ! P_FIRST_SCALAR, restart, allowed_to_read
          !                 ids, ide, jds, jde, kds, kde,  &
-         !                 ids, ide, jds, jde, kds, kde,    &
+         !                 ids, ide, jds, jde, kds, kde,    &  ! !!!!!!!!!!!! kme iso kde!
          !                 ids, ide, jds, jde, kds, kde-1)
 
 
@@ -280,12 +280,12 @@ subroutine convect(domain,options,dt_in)
     !           ,domain%tend%qv, domain%tend%qc                &
     !           ,domain%tend%qr, domain%tend%qi                &
     !           ,domain%tend%qs, domain%tend%th)
+
     elseif (options%physics%convection==kCU_NSAS) then
 
         ! TO DO:
         !  - calculate height of PBL
         !  - use wrf_constants.f90 ?
-
 
         ! set dx_factor_nsas (cu_nsas.f90 line 567):
         if (domain%dx.le.1000) then
@@ -369,7 +369,8 @@ subroutine convect(domain,options,dt_in)
     ! use a separate dt to make it easier to apply on a different dt
     internal_dt = dt_in
 
-    if (options%physics%convection==kCU_TIEDTKE) then
+    ! if (options%physics%convection==kCU_TIEDTKE) then
+    if ((options%physics%convection==kCU_TIEDTKE) .or. (options%physics%convection==kCU_NSAS)) then
         ! $omp parallel private(j) &
         ! $omp default(shared)
         ! $omp do schedule(static)

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -8,11 +8,9 @@
 module convection
     use data_structures
     use icar_constants
-    use mod_wrf_constants
     use module_cu_tiedtke,  only: tiedtkeinit, CU_TIEDTKE
     ! use module_cu_kf,       only: kfinit, KFCPS
     use module_cu_nsas,  only: nsasinit, cu_nsas
-    use module_cu_bmj,  only: bmjinit, bmjdrv
 
     use options_interface,   only : options_t
     use domain_interface,    only : domain_t
@@ -21,18 +19,14 @@ module convection
     private
     public :: init_convection, convect, cu_var_request
 
-    logical,allocatable, dimension(:,:) ::  CU_ACT_FLAG
-    real,   allocatable, dimension(:,:) ::  XLAND, RAINCV, PRATEC, NCA
+    logical,allocatable, dimension(:,:) :: CU_ACT_FLAG
+    real,   allocatable, dimension(:,:) :: XLAND, RAINCV, PRATEC, NCA
     real,   allocatable, dimension(:,:,:):: W0AVG, w_stochastic
-    real,   allocatable, dimension(:,:)::   lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS.
-    real,   allocatable, dimension(:,:)::   CLDEFI ! precipitation efficiency (for BMJ scheme) (dimensionless)
-    real,   allocatable, dimension(:,:)::   CUBOT,CUTOP, CONVCLD  ! for BMJ scheme
-    real,   allocatable, dimension(:,:,:):: CCLDFRA, QCCONV, QICONV ! for BMJ scheme
+    real,   allocatable, dimension(:,:)::  lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS. 
+
     integer :: ids,ide,jds,jde,kds,kde ! Domain dimensions
     integer :: ims,ime,jms,jme,kms,kme ! Local Memory dimensions
     integer :: its,ite,jts,jte,kts,kte ! Processing Tile dimensions
-    integer, allocatable, dimension(:,:) :: lowlyr, kpbl  ! for bmj scheme
-    logical :: bmj_rad_feedback
 
 contains
 
@@ -71,23 +65,6 @@ contains
                          [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
                          kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
                          kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
-
-        else if (options%physics%convection == kCU_BMJ) then  ! Not checked thoroughly yet
-            call options%alloc_vars( &
-                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
-                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
-                         kVARS%exner, kVARS%dz_interface, kVARS%density, kVARS%pressure_interface, kVARS%pressure,  &
-                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%w, kVARS%land_mask,        &
-                         kVARS%tend_qv, kVARS%tend_th, kVARS%tend_qc, kVARS%tend_qi, kVARS%tend_qs, kVARS%tend_qr,  &
-                         kVARS%tend_u, kVARS%tend_v])
-
-             call options%advect_vars([kVARS%potential_temperature, kVARS%water_vapor])
-
-             call options%restart_vars( &
-                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
-                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
-                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
-
         endif
 
 
@@ -200,56 +177,7 @@ contains
                             ,its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte &  ! -1 or not? 
                             )
 
-        else if (options%physics%convection==kCU_BMJ) then
-            if (this_image()==1) write(*,*) "     BMJ Cumulus scheme"
 
-            ! TO DO:
-            !   - add kCU_BMJ to options
-            !   - kpbl (layer index of the pbl (top? bottom? ....))
-            !   - ...
-
-            allocate( CLDEFI(ims:ime,jms:jme) )
-            allocate( CUBOT(IMS:IME,JMS:JME) )
-            allocate( CUTOP(IMS:IME,JMS:JME) )  ! INTENT:OUT
-            allocate( CCLDFRA(ims:ime,jms:jme,kms:kme) )  
-            allocate( QCCONV(ims:ime,jms:jme,kms:kme) )
-            allocate( QICONV(ims:ime,jms:jme,kms:kme) )
-            allocate( CONVCLD(ims:ime,jms:jme) )
-            allocate( lowlyr(ims:ime,jms:jme) )
-            allocate( kpbl(ims:ime,jms:jme) )
-
-
-            ! ----- the values below are just educated (or not) guesses. Need to refine.  -------
-            ! INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) :: KPBL,LOWLYR
-            do i=ims,ime
-                do j=jms,jme
-                    lowlyr(i,j) = 1 ! ???? 
-                    kpbl(i,j) = 10 !????
-                enddo
-            enddo
-            bmj_rad_feedback = .true.  !??
-
-            call BMJINIT( rthcuten=domain%tend%th                               &
-                         ,rqvcuten=domain%tend%qv                               &
-                         ,rqccuten=domain%tend%qc                               &
-                         ,rqrcuten=domain%tend%qr                               & !-- RQRCUTEN      Qr tendency due to cumulus scheme precipitation (kg/kg/s)
-                         ,cldefi=CLDEFI                                         & !-- CLDEFI        precipitation efficiency (for BMJ scheme) (dimensionless)
-                         ,lowlyr=lowlyr                                         & !-- LOWLYR        index of lowest model layer above the ground
-                         ,cp=cp                                                 & ! cp  = 1012.0    ! J/kg/K   specific heat capacity of moist STP air?                 CP
-                         ,RD=r_d                      & ! r_d (wrf_constatns) = 287., while Rd  = 287.058 (icar_constants)          
-                         ,RESTART= .false.                                      &
-                         ,allowed_to_read=.true.                                & !
-                         ,ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde  &
-                         ,ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme  &
-                         ,its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte  &  ! -1 or not?
-                         )
-
-         endif
-
-         if ((options%cu_options%stochastic_cu /= kNO_STOCHASTIC) .and.  (this_image()==1)) then
-            write(*,*)"      stochastic W pertubation for convection triggering"  ! to check that it actually turns on/of
-         elseif ((options%cu_options%stochastic_cu == kNO_STOCHASTIC) .and.  (this_image()==1)) then
-            write(*,*)"      No stochastic W pertubation for convection triggering"  
          endif
 
     end subroutine init_convection
@@ -319,8 +247,8 @@ subroutine convect(domain,options,dt_in)
                 ,domain%density%data_3d                         &
                 ,domain%tend%qv_adv                             &
                 ,domain%tend%qv_pbl                             &
-                ,domain%dz_interface%data_3d                    & ! dz8w
-                ,domain%pressure%data_3d                        & ! 
+                ,domain%dz_interface%data_3d                    &
+                ,domain%pressure%data_3d                        &
                 ,domain%pressure_interface%data_3d              &
                 ,XLAND, CU_ACT_FLAG                             &
                 ,ids,ide, jds,jde, kds,kde                      &
@@ -368,7 +296,7 @@ subroutine convect(domain,options,dt_in)
 
         call cu_nsas( &
             dt=dt_in               & !-- dt          time step (s)
-            ,dx=domain%dx           & !-- dx          grid interval (m)
+            ,dx=domain%dx           & !-- dx          grid interval (m)   ! till here
             ,p3di=domain%pressure_interface%data_3d              & !-- p3di        3d pressure (pa) at interface level
             ,p3d=domain%pressure%data_3d                         & !-- p3d         3d pressure (pa)
             ,pi3d=domain%exner%data_3d                           & !-- pi3d        3d exner function (dimensionless)
@@ -381,8 +309,8 @@ subroutine convect(domain,options,dt_in)
             ,htop=highest_convection_layer                       & !-- HTOP          index of highest model layer with convection
             ,cu_act_flag=CU_ACT_FLAG                             &
             ,rthcuten=domain%tend%th                             &
-            ,rqvcuten=domain%tend%qv                             & !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)
-            ,rqccuten=domain%tend%qc                             & !--   ...etc...
+            ,rqvcuten=domain%tend%qv                             &
+            ,rqccuten=domain%tend%qc                             &
             ,rqicuten=domain%tend%qi                             &
             ,rucuten=domain%tend%u                               &
             ,rvcuten=domain%tend%v                               &
@@ -396,11 +324,11 @@ subroutine convect(domain,options,dt_in)
             ,u3d=domain%u_mass%data_3d                           & !-- u3d         3d u-velocity interpolated to theta points (m/s)
             ,v3d=domain%v_mass%data_3d                           & !-- v3d         3d v-velocity interpolated to theta points (m/s)
             ,hpbl=hpbl  &  ! ?? PBL height I assume? But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
-            ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)
+            ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)       
             ,qfx=domain%latent_heat%data_2d/LH_vaporization       & !  QFX  - net upward moisture flux at the surface (kg/m^2/s)
             ,mp_physics=5        & ! - sets ncloud: - integer no_cloud(0),no_ice(1),cloud+ice(2) (see ln 141 cu_nsas.f90)  use options%physics%microphysics?
             ,dx_factor_nsas=dx_factor_nsas                       & !
-            ,p_qc=1                                              & ! copied from Tiedke; no idea as to what these 3 flags represent.
+            ,p_qc=1                                              & ! copied from Tiedke; no idea as to what these 3 flags represent. 
             ,p_qi=1                                              &
             ,p_first_scalar=0                                    &
             ! ,pgcon=""                                            & ! pgcon_use  = 0.55  ! Zhang & Wu (2003,JAS) ! 0.55 is a physically-based value used by GFS
@@ -423,9 +351,9 @@ subroutine convect(domain,options,dt_in)
             its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1 )
         ! ! ! Definitions (for coupling - temporary):
         ! - - - - - - - - - - - - - - - - -
-        ! microphysics scheme --> ncloud
+        ! microphysics scheme --> ncloud 
         !
-        !      !! ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2)
+        !      !! ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2) 
         !    if (mp_physics .eq. 0) then
         !     ncloud = 0
         !   elseif ( mp_physics .eq. 1 .or. mp_physics .eq. 3 ) then
@@ -435,42 +363,6 @@ subroutine convect(domain,options,dt_in)
         !   endif
         ! - - - - - - - - - - - - - - - - -
 
-
-    elseif (options%physics%convection==kCU_BMJ) then
-        CALL BMJDRV(                                            &
-                TH=domain%potential_temperature%data_3d         &
-                ,T=domain%temperature%data_3d                   &
-                ,RAINCV=RAINCV                                  &
-                ,PRATEC=PRATEC                                  &
-                ,rho=domain%density%data_3d                     &
-                ,dt=dt_in                                       & !-- dt          time step (s)
-                ,ITIMESTEP=itimestep ,STEPCU=stepcu             &
-                ,CUTOP=CUTOP, CUBOT=CUBOT                       &
-                ,KPBL=kpbl                                      &!-- KPBL          layer index of the PBL
-                ,dz8w=domain%dz_interface%data_3d               &!-- dz8w          dz between full levels (m)
-                ,PINT=domain%pressure_interface%data_3d         &  !-- p8w           pressure at full levels (Pa)
-                ,PMID=domain%pressure%data_3d                   &!-- Pcps        3D hydrostatic pressure at half levels (Pa)
-                ,PI=domain%exner%data_3d                        &   ! exner
-                ,CP=cp ,R=r_d ,ELWV=xlv ,ELIV=xls ,G=gravity    &
-                ,TFRZ=svpt0 ,D608=ep_1 ,CLDEFI=cldefi           &
-                ,LOWLYR=lowlyr                                  &
-                ,XLAND=XLAND                                    &
-                ,CU_ACT_FLAG=CU_ACT_FLAG                        &
-                ,QV=domain%water_vapor%data_3d                  &
-                ,CCLDFRA=CCLDFRA                                &                 !-- CCLDFRA       convective cloud fraction (for BMJ scheme)
-                ,CONVCLD=CONVCLD                                &  !-- CONVCLD       Convective cloud (for BMJ scheme) (kg/m^2)
-                ,QCCONV=qcconv                                  &! QCCONV     convective cloud mixing ratio (kg/kg)
-                ,QICONV=qiconv                                  &! QICONV     convective ice mixing ratio (kg/kg)
-                ,BMJ_RAD_FEEDBACK=bmj_rad_feedback                 &
-                ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde   &
-                ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme   &
-                ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte-1 &
-                ! optionals
-                ,rthcuten=domain%tend%th                           &  !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)
-                ,rqvcuten=domain%tend%qv                           &  !-- RTHCUTEN      Theta tendency due to cumulus scheme precipitation (K/s)
-                )
-
-
     endif
 
     ! add domain wide tendency terms
@@ -478,20 +370,12 @@ subroutine convect(domain,options,dt_in)
     internal_dt = dt_in
 
     ! if (options%physics%convection==kCU_TIEDTKE) then
-    if ( &
-        (options%physics%convection==kCU_TIEDTKE) .or.  &
-        (options%physics%convection==kCU_NSAS) .or.     &
-        (options%physics%convection==kCU_BMJ)           &
-        ) then
+    if ((options%physics%convection==kCU_TIEDTKE) .or. (options%physics%convection==kCU_NSAS)) then
         ! $omp parallel private(j) &
         ! $omp default(shared)
         ! $omp do schedule(static)
         do j=jts,jte
             if (options%cu_options%tendency_fraction > 0) then
-                ! Here we adjust the tendencies calculated by the cumulus scheme based on the namelist setting tendency_fraction (cu_parameters)
-                !-- RTHCUTEN      Theta tendency due to cumulus scheme precipitation (K/s)  (domain%tend%qv)
-                !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)  (domain%tend%th)
-                ! -- ...etc
                 if (options%cu_options%tend_qv_fraction > 0) domain%water_vapor%data_3d(:,:,j)           = domain%water_vapor%data_3d(:,:,j)           + domain%tend%qv(:,:,j)*internal_dt * options%cu_options%tend_qv_fraction
                 if (options%cu_options%tend_qc_fraction > 0) domain%cloud_water_mass%data_3d(:,:,j)      = domain%cloud_water_mass%data_3d(:,:,j)      + domain%tend%qc(:,:,j)*internal_dt * options%cu_options%tend_qc_fraction
                 if (options%cu_options%tend_th_fraction > 0) domain%potential_temperature%data_3d(:,:,j) = domain%potential_temperature%data_3d(:,:,j) + domain%tend%th(:,:,j)*internal_dt * options%cu_options%tend_th_fraction
@@ -514,7 +398,6 @@ subroutine convect(domain,options,dt_in)
         enddo
         ! $omp end do
         ! $omp end parallel
-
     endif
 
 end subroutine convect

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -8,9 +8,11 @@
 module convection
     use data_structures
     use icar_constants
+    use mod_wrf_constants
     use module_cu_tiedtke,  only: tiedtkeinit, CU_TIEDTKE
     ! use module_cu_kf,       only: kfinit, KFCPS
     use module_cu_nsas,  only: nsasinit, cu_nsas
+    use module_cu_bmj,  only: bmjinit, bmjdrv
 
     use options_interface,   only : options_t
     use domain_interface,    only : domain_t
@@ -19,14 +21,18 @@ module convection
     private
     public :: init_convection, convect, cu_var_request
 
-    logical,allocatable, dimension(:,:) :: CU_ACT_FLAG
-    real,   allocatable, dimension(:,:) :: XLAND, RAINCV, PRATEC, NCA
+    logical,allocatable, dimension(:,:) ::  CU_ACT_FLAG
+    real,   allocatable, dimension(:,:) ::  XLAND, RAINCV, PRATEC, NCA
     real,   allocatable, dimension(:,:,:):: W0AVG, w_stochastic
-    real,   allocatable, dimension(:,:)::  lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS. 
-
+    real,   allocatable, dimension(:,:)::   lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS.
+    real,   allocatable, dimension(:,:)::   CLDEFI ! precipitation efficiency (for BMJ scheme) (dimensionless)
+    real,   allocatable, dimension(:,:)::   CUBOT,CUTOP, CONVCLD  ! for BMJ scheme
+    real,   allocatable, dimension(:,:,:):: CCLDFRA, QCCONV, QICONV ! for BMJ scheme
     integer :: ids,ide,jds,jde,kds,kde ! Domain dimensions
     integer :: ims,ime,jms,jme,kms,kme ! Local Memory dimensions
     integer :: its,ite,jts,jte,kts,kte ! Processing Tile dimensions
+    integer, allocatable, dimension(:,:) :: lowlyr, kpbl  ! for bmj scheme
+    logical :: bmj_rad_feedback
 
 contains
 
@@ -65,6 +71,23 @@ contains
                          [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
                          kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
                          kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
+
+        else if (options%physics%convection == kCU_BMJ) then  ! Not checked thoroughly yet
+            call options%alloc_vars( &
+                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
+                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
+                         kVARS%exner, kVARS%dz_interface, kVARS%density, kVARS%pressure_interface, kVARS%pressure,  &
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%w, kVARS%land_mask,        &
+                         kVARS%tend_qv, kVARS%tend_th, kVARS%tend_qc, kVARS%tend_qi, kVARS%tend_qs, kVARS%tend_qr,  &
+                         kVARS%tend_u, kVARS%tend_v])
+
+             call options%advect_vars([kVARS%potential_temperature, kVARS%water_vapor])
+
+             call options%restart_vars( &
+                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
+                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
+
         endif
 
 
@@ -177,7 +200,56 @@ contains
                             ,its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte &  ! -1 or not? 
                             )
 
+        else if (options%physics%convection==kCU_BMJ) then
+            if (this_image()==1) write(*,*) "     BMJ Cumulus scheme"
 
+            ! TO DO:
+            !   - add kCU_BMJ to options
+            !   - kpbl (layer index of the pbl (top? bottom? ....))
+            !   - ...
+
+            allocate( CLDEFI(ims:ime,jms:jme) )
+            allocate( CUBOT(IMS:IME,JMS:JME) )
+            allocate( CUTOP(IMS:IME,JMS:JME) )  ! INTENT:OUT
+            allocate( CCLDFRA(ims:ime,jms:jme,kms:kme) )  
+            allocate( QCCONV(ims:ime,jms:jme,kms:kme) )
+            allocate( QICONV(ims:ime,jms:jme,kms:kme) )
+            allocate( CONVCLD(ims:ime,jms:jme) )
+            allocate( lowlyr(ims:ime,jms:jme) )
+            allocate( kpbl(ims:ime,jms:jme) )
+
+
+            ! ----- the values below are just educated (or not) guesses. Need to refine.  -------
+            ! INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) :: KPBL,LOWLYR
+            do i=ims,ime
+                do j=jms,jme
+                    lowlyr(i,j) = 1 ! ???? 
+                    kpbl(i,j) = 10 !????
+                enddo
+            enddo
+            bmj_rad_feedback = .true.  !??
+
+            call BMJINIT( rthcuten=domain%tend%th                               &
+                         ,rqvcuten=domain%tend%qv                               &
+                         ,rqccuten=domain%tend%qc                               &
+                         ,rqrcuten=domain%tend%qr                               & !-- RQRCUTEN      Qr tendency due to cumulus scheme precipitation (kg/kg/s)
+                         ,cldefi=CLDEFI                                         & !-- CLDEFI        precipitation efficiency (for BMJ scheme) (dimensionless)
+                         ,lowlyr=lowlyr                                         & !-- LOWLYR        index of lowest model layer above the ground
+                         ,cp=cp                                                 & ! cp  = 1012.0    ! J/kg/K   specific heat capacity of moist STP air?                 CP
+                         ,RD=r_d                      & ! r_d (wrf_constatns) = 287., while Rd  = 287.058 (icar_constants)          
+                         ,RESTART= .false.                                      &
+                         ,allowed_to_read=.true.                                & !
+                         ,ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde  &
+                         ,ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme  &
+                         ,its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte  &  ! -1 or not?
+                         )
+
+         endif
+
+         if ((options%cu_options%stochastic_cu /= kNO_STOCHASTIC) .and.  (this_image()==1)) then
+            write(*,*)"      stochastic W pertubation for convection triggering"  ! to check that it actually turns on/of
+         elseif ((options%cu_options%stochastic_cu == kNO_STOCHASTIC) .and.  (this_image()==1)) then
+            write(*,*)"      No stochastic W pertubation for convection triggering"  
          endif
 
     end subroutine init_convection
@@ -247,8 +319,8 @@ subroutine convect(domain,options,dt_in)
                 ,domain%density%data_3d                         &
                 ,domain%tend%qv_adv                             &
                 ,domain%tend%qv_pbl                             &
-                ,domain%dz_interface%data_3d                    &
-                ,domain%pressure%data_3d                        &
+                ,domain%dz_interface%data_3d                    & ! dz8w
+                ,domain%pressure%data_3d                        & ! 
                 ,domain%pressure_interface%data_3d              &
                 ,XLAND, CU_ACT_FLAG                             &
                 ,ids,ide, jds,jde, kds,kde                      &
@@ -296,7 +368,7 @@ subroutine convect(domain,options,dt_in)
 
         call cu_nsas( &
             dt=dt_in               & !-- dt          time step (s)
-            ,dx=domain%dx           & !-- dx          grid interval (m)   ! till here
+            ,dx=domain%dx           & !-- dx          grid interval (m)
             ,p3di=domain%pressure_interface%data_3d              & !-- p3di        3d pressure (pa) at interface level
             ,p3d=domain%pressure%data_3d                         & !-- p3d         3d pressure (pa)
             ,pi3d=domain%exner%data_3d                           & !-- pi3d        3d exner function (dimensionless)
@@ -309,8 +381,8 @@ subroutine convect(domain,options,dt_in)
             ,htop=highest_convection_layer                       & !-- HTOP          index of highest model layer with convection
             ,cu_act_flag=CU_ACT_FLAG                             &
             ,rthcuten=domain%tend%th                             &
-            ,rqvcuten=domain%tend%qv                             &
-            ,rqccuten=domain%tend%qc                             &
+            ,rqvcuten=domain%tend%qv                             & !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)
+            ,rqccuten=domain%tend%qc                             & !--   ...etc...
             ,rqicuten=domain%tend%qi                             &
             ,rucuten=domain%tend%u                               &
             ,rvcuten=domain%tend%v                               &
@@ -324,11 +396,11 @@ subroutine convect(domain,options,dt_in)
             ,u3d=domain%u_mass%data_3d                           & !-- u3d         3d u-velocity interpolated to theta points (m/s)
             ,v3d=domain%v_mass%data_3d                           & !-- v3d         3d v-velocity interpolated to theta points (m/s)
             ,hpbl=hpbl  &  ! ?? PBL height I assume? But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
-            ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)       
+            ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)
             ,qfx=domain%latent_heat%data_2d/LH_vaporization       & !  QFX  - net upward moisture flux at the surface (kg/m^2/s)
             ,mp_physics=5        & ! - sets ncloud: - integer no_cloud(0),no_ice(1),cloud+ice(2) (see ln 141 cu_nsas.f90)  use options%physics%microphysics?
             ,dx_factor_nsas=dx_factor_nsas                       & !
-            ,p_qc=1                                              & ! copied from Tiedke; no idea as to what these 3 flags represent. 
+            ,p_qc=1                                              & ! copied from Tiedke; no idea as to what these 3 flags represent.
             ,p_qi=1                                              &
             ,p_first_scalar=0                                    &
             ! ,pgcon=""                                            & ! pgcon_use  = 0.55  ! Zhang & Wu (2003,JAS) ! 0.55 is a physically-based value used by GFS
@@ -351,9 +423,9 @@ subroutine convect(domain,options,dt_in)
             its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1 )
         ! ! ! Definitions (for coupling - temporary):
         ! - - - - - - - - - - - - - - - - -
-        ! microphysics scheme --> ncloud 
+        ! microphysics scheme --> ncloud
         !
-        !      !! ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2) 
+        !      !! ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2)
         !    if (mp_physics .eq. 0) then
         !     ncloud = 0
         !   elseif ( mp_physics .eq. 1 .or. mp_physics .eq. 3 ) then
@@ -363,6 +435,42 @@ subroutine convect(domain,options,dt_in)
         !   endif
         ! - - - - - - - - - - - - - - - - -
 
+
+    elseif (options%physics%convection==kCU_BMJ) then
+        CALL BMJDRV(                                            &
+                TH=domain%potential_temperature%data_3d         &
+                ,T=domain%temperature%data_3d                   &
+                ,RAINCV=RAINCV                                  &
+                ,PRATEC=PRATEC                                  &
+                ,rho=domain%density%data_3d                     &
+                ,dt=dt_in                                       & !-- dt          time step (s)
+                ,ITIMESTEP=itimestep ,STEPCU=stepcu             &
+                ,CUTOP=CUTOP, CUBOT=CUBOT                       &
+                ,KPBL=kpbl                                      &!-- KPBL          layer index of the PBL
+                ,dz8w=domain%dz_interface%data_3d               &!-- dz8w          dz between full levels (m)
+                ,PINT=domain%pressure_interface%data_3d         &  !-- p8w           pressure at full levels (Pa)
+                ,PMID=domain%pressure%data_3d                   &!-- Pcps        3D hydrostatic pressure at half levels (Pa)
+                ,PI=domain%exner%data_3d                        &   ! exner
+                ,CP=cp ,R=r_d ,ELWV=xlv ,ELIV=xls ,G=gravity    &
+                ,TFRZ=svpt0 ,D608=ep_1 ,CLDEFI=cldefi           &
+                ,LOWLYR=lowlyr                                  &
+                ,XLAND=XLAND                                    &
+                ,CU_ACT_FLAG=CU_ACT_FLAG                        &
+                ,QV=domain%water_vapor%data_3d                  &
+                ,CCLDFRA=CCLDFRA                                &                 !-- CCLDFRA       convective cloud fraction (for BMJ scheme)
+                ,CONVCLD=CONVCLD                                &  !-- CONVCLD       Convective cloud (for BMJ scheme) (kg/m^2)
+                ,QCCONV=qcconv                                  &! QCCONV     convective cloud mixing ratio (kg/kg)
+                ,QICONV=qiconv                                  &! QICONV     convective ice mixing ratio (kg/kg)
+                ,BMJ_RAD_FEEDBACK=bmj_rad_feedback                 &
+                ,IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde   &
+                ,IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme   &
+                ,ITS=its,ITE=ite,JTS=jts,JTE=jte,KTS=kts,KTE=kte-1 &
+                ! optionals
+                ,rthcuten=domain%tend%th                           &  !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)
+                ,rqvcuten=domain%tend%qv                           &  !-- RTHCUTEN      Theta tendency due to cumulus scheme precipitation (K/s)
+                )
+
+
     endif
 
     ! add domain wide tendency terms
@@ -370,12 +478,20 @@ subroutine convect(domain,options,dt_in)
     internal_dt = dt_in
 
     ! if (options%physics%convection==kCU_TIEDTKE) then
-    if ((options%physics%convection==kCU_TIEDTKE) .or. (options%physics%convection==kCU_NSAS)) then
+    if ( &
+        (options%physics%convection==kCU_TIEDTKE) .or.  &
+        (options%physics%convection==kCU_NSAS) .or.     &
+        (options%physics%convection==kCU_BMJ)           &
+        ) then
         ! $omp parallel private(j) &
         ! $omp default(shared)
         ! $omp do schedule(static)
         do j=jts,jte
             if (options%cu_options%tendency_fraction > 0) then
+                ! Here we adjust the tendencies calculated by the cumulus scheme based on the namelist setting tendency_fraction (cu_parameters)
+                !-- RTHCUTEN      Theta tendency due to cumulus scheme precipitation (K/s)  (domain%tend%qv)
+                !-- RQVCUTEN      Qv tendency due to cumulus scheme precipitation (kg/kg/s)  (domain%tend%th)
+                ! -- ...etc
                 if (options%cu_options%tend_qv_fraction > 0) domain%water_vapor%data_3d(:,:,j)           = domain%water_vapor%data_3d(:,:,j)           + domain%tend%qv(:,:,j)*internal_dt * options%cu_options%tend_qv_fraction
                 if (options%cu_options%tend_qc_fraction > 0) domain%cloud_water_mass%data_3d(:,:,j)      = domain%cloud_water_mass%data_3d(:,:,j)      + domain%tend%qc(:,:,j)*internal_dt * options%cu_options%tend_qc_fraction
                 if (options%cu_options%tend_th_fraction > 0) domain%potential_temperature%data_3d(:,:,j) = domain%potential_temperature%data_3d(:,:,j) + domain%tend%th(:,:,j)*internal_dt * options%cu_options%tend_th_fraction
@@ -398,6 +514,7 @@ subroutine convect(domain,options,dt_in)
         enddo
         ! $omp end do
         ! $omp end parallel
+
     endif
 
 end subroutine convect

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -10,6 +10,7 @@ module convection
     use icar_constants
     use module_cu_tiedtke,  only: tiedtkeinit, CU_TIEDTKE
     ! use module_cu_kf,       only: kfinit, KFCPS
+    use module_cu_nsas,  only: nsasinit, cu_nsas
 
     use options_interface,   only : options_t
     use domain_interface,    only : domain_t
@@ -21,6 +22,7 @@ module convection
     logical,allocatable, dimension(:,:) :: CU_ACT_FLAG
     real,   allocatable, dimension(:,:) :: XLAND, RAINCV, PRATEC, NCA
     real,   allocatable, dimension(:,:,:):: W0AVG, w_stochastic
+    real,   allocatable, dimension(:,:)::  lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS. 
 
     integer :: ids,ide,jds,jde,kds,kde ! Domain dimensions
     integer :: ims,ime,jms,jme,kms,kme ! Local Memory dimensions
@@ -47,7 +49,24 @@ contains
                          [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
                          kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
                          kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
+
+        else if (options%physics%convection == kCU_NSAS) then  ! Not checked thoroughly yet
+            call options%alloc_vars( &
+                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
+                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
+                         kVARS%exner, kVARS%dz_interface, kVARS%density, kVARS%pressure_interface, kVARS%pressure,  &
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%w, kVARS%land_mask,        &
+                         kVARS%tend_qv, kVARS%tend_th, kVARS%tend_qc, kVARS%tend_qi, kVARS%tend_qs, kVARS%tend_qr,  &
+                         kVARS%tend_u, kVARS%tend_v])
+
+             call options%advect_vars([kVARS%potential_temperature, kVARS%water_vapor])
+
+             call options%restart_vars( &
+                         [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
+                         kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
         endif
+
 
     end subroutine cu_var_request
 
@@ -56,6 +75,7 @@ contains
         implicit none
         type(domain_t),  intent(inout) :: domain
         type(options_t), intent(in) :: options
+        integer :: i, j
 
         if (this_image()==1) write(*,*) "Initializing Cumulus Scheme"
 
@@ -95,12 +115,14 @@ contains
             allocate(XLAND(ims:ime,jms:jme))
             XLAND = domain%land_mask
             where(domain%land_mask == 0) XLAND = 2 ! 0 is water if using "LANDMASK" as input
+
+            allocate(w_stochastic(ims:ime,kms:kme,jms:jme))
+
         endif
 
         if (options%physics%convection == kCU_TIEDTKE) then
             if (this_image()==1) write(*,*) "    Tiedtke Cumulus scheme"
 
-            allocate(w_stochastic(ims:ime,kms:kme,jms:jme))
             call tiedtkeinit(domain%tend%th,domain%tend%qv,   &
                              domain%tend%qc,domain%tend%qi,   &
                              domain%tend%u, domain%tend%v,    &
@@ -124,6 +146,38 @@ contains
          !                 ids, ide, jds, jde, kds, kde,    &
          !                 ids, ide, jds, jde, kds, kde-1)
 
+
+        else if (options%physics%convection==kCU_NSAS) then
+            if (this_image()==1) write(*,*) "     NSAS Cumulus scheme"
+
+            allocate(hpbl(ims:ime,jms:jme))  ! ?? PBL height I assume? 
+            allocate(lowest_convection_layer(ims:ime,jms:jme))
+            allocate(highest_convection_layer(ims:ime,jms:jme))
+
+            ! NSAS expects a PBL height, But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
+            do i=ims,ime
+                do j=jms,jme
+                    hpbl(i,j)=1000.  ! or take terrain height into account?
+                enddo
+            enddo
+
+            call nsasinit(  rthcuten=domain%tend%th                             &
+                            ,rqvcuten=domain%tend%qv                            &
+                            ,rqccuten=domain%tend%qc                            &
+                            ,rqicuten=domain%tend%qi                            &
+                            ,rucuten=domain%tend%u                              &
+                            ,rvcuten=domain%tend%v                              &
+                            ,restart=.false.             &  ! options%restart                            &
+                            ,p_qc=1                                             & ! copied from Tiedke; no idea as to what these 3 flags represent. 
+                            ,p_qi=1                                             &
+                            ,p_first_scalar=0                                   &
+                            ,allowed_to_read=.true.                             &
+                            ,ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde   &
+                            ,ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme   &
+                            ,its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte &  ! -1 or not? 
+                            )
+
+
          endif
 
     end subroutine init_convection
@@ -134,7 +188,7 @@ subroutine convect(domain,options,dt_in)
     type(options_t), intent(in)    :: options
     real, intent(in) :: dt_in
 
-    integer :: j,itimestep,STEPCU
+    integer :: j,itimestep,STEPCU, dx_factor_nsas
     real :: internal_dt
 
     if (options%physics%convection==0) return
@@ -159,19 +213,23 @@ subroutine convect(domain,options,dt_in)
     !$omp end do
     !$omp end parallel
 
+    ! Stochastic disturbance for  vertical speeds:
+    if (options%cu_options%stochastic_cu /= kNO_STOCHASTIC) then
+        call random_number(w_stochastic)
+        block
+            integer :: i
+            do i=1,size(w_stochastic,2)
+                w_stochastic(:,i,:) = domain%sensible_heat%data_2d/500 + w_stochastic(:,i,:)
+            enddo
+        end block
+        W0AVG = domain%w_real%data_3d+(w_stochastic * options%cu_options%stochastic_cu - options%cu_options%stochastic_cu*0.75) ! e.g. * 20 - 15)
+    else
+        W0AVG = domain%w_real%data_3d
+    endif
+
+
     if (options%physics%convection==kCU_TIEDTKE) then
-        if (options%cu_options%stochastic_cu /= kNO_STOCHASTIC) then
-            call random_number(w_stochastic)
-            block
-                integer :: i
-                do i=1,size(w_stochastic,2)
-                    w_stochastic(:,i,:) = domain%sensible_heat%data_2d/500 + w_stochastic(:,i,:)
-                enddo
-            end block
-            W0AVG = domain%w_real%data_3d+(w_stochastic * options%cu_options%stochastic_cu - options%cu_options%stochastic_cu*0.75) ! e.g. * 20 - 15)
-        else
-            W0AVG = domain%w_real%data_3d
-        endif
+
         call CU_TIEDTKE(                                        &
                  dt_in, itimestep, STEPCU                       &
                 ,RAINCV, PRATEC                                 &
@@ -222,6 +280,89 @@ subroutine convect(domain,options,dt_in)
     !           ,domain%tend%qv, domain%tend%qc                &
     !           ,domain%tend%qr, domain%tend%qi                &
     !           ,domain%tend%qs, domain%tend%th)
+    elseif (options%physics%convection==kCU_NSAS) then
+
+        ! TO DO:
+        !  - calculate height of PBL
+        !  - use wrf_constants.f90 ?
+
+
+        ! set dx_factor_nsas (cu_nsas.f90 line 567):
+        if (domain%dx.le.1000) then
+            dx_factor_nsas=1  !       if (dx_factor_nsas == 1) then   dx_factor = 250. / delx ! assume 2.5 ms-1 (1km) and 1.125 cms-1 (200km) (cu_nsas.f90 line 567)
+        else
+            dx_factor_nsas=2
+        endif
+
+        call cu_nsas( &
+            dt=dt_in               & !-- dt          time step (s)
+            ,dx=domain%dx           & !-- dx          grid interval (m)   ! till here
+            ,p3di=domain%pressure_interface%data_3d              & !-- p3di        3d pressure (pa) at interface level
+            ,p3d=domain%pressure%data_3d                         & !-- p3d         3d pressure (pa)
+            ,pi3d=domain%exner%data_3d                           & !-- pi3d        3d exner function (dimensionless)
+            ,qc3d=domain%cloud_water_mass%data_3d                & !-- qc3d        cloud water mixing ratio (kg/kg)
+            ,qi3d=domain%cloud_ice_mass%data_3d                  & !-- qi3d        cloud ice mixing ratio (kg/kg)
+            ,rho3d=domain%density%data_3d                        &
+            ,itimestep=itimestep                                 &
+            ,stepcu=STEPCU                                       &
+            ,hbot=lowest_convection_layer                        & !-- HBOT          index of lowest model layer with convection  intent(out) ???
+            ,htop=highest_convection_layer                       & !-- HTOP          index of highest model layer with convection
+            ,cu_act_flag=CU_ACT_FLAG                             &
+            ,rthcuten=domain%tend%th                             &
+            ,rqvcuten=domain%tend%qv                             &
+            ,rqccuten=domain%tend%qc                             &
+            ,rqicuten=domain%tend%qi                             &
+            ,rucuten=domain%tend%u                               &
+            ,rvcuten=domain%tend%v                               &
+            ,qv3d=domain%water_vapor%data_3d                     & !-- qv3d        3d water vapor mixing ratio (kg/kg)
+            ,t3d=domain%temperature%data_3d                      & !-- t3d         temperature (k)
+            ,raincv=RAINCV                                       & !-- raincv      cumulus scheme precipitation (mm)
+            ,pratec=PRATEC                                       &
+            ,xland=XLAND                                         &
+            ,dz8w=domain%dz_interface%data_3d                    & !-- dz8w        dz between full levels (m)
+            ,w=W0AVG                                             & !-- w           vertical velocity (m/s)
+            ,u3d=domain%u_mass%data_3d                           & !-- u3d         3d u-velocity interpolated to theta points (m/s)
+            ,v3d=domain%v_mass%data_3d                           & !-- v3d         3d v-velocity interpolated to theta points (m/s)
+            ,hpbl=hpbl  &  ! ?? PBL height I assume? But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
+            ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)       
+            ,qfx=domain%latent_heat%data_2d/LH_vaporization       & !  QFX  - net upward moisture flux at the surface (kg/m^2/s)
+            ,mp_physics=5        & ! - sets ncloud: - integer no_cloud(0),no_ice(1),cloud+ice(2) (see ln 141 cu_nsas.f90)  use options%physics%microphysics?
+            ,dx_factor_nsas=dx_factor_nsas                       & !
+            ,p_qc=1                                              & ! copied from Tiedke; no idea as to what these 3 flags represent. 
+            ,p_qi=1                                              &
+            ,p_first_scalar=0                                    &
+            ! ,pgcon=""                                            & ! pgcon_use  = 0.55  ! Zhang & Wu (2003,JAS) ! 0.55 is a physically-based value used by GFS
+            ,cp=cp                                               & ! cp  = 1012.0    ! J/kg/K   specific heat capacity of moist STP air?
+            ,cliq=4190.                                          & ! from wrf_constants.f90
+            ,cpv=4.*461.6                                        & ! from wrf_constants.f90
+            ,g=gravity                                           &
+            ,xlv=2.5E6                                           & ! from wrf_constants.f90
+            ,r_d=287.                                            & ! from wrf_constants.f90
+            ,r_v=461.6                                           & ! from wrf_constants.f90
+            ,ep_1=461.6/287.-1.                                  & ! EP_1=R_v/R_d-1. (wrf_constants.f90)
+            ,ep_2=287./461.6                                     & ! EP_2=R_d/R_v
+            ,cice=2106.                                           & ! from wrf_constants.f90                                          &
+            ,xls=2.85E6                                           & ! from wrf_constants.f90
+            ,psat=610.78                                           & ! from wrf_constants.f90
+            ,f_qi=.true.                                             & ! optional arg
+            ,f_qc=.true.                                             & ! optional arg
+            ,ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,  &
+            ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,  &
+            its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte-1 )
+        ! ! ! Definitions (for coupling - temporary):
+        ! - - - - - - - - - - - - - - - - -
+        ! microphysics scheme --> ncloud 
+        !
+        !      !! ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2) 
+        !    if (mp_physics .eq. 0) then
+        !     ncloud = 0
+        !   elseif ( mp_physics .eq. 1 .or. mp_physics .eq. 3 ) then
+        !     ncloud = 1
+        !   else
+        !     ncloud = 2
+        !   endif
+        ! - - - - - - - - - - - - - - - - -
+
     endif
 
     ! add domain wide tendency terms

--- a/src/physics/cu_nsas.f90
+++ b/src/physics/cu_nsas.f90
@@ -626,6 +626,7 @@ MODULE module_cu_nsas
            if(prsl(i,k).gt.prsi(i,1)*0.04) kmax  = k + 1 
          enddo 
        enddo 
+       kbmax = min(kbmax,kte)  ! BK added after 'outo of bounds' error in ln 761 (maybe should even be kte-1 to accomodate zi(k+2) ln 893?)
        kmax = min(kmax,kte)
        kmax1 = kmax - 1
        kbm = min(kbm,kte)

--- a/src/physics/cu_nsas.f90
+++ b/src/physics/cu_nsas.f90
@@ -1,0 +1,3292 @@
+!
+!
+!
+!
+MODULE module_cu_nsas
+    CONTAINS
+    !-------------------------------------------------------------------------------
+       subroutine cu_nsas(dt,dx,p3di,p3d,pi3d,qc3d,qi3d,rho3d,itimestep,stepcu,    &
+                         hbot,htop,cu_act_flag,                                    &
+                         rthcuten,rqvcuten,rqccuten,rqicuten,                      &
+                         rucuten,rvcuten,                                          &
+                         qv3d,t3d,raincv,pratec,xland,dz8w,w,u3d,v3d,              &
+                         hpbl,hfx,qfx,                                             &
+                         mp_physics,dx_factor_nsas,                                &
+                         p_qc,p_qi,p_first_scalar,                                 &
+                         pgcon,                                                    &
+                         cp,cliq,cpv,g,xlv,r_d,r_v,ep_1,ep_2,                      &
+                         cice,xls,psat,f_qi,f_qc,                                  &
+                         ids,ide, jds,jde, kds,kde,                                &
+                         ims,ime, jms,jme, kms,kme,                                &
+                         its,ite, jts,jte, kts,kte)
+    !-------------------------------------------------------------------------------
+       implicit none
+    !-------------------------------------------------------------------------------
+    !-- dt          time step (s)
+    !-- dx          grid interval (m)
+    !-- p3di        3d pressure (pa) at interface level
+    !-- p3d         3d pressure (pa)
+    !-- pi3d        3d exner function (dimensionless)
+    !-- z           height above sea level (m)
+    !-- qc3d        cloud water mixing ratio (kg/kg)
+    !-- qi3d        cloud ice mixing ratio (kg/kg)
+    !-- qv3d        3d water vapor mixing ratio (kg/kg)
+    !-- t3d         temperature (k)
+    !-- raincv      cumulus scheme precipitation (mm)
+    !-- w           vertical velocity (m/s)
+    !-- dz8w        dz between full levels (m)
+    !-- u3d         3d u-velocity interpolated to theta points (m/s)
+    !-- v3d         3d v-velocity interpolated to theta points (m/s)
+    !-- ids         start index for i in domain 
+    !-- ide         end index for i in domain
+    !-- jds         start index for j in domain
+    !-- jde         end index for j in domain
+    !-- kds         start index for k in domain
+    !-- kde         end index for k in domain
+    !-- ims         start index for i in memory
+    !-- ime         end index for i in memory
+    !-- jms         start index for j in memory
+    !-- jme         end index for j in memory
+    !-- kms         start index for k in memory
+    !-- kme         end index for k in memory 
+    !-- its         start index for i in tile
+    !-- ite         end index for i in tile
+    !-- jts         start index for j in tile
+    !-- jte         end index for j in tile
+    !-- kts         start index for k in tile
+    !-- kte         end index for k in tile
+    !-------------------------------------------------------------------------------
+       integer,  intent(in   )   ::       ids,ide, jds,jde, kds,kde,               &
+                                          ims,ime, jms,jme, kms,kme,               &
+                                          its,ite, jts,jte, kts,kte,               &
+                                          itimestep, stepcu,                       &
+                                          p_qc,p_qi,p_first_scalar
+       real,     intent(in   )   ::      cp,cliq,cpv,g,xlv,r_d,r_v,ep_1,ep_2,      &
+                                         cice,xls,psat
+       real,     intent(in   )   ::      dt,dx
+       real,     optional, intent(in ) :: pgcon
+       real,     dimension( ims:ime, kms:kme, jms:jme ),optional                  ,&
+                 intent(inout)   ::                                       rthcuten,&
+                                                                           rucuten,&
+                                                                           rvcuten,&
+                                                                          rqccuten,&
+                                                                          rqicuten,&
+                                                                          rqvcuten
+       logical, optional ::                                              F_QC,F_QI
+       real,     dimension( ims:ime, kms:kme, jms:jme )                           ,&
+                 intent(in   )   ::                                           qv3d,&
+                                                                              qc3d,&
+                                                                              qi3d,&
+                                                                             rho3d,&
+                                                                               p3d,&
+                                                                              pi3d,&
+                                                                               t3d
+       real,     dimension( ims:ime, kms:kme, jms:jme )                           ,&
+                 intent(in   )   ::                                           p3di
+       real,     dimension( ims:ime, kms:kme, jms:jme )                           ,&
+                 intent(in   )   ::                                           dz8w,&  
+                                                                                 w
+       real,     dimension( ims:ime, jms:jme )                                    ,&
+                 intent(inout) ::                                           raincv,&
+                                                                            pratec
+       real,     dimension( ims:ime, jms:jme )                                    ,&
+                 intent(out) ::                                               hbot,&
+                                                                              htop
+    !
+       real,     dimension( ims:ime, jms:jme )                                    ,&
+                 intent(in   ) ::                                            xland
+    !
+       real,     dimension( ims:ime, kms:kme, jms:jme )                           ,&
+                  intent(in   )   ::                                           u3d,&
+                                                                               v3d
+       logical,  dimension( ims:ime, jms:jme )                                    ,&
+                 intent(inout) ::                                      cu_act_flag
+    !
+       real,     dimension( ims:ime, jms:jme )                                    ,&
+                  intent(in   )   ::                                          hpbl,&
+                                                                               hfx,&
+                                                                               qfx
+       integer,   intent(in   )   ::                                    mp_physics
+       integer,   intent(in   )   ::                                dx_factor_nsas 
+       integer :: ncloud
+    !
+    !local
+    !
+       real,  dimension( its:ite, jts:jte )  ::                            raincv1,&
+                                                                           raincv2,&
+                                                                           pratec1,&
+                                                                           pratec2
+       real,   dimension( its:ite, kts:kte )  ::                               del,&
+                                                                             prsll,&
+                                                                               dot,&
+                                                                                u1,&
+                                                                                v1,&
+                                                                                t1,&
+                                                                               q1, &
+                                                                               qc2,&
+                                                                               qi2
+       real,   dimension( its:ite, kts:kte+1 )  ::                           prsii,&
+                                                                               zii
+       real,   dimension( its:ite, kts:kte )  ::                               zll 
+       real,   dimension( its:ite)  ::                                         rain
+       real ::                                                          delt,rdelt
+       integer, dimension (its:ite)  ::                                       kbot,&
+                                                                              ktop,&
+                                                                              icps
+       real :: pgcon_use
+       integer ::  i,j,k,kp
+    !
+    ! microphysics scheme --> ncloud 
+    !
+       if (mp_physics .eq. 0) then
+         ncloud = 0
+       elseif ( mp_physics .eq. 1 .or. mp_physics .eq. 3 ) then
+         ncloud = 1
+       else
+         ncloud = 2
+       endif
+    !
+       if(present(pgcon)) then
+         pgcon_use = pgcon
+       else
+    !    pgcon_use  = 0.7     ! Gregory et al. (1997, QJRMS)
+         pgcon_use  = 0.55    ! Zhang & Wu (2003,JAS)
+         ! 0.55 is a physically-based value used by GFS
+         ! HWRF uses 0.2, for model tuning purposes
+       endif
+    !
+       do j = jts,jte
+         do i = its,ite
+           cu_act_flag(i,j)=.TRUE.
+         enddo
+       enddo
+       delt=dt*stepcu
+       rdelt=1./delt
+    !
+    ! outer most J_loop
+    !
+       do j = jts,jte
+         do k = kts,kte
+           kp = k+1
+           do i = its,ite
+             dot(i,k) = -5.0e-4*g*rho3d(i,k,j)*(w(i,k,j)+w(i,kp,j))
+             prsll(i,k)=p3d(i,k,j)*0.001
+             prsii(i,k)=p3di(i,k,j)*0.001
+           enddo
+         enddo
+    !
+         do i = its,ite
+           prsii(i,kte+1)=p3di(i,kte+1,j)*0.001
+         enddo
+    !
+         do i = its,ite
+           zii(i,1)=0.0
+         enddo
+    !
+         do k = kts,kte
+           do i = its,ite
+             zii(i,k+1)=zii(i,k)+dz8w(i,k,j)
+           enddo
+         enddo
+    !
+         do k = kts,kte
+           do i = its,ite
+             zll(i,k)=0.5*(zii(i,k)+zii(i,k+1))
+           enddo
+         enddo
+    !
+         do k = kts,kte
+           do i = its,ite
+             del(i,k)=prsll(i,k)*g/r_d*dz8w(i,k,j)/t3d(i,k,j)
+             u1(i,k)=u3d(i,k,j)
+             v1(i,k)=v3d(i,k,j)
+             q1(i,k)=qv3d(i,k,j)
+    !        q1(i,k)=qv3d(i,k,j)/(1.+qv3d(i,k,j))
+             t1(i,k)=t3d(i,k,j)
+             qi2(i,k) = qi3d(i,k,j)
+             qc2(i,k) = qc3d(i,k,j)
+           enddo
+         enddo
+    !
+    ! NCEP SAS 
+    !
+         call nsas2d(delt=delt,delx=dx,del=del(its,kts),                           &
+                  prsl=prsll(its,kts),prsi=prsii(its,kts),prslk=pi3d(ims,kms,j),   &
+                  zl=zll(its,kts),                                                 &
+                  ncloud=ncloud,qc2=qc2(its,kts),qi2=qi2(its,kts),                 &
+                  q1=q1(its,kts),t1=t1(its,kts),rain=rain(its),                    &
+                  kbot=kbot(its),ktop=ktop(its),                                   &
+                  icps=icps(its),                                                  &
+                  lat=j,slimsk=xland(ims,j),dot=dot(its,kts),                      &
+                  u1=u1(its,kts), v1=v1(its,kts),                                  &
+                  cp_=cp,cliq_=cliq,cvap_=cpv,g_=g,hvap_=xlv,                      &
+                  rd_=r_d,rv_=r_v,fv_=ep_1,ep2=ep_2,                               &
+                  cice=cice,xls=xls,psat=psat,                                     &
+                  pgcon=pgcon_use,                                                 &
+                  dx_factor_nsas=dx_factor_nsas,                                   &
+                  ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde,               &
+                  ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme,               &
+                  its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
+    !
+         do i = its,ite
+           pratec1(i,j)=rain(i)*1000./(stepcu*dt)
+           raincv1(i,j)=rain(i)*1000./(stepcu)
+         enddo
+    !
+    ! NCEP SCV
+    !
+         call nscv2d(delt=delt,del=del(its,kts),prsl=prsll(its,kts),               &
+                  prsi=prsii(its,kts),prslk=pi3d(ims,kms,j),zl=zll(its,kts),       &
+                  ncloud=ncloud,qc2=qc2(its,kts),qi2=qi2(its,kts),                 &
+                  q1=q1(its,kts),t1=t1(its,kts),rain=rain(its),                    &
+                  kbot=kbot(its),ktop=ktop(its),                                   &
+                  icps=icps(its),                                                  &
+                  slimsk=xland(ims,j),dot=dot(its,kts),                            &
+                  u1=u1(its,kts), v1=v1(its,kts),                                  &
+                  cp_=cp,cliq_=cliq,cvap_=cpv,g_=g,hvap_=xlv,                      &
+                  rd_=r_d,rv_=r_v,fv_=ep_1,ep2=ep_2,                               &
+                  cice=cice,xls=xls,psat=psat,                                     &
+                  hpbl=hpbl(ims,j),hfx=hfx(ims,j),qfx=qfx(ims,j),                  &
+                  pgcon=pgcon_use,                                                 &
+                  ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde,               &
+                  ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme,               &
+                  its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
+    !
+         do i = its,ite
+           pratec2(i,j)=rain(i)*1000./(stepcu*dt)
+           raincv2(i,j)=rain(i)*1000./(stepcu)
+         enddo
+    !
+         do i = its,ite
+           raincv(i,j) = raincv1(i,j) + raincv2(i,j)
+           pratec(i,j) = pratec1(i,j) + pratec2(i,j)
+           hbot(i,j) = kbot(i)
+           htop(i,j) = ktop(i)
+         enddo
+    !
+         IF(PRESENT(rthcuten).AND.PRESENT(rqvcuten)) THEN
+           do k = kts,kte
+             do i = its,ite
+               rthcuten(i,k,j)=(t1(i,k)-t3d(i,k,j))/pi3d(i,k,j)*rdelt
+               rqvcuten(i,k,j)=(q1(i,k)-qv3d(i,k,j))*rdelt
+             enddo
+           enddo
+         ENDIF
+    !
+         IF(PRESENT(rucuten).AND.PRESENT(rvcuten)) THEN
+           do k = kts,kte
+             do i = its,ite
+               rucuten(i,k,j)=(u1(i,k)-u3d(i,k,j))*rdelt
+               rvcuten(i,k,j)=(v1(i,k)-v3d(i,k,j))*rdelt
+             enddo
+           enddo
+         ENDIF
+    !
+         IF(PRESENT( rqicuten )) THEN
+           IF ( F_QI ) THEN
+             do k = kts,kte
+               do i = its,ite
+                 rqicuten(i,k,j)=(qi2(i,k)-qi3d(i,k,j))*rdelt
+               enddo
+             enddo
+           ENDIF
+         ENDIF
+    !
+         IF(PRESENT( rqccuten )) THEN
+           IF ( F_QC ) THEN
+             do k = kts,kte
+               do i = its,ite
+                 rqccuten(i,k,j)=(qc2(i,k)-qc3d(i,k,j))*rdelt
+               enddo
+             enddo
+           ENDIF
+         ENDIF
+    !
+       enddo ! outer most J_loop
+    !
+       return
+       end subroutine cu_nsas
+    !
+    !-------------------------------------------------------------------------------
+    ! NCEP SAS (Deep Convection Scheme)
+    !-------------------------------------------------------------------------------
+       subroutine nsas2d(delt,delx,del,prsl,prsi,prslk,zl,                         &
+                ncloud,                                                            & 
+                qc2,qi2,                                                           & 
+                q1,t1,rain,kbot,ktop,                                              &
+                icps,                                                              &
+                lat,slimsk,dot,u1,v1,cp_,cliq_,cvap_,g_,hvap_,rd_,rv_,fv_,ep2,     &
+                cice,xls,psat,                                                     &
+                pgcon,                                                             &
+                dx_factor_nsas,                                                    &
+                ids,ide, jds,jde, kds,kde,                                         &
+                ims,ime, jms,jme, kms,kme,                                         &
+                its,ite, jts,jte, kts,kte)
+    !-------------------------------------------------------------------------------
+    !
+    ! subprogram:    phys_cps_sas      computes convective heating and moistening
+    !                                                      and momentum transport
+    !
+    ! abstract: computes convective heating and moistening using a one
+    !   cloud type arakawa-schubert convection scheme originally developed
+    !   by georg grell. the scheme has been revised at ncep since initial 
+    !   implementation in 1993. it includes updraft and downdraft effects.
+    !   the closure is the cloud work function. both updraft and downdraft
+    !   are assumed to be saturated and the heating and moistening are
+    !   accomplished by the compensating environment. convective momentum transport
+    !   is taken into account. the name comes from "simplified arakawa-schubert
+    !   convection parameterization".
+    !
+    ! developed by hua-lu pan, wan-shu wu, songyou hong, and jongil han
+    !   implemented into wrf by kyosun sunny lim and songyou hong
+    !   module with cpp-based options is available in grims 
+    !
+    ! program history log:
+    !   92-03-01  hua-lu pan       operational development
+    !   96-03-01  song-you hong    revised closure, and trigger 
+    !   99-03-01  hua-lu pan       multiple clouds
+    !   06-03-01  young-hwa byun   closure based on moisture convergence (optional)
+    !   09-10-01  jung-eun kim     f90 format with standard physics modules
+    !   10-07-01  jong-il han      revised cloud model,trigger, as in gfs july 2010
+    !   10-12-01  kyosun sunny lim wrf compatible version
+    !   14-01-09  song-you hong    dx dependent trigger, closure, and mass flux
+    !
+    !
+    ! usage:    call phys_cps_sas(delt,delx,del,prsl,prsi,prslk,prsik,zl,          &
+    !                             q2,q1,t1,u1,v1,rcs,slimsk,dot,cldwrk,rain,       &
+    !                             jcap,ncloud,lat,kbot,ktop,icps,                  &
+    !                             ids,ide, jds,jde, kds,kde,                       &
+    !                             ims,ime, jms,jme, kms,kme,                       &
+    !                             its,ite, jts,jte, kts,kte)
+    !
+    !   delt     - real model integration time step
+    !   delx     - real model grid interval
+    !   del      - real (kms:kme) sigma layer thickness
+    !   prsl     - real (ims:ime,kms:kme) pressure values
+    !   prsi     - real (ims:ime,kms:kme) pressure values at interface level
+    !   prslk    - real (ims:ime,kms:kme) pressure values to the kappa
+    !   prsik    - real (ims:ime,kms:kme) pressure values to the kappa at interface lev.
+    !   zl       - real (ims:ime,kms:kme) height above sea level
+    !   zi       - real (ims:ime,kms:kme) height above sea level at interface level
+    !   rcs      - real
+    !   slimsk   - real (ims:ime) land(1),sea(0), ice(2) flag
+    !   dot      - real (ims:ime,kms:kme) vertical velocity
+    !   jcap     - integer wave number 
+    !   ncloud   - integer no_cloud(0),no_ice(1),cloud+ice(2) 
+    !   lat      - integer  current latitude index
+    !
+    ! output argument list:
+    !   q2       - real (ims:ime,kms:kme) detrained hydrometeors in kg/kg
+    !            - in case of the  --> qc2(cloud), qi2(ice)
+    !   q1       - real (ims:ime,kms:kme) adjusted specific humidity in kg/kg
+    !   t1       - real (ims:ime,kms:kme) adjusted temperature in kelvin
+    !   u1       - real (ims:ime,kms:kme) adjusted zonal wind in m/s
+    !   v1       - real (ims:ime,kms:kme) adjusted meridional wind in m/s
+    !   cldwrk   - real (ims:ime) cloud work function
+    !   rain     - real (ims:ime) convective rain in meters
+    !   kbot     - integer (ims:ime) cloud bottom level
+    !   ktop     - integer (ims:ime) cloud top level
+    !   icps     - integer (ims:ime) bit flag indicating deep convection
+    !
+    ! subprograms called:
+    !   fpvs     - function to compute saturation vapor pressure
+    !
+    ! remarks: function fpvs is inlined by fpp.
+    !          nonstandard automatic arrays are used.
+    !
+    ! references :
+    !   pan and wu    (1995, ncep office note)
+    !   hong and pan  (1998, mon wea rev)
+    !   park and hong (2007,jmsj)
+    !   byun and hong (2007, mon wea rev)
+    !   han and pan   (2011, wea. forecasting)
+    !
+    !-------------------------------------------------------------------------------
+    !-------------------------------------------------------------------------------
+       implicit none
+    !-------------------------------------------------------------------------------
+    !
+    ! model tunable parameters 
+    !
+       real,parameter  ::  alphal = 0.5,    alphas = 0.5
+       real,parameter  ::  betal  = 0.05,   betas  = 0.05
+       real,parameter  ::  pdpdwn = 0.0,    pdetrn = 200.0
+       real,parameter  ::  c0     = 0.002,  c1     = 0.002
+       real,parameter  ::  xlamdd = 1.0e-4, xlamde = 1.0e-4
+       real,parameter  ::  clam   = 0.1,    cxlamu = 1.0e-4
+       real,parameter  ::  aafac  = 0.1
+       real,parameter  ::  dthk=25.
+       real,parameter  ::  cincrmax = 180.,cincrmin = 120.
+       real,parameter  ::  mbdt = 10., edtmaxl = 0.3, edtmaxs = 0.3
+       real,parameter  ::  evfacts = 0.3, evfactl = 0.3
+    !
+       real,parameter  ::  tf=233.16,tcr=263.16,tcrf=1.0/(tcr-tf)
+       real,parameter  ::  xk1=2.e-5,xlhor=3.e4,xhver=5000.,theimax=1.
+       real,parameter  ::  xc1=1.e-7,xc2=1.e4,xc3=3.e3,ecesscr=3.0,edtk1=3.e4
+    !
+    !  passing variables
+    !
+       real            ::  cp_,cliq_,cvap_,g_,hvap_,rd_,rv_,fv_,ep2
+       real            ::  pi_,qmin_,t0c_,cice,xlv0,xls,psat
+       real            ::  pgcon
+       integer         ::  dx_factor_nsas
+       integer         ::  lat,                                                    &
+                           ncloud,                                                 &
+                           ids,ide, jds,jde, kds,kde,                              &
+                           ims,ime, jms,jme, kms,kme,                              &
+                           its,ite, jts,jte, kts,kte
+    !
+       real            ::  delt,rcs
+       real            ::  del(its:ite,kts:kte),                                   &
+                           prsl(its:ite,kts:kte),prslk(ims:ime,kms:kme),           &
+                           prsi(its:ite,kts:kte+1),                                &
+                           zl(its:ite,kts:kte),                                    &
+                           q1(its:ite,kts:kte),t1(its:ite,kts:kte),                &
+                           u1(its:ite,kts:kte),v1(its:ite,kts:kte),                &
+                           dot(its:ite,kts:kte)
+       real            ::  qi2(its:ite,kts:kte)
+       real            ::  qc2(its:ite,kts:kte)
+    !
+       real            ::  rain(its:ite)
+       integer         ::  kbot(its:ite),ktop(its:ite),icps(its:ite)
+       real            ::  slimsk(ims:ime)
+    !
+    !
+    !  local variables and arrays
+    !
+       integer         ::  i,k,kmax,kbmax,kbm,jmn,indx,indp,kts1,kte1,kmax1,kk
+       real            ::  p(its:ite,kts:kte),pdot(its:ite),acrtfct(its:ite)
+       real            ::  zi(its:ite,kts:kte+1)
+       real            ::  uo(its:ite,kts:kte),vo(its:ite,kts:kte)
+       real            ::  to(its:ite,kts:kte),qo(its:ite,kts:kte)
+       real            ::  hcko(its:ite,kts:kte)
+       real            ::  qcko(its:ite,kts:kte),eta(its:ite,kts:kte)
+       real            ::  etad(its:ite,kts:kte)
+       real            ::  qrcdo(its:ite,kts:kte)
+       real            ::  pwo(its:ite,kts:kte),pwdo(its:ite,kts:kte)
+       real            ::  dtconv(its:ite)
+       real            ::  deltv(its:ite),acrt(its:ite)
+       real            ::  qeso(its:ite,kts:kte)
+       real            ::  tvo(its:ite,kts:kte),dbyo(its:ite,kts:kte)
+       real            ::  heo(its:ite,kts:kte),heso(its:ite,kts:kte)
+       real            ::  qrcd(its:ite,kts:kte)
+       real            ::  dellah(its:ite,kts:kte),dellaq(its:ite,kts:kte)
+    !
+       integer         ::  kb(its:ite),kbcon(its:ite)
+       integer         ::  kbcon1(its:ite)
+       real            ::  hmax(its:ite),delq(its:ite)
+       real            ::  hkbo(its:ite),qkbo(its:ite),pbcdif(its:ite)
+       integer         ::  kbds(its:ite),lmin(its:ite),jmin(its:ite)
+       integer         ::  ktcon(its:ite)
+       integer         ::  ktcon1(its:ite)
+       integer         ::  kbdtr(its:ite)
+       integer         ::  klcl(its:ite),ktdown(its:ite)
+       real            ::  vmax(its:ite)
+       real            ::  hmin(its:ite),pwavo(its:ite)
+       real            ::  aa1(its:ite),vshear(its:ite)
+       real            ::  qevap(its:ite)
+       real            ::  edt(its:ite)
+       real            ::  edto(its:ite),pwevo(its:ite)
+       real            ::  qcond(its:ite)
+       real            ::  hcdo(its:ite,kts:kte)
+       real            ::  ddp(its:ite),pp2(its:ite)
+       real            ::  qcdo(its:ite,kts:kte)
+       real            ::  adet(its:ite),aatmp(its:ite)
+       real            ::  xhkb(its:ite),xqkb(its:ite)
+       real            ::  xpwav(its:ite),xpwev(its:ite),xhcd(its:ite,kts:kte)
+       real            ::  xaa0(its:ite),f(its:ite),xk(its:ite)
+       real            ::  xmb(its:ite)
+       real            ::  edtx(its:ite),xqcd(its:ite,kts:kte)
+       real            ::  hsbar(its:ite),xmbmax(its:ite)
+       real            ::  xlamb(its:ite,kts:kte),xlamd(its:ite)
+       real            ::  excess(its:ite)
+       real            ::  plcl(its:ite)
+       real            ::  delhbar(its:ite),delqbar(its:ite),deltbar(its:ite)
+       real,save       ::  pcrit(15), acritt(15)
+       real            ::  acrit(15)
+       real            ::  qcirs(its:ite,kts:kte),qrski(its:ite)
+       real            ::  dellal(its:ite,kts:kte)
+       real            ::  rntot(its:ite),delqev(its:ite),delq2(its:ite) 
+    !
+       real            ::  fent1(its:ite,kts:kte),fent2(its:ite,kts:kte)
+       real            ::  frh(its:ite,kts:kte)
+       real            ::  xlamud(its:ite),sumx(its:ite)
+       real            ::  aa2(its:ite)
+       real            ::  ucko(its:ite,kts:kte),vcko(its:ite,kts:kte)
+       real            ::  ucdo(its:ite,kts:kte),vcdo(its:ite,kts:kte)
+       real            ::  dellau(its:ite,kts:kte),dellav(its:ite,kts:kte)
+       real            ::  delubar(its:ite),delvbar(its:ite)
+       real            ::  qlko_ktcon(its:ite)
+    !
+       real            ::  alpha,beta,                                             &
+                           dt2,dtmin,dtmax,dtmaxl,dtmaxs,                          &
+                           el2orc,eps,fact1,fact2,                                 &
+                           tem,tem1,cincr
+       real            ::  dz,dp,es,pprime,qs,                                     &
+                           dqsdp,desdt,dqsdt,gamma,                                &
+                           dt,dq,po,thei,delx,delza,dzfac,                         &
+                           thec,theb,thekb,thekh,theavg,thedif,                    &
+                           omgkb,omgkbp1,omgdif,omgfac,heom,rh,thermal,chi,        &
+                           factor,onemf,dz1,qrch,etah,qlk,qc,rfact,shear,          &
+                           e1,dh,deta,detad,theom,edtmax,dhh,dg,aup,adw,           &
+                           dv1,dv2,dv3,dv1q,dv2q,dv3q,dvq1,                        &
+                           dv1u,dv2u,dv3u,dv1v,dv2v,dv3v,                          &
+                           dellat,xdby,xqrch,xqc,xpw,xpwd,                         &
+                           W1l,W2l,W3l,W4l,W1s,W2s,W3s,W4s,                        & 
+                           w1,w2,w3,w4,qrsk(its:ite,kts:kte),evef,ptem,ptem1
+    !
+       logical         ::  totflg, cnvflg(its:ite),flg(its:ite),lclflg
+       real            ::  dx_factor
+    !
+    !  climatological critical cloud work functions for closure
+    !
+       data pcrit/850.,800.,750.,700.,650.,600.,550.,500.,450.,400.,               &
+                  350.,300.,250.,200.,150./
+       data acritt/.0633,.0445,.0553,.0664,.075,.1082,.1521,.2216,                 &
+                  .3151,.3677,.41,.5255,.7663,1.1686,1.6851/
+    !
+    !-----------------------------------------------------------------------
+    !
+    ! define miscellaneous values
+    !
+       pi_   = 3.14159
+       qmin_ = 1.0e-30
+       t0c_ = 273.15
+       xlv0 = hvap_
+       rcs  = 1.
+       el2orc = hvap_*hvap_/(rv_*cp_)
+       eps    = rd_/rv_
+       fact1  = (cvap_-cliq_)/rv_
+       fact2  = hvap_/rv_-fact1*t0c_
+       kts1 = kts + 1
+       kte1 = kte - 1
+       dt2    = delt
+       dtmin  = max(dt2,1200.)
+       dtmax  = max(dt2,3600.)
+    !
+       if (dx_factor_nsas == 1) then
+       dx_factor = 250. / delx ! assume 2.5 ms-1 (1km) and 1.125 cms-1 (200km)
+       W1l = dx_factor * 0.1 * (-1.)
+       W2l = dx_factor * (-1.)
+       W3l = dx_factor * (-1.)
+       W4l = dx_factor * 0.1 * (-1.)
+       W1s = W1l
+       W2s = W2l
+       W3s = W3l
+       W4s = W4l
+       else 
+       W1l = -8.E-3
+       W2l = -4.E-2
+       W3l = -5.E-3
+       W4l = -5.E-4
+       W1s = -2.E-4
+       W2s = -2.E-3
+       W3s = -1.E-3
+       W4s = -2.E-5
+       endif
+    !
+    !  initialize arrays
+    !
+       lclflg = .true.
+       do i = its,ite
+         rain(i)     = 0.0
+         kbot(i)   = kte+1
+         ktop(i)   = 0
+         icps(i)   = 0
+         cnvflg(i) = .true.
+         dtconv(i) = 3600.
+         pdot(i)   = 0.0
+         edto(i)   = 0.0
+         edtx(i)   = 0.0
+         xmbmax(i) = 0.3
+         excess(i) = 0.0
+         plcl(i)   = 0.0
+         aa2(i) = 0.0
+         qlko_ktcon(i) = 0.0
+         pbcdif(i)= 0.0
+         lmin(i) = 1
+         jmin(i) = 1
+         edt(i) = 0.0
+       enddo
+    !
+       do k = 1,15
+         acrit(k) = acritt(k) * (975. - pcrit(k))
+       enddo
+    !
+    ! Define top layer for search of the downdraft originating layer
+    ! and the maximum thetae for updraft
+    !
+       kbmax = kte 
+       kbm   = kte 
+       kmax  = kte 
+       do k = kts,kte 
+         do i = its,ite 
+           if(prsl(i,k).gt.prsi(i,1)*0.45) kbmax = k + 1 
+           if(prsl(i,k).gt.prsi(i,1)*0.70) kbm   = k + 1 
+           if(prsl(i,k).gt.prsi(i,1)*0.04) kmax  = k + 1 
+         enddo 
+       enddo 
+       kmax = min(kmax,kte)
+       kmax1 = kmax - 1
+       kbm = min(kbm,kte)
+    !
+    ! convert surface pressure to mb from cb
+    !
+       do k = kts,kte
+         do i = its,ite
+           pwo(i,k)  = 0.0
+           pwdo(i,k) = 0.0
+           dellal(i,k) = 0.0
+           hcko(i,k) = 0.0
+           qcko(i,k) = 0.0
+           hcdo(i,k) = 0.0
+           qcdo(i,k) = 0.0
+         enddo
+       enddo
+    !
+       do k = kts,kmax
+         do i = its,ite
+           p(i,k) = prsl(i,k) * 10.
+           pwo(i,k) = 0.0
+           pwdo(i,k) = 0.0
+           to(i,k) = t1(i,k)
+           qo(i,k) = q1(i,k)
+           dbyo(i,k) = 0.0
+           fent1(i,k) = 1.0
+           fent2(i,k) = 1.0
+           frh(i,k) = 0.0
+           ucko(i,k) = 0.0
+           vcko(i,k) = 0.0
+           ucdo(i,k) = 0.0
+           vcdo(i,k) = 0.0
+           uo(i,k) = u1(i,k) * rcs
+           vo(i,k) = v1(i,k) * rcs
+         enddo
+       enddo
+    !
+    ! column variables
+    !
+    !  p is pressure of the layer (mb)
+    !  t is temperature at t-dt (k)..tn
+    !  q is mixing ratio at t-dt (kg/kg)..qn
+    !  to is temperature at t+dt (k)... this is after advection and turbulan
+    !  qo is mixing ratio at t+dt (kg/kg)..q1
+    !
+       do k = kts,kmax
+         do i = its,ite
+           qeso(i,k)=0.01*fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+           qeso(i,k) = eps * qeso(i,k) / (p(i,k) + (eps-1.) * qeso(i,k))
+           qeso(i,k) = max(qeso(i,k),qmin_)
+           qo(i,k)   = max(qo(i,k), 1.e-10 )
+           tvo(i,k)  = to(i,k) + fv_ * to(i,k) * max(qo(i,k),qmin_)
+         enddo
+       enddo
+    !
+    ! compute moist static energy
+    !
+       do k = kts,kmax
+         do i = its,ite
+           heo(i,k)  = g_ * zl(i,k) + cp_* to(i,k) + hvap_ * qo(i,k)
+           heso(i,k) = g_ * zl(i,k) + cp_* to(i,k) + hvap_ * qeso(i,k)
+         enddo
+       enddo
+    !
+    ! Determine level with largest moist static energy
+    ! This is the level where updraft starts
+    !
+       do i = its,ite
+         hmax(i) = heo(i,1)
+         kb(i) = 1
+       enddo
+    !
+       do k = kts1,kbm
+         do i = its,ite
+           if(heo(i,k).gt.hmax(i)) then
+             kb(i) = k
+             hmax(i) = heo(i,k)
+           endif
+         enddo
+       enddo
+    !
+       do k = kts,kmax1
+         do i = its,ite
+           if(cnvflg(i)) then
+             dz = .5 * (zl(i,k+1) - zl(i,k))
+             dp = .5 * (p(i,k+1) - p(i,k))
+             es = 0.01*fpvs(to(i,k+1),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             pprime = p(i,k+1) + (eps-1.) * es
+             qs = eps * es / pprime
+             dqsdp = - qs / pprime
+             desdt = es * (fact1 / to(i,k+1) + fact2 / (to(i,k+1)**2))
+             dqsdt = qs * p(i,k+1) * desdt / (es * pprime)
+             gamma = el2orc * qeso(i,k+1) / (to(i,k+1)**2)
+             dt = (g_ * dz + hvap_ * dqsdp * dp) / (cp_ * (1. + gamma))
+             dq = dqsdt * dt + dqsdp * dp
+             to(i,k) = to(i,k+1) + dt
+             qo(i,k) = qo(i,k+1) + dq
+             po = .5 * (p(i,k) + p(i,k+1))
+             qeso(i,k)=0.01*fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (po + (eps-1.) * qeso(i,k))
+             qeso(i,k) = max(qeso(i,k),qmin_)
+             qo(i,k)   = max(qo(i,k), 1.e-10)
+             frh(i,k)  = 1. - min(qo(i,k)/qeso(i,k), 1.)
+             heo(i,k)  = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                          &
+                    cp_ * to(i,k) + hvap_ * qo(i,k)
+             heso(i,k) = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                          &
+                    cp_ * to(i,k) + hvap_ * qeso(i,k)
+             uo(i,k)   = .5 * (uo(i,k) + uo(i,k+1))
+             vo(i,k)   = .5 * (vo(i,k) + vo(i,k+1))
+           endif
+         enddo
+       enddo
+    !
+    ! look for convective cloud base as the level of free convection
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           indx = kb(i)
+           hkbo(i) = heo(i,indx)
+           qkbo(i) = qo(i,indx)
+         endif
+       enddo
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         kbcon(i) = kmax
+       enddo
+    !
+       do k = kts,kbmax
+         do i = its,ite
+           if(flg(i).and.k.gt.kb(i)) then
+             hsbar(i) = heso(i,k)
+             if(hkbo(i).gt.hsbar(i)) then
+               flg(i) = .false.
+               kbcon(i) = k
+             endif
+           endif
+         enddo
+       enddo
+       do i = its,ite
+         if(kbcon(i).eq.kmax) cnvflg(i) = .false.
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+    !
+    !  determine critical convective inhibition
+    !  as a function of vertical velocity at cloud base.
+    !
+           pdot(i)  = 10.* dot(i,kbcon(i))
+           if(slimsk(i).eq.1.) then
+             w1 = w1l
+             w2 = w2l
+             w3 = w3l
+             w4 = w4l
+           else
+             w1 = w1s
+             w2 = w2s
+             w3 = w3s
+             w4 = w4s
+           endif
+           if(pdot(i).le.w4) then
+             tem = (pdot(i) - w4) / (w3 - w4)
+           elseif(pdot(i).ge.-w4) then
+             tem = - (pdot(i) + w4) / (w4 - w3)
+           else
+             tem = 0.
+           endif
+           tem = max(tem,-1.)
+           tem = min(tem,1.)
+           tem = 1. - tem
+           tem1= .5*(cincrmax-cincrmin)
+           cincr = cincrmax - tem * tem1
+           pbcdif(i) = -p(i,kbcon(i)) + p(i,kb(i))
+           if(pbcdif(i).gt.cincr) cnvflg(i) = .false.
+         endif
+       enddo
+    !
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+       do k = kts1,kte
+         do i = its,ite
+           zi(i,k) = 0.5*(zl(i,k-1)+zl(i,k))
+         enddo
+       enddo
+    !
+       do k = kts,kte1
+         do i = its,ite
+           xlamb(i,k) = clam / zi(i,k+1) 
+         enddo
+       enddo
+    !
+    !  assume that updraft entrainment rate above cloud base is
+    !  same as that at cloud base
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.(k.gt.kbcon(i))) then
+             xlamb(i,k) = xlamb(i,kbcon(i))
+           endif
+         enddo
+       enddo
+    !
+    !   assume the detrainment rate for the updrafts to be same as
+    !   the entrainment rate at cloud base
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           xlamud(i) = xlamb(i,kbcon(i))
+         endif
+       enddo
+    !
+    !  functions rapidly decreasing with height, mimicking a cloud ensemble
+    !    (Bechtold et al., 2008)
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.(k.gt.kbcon(i))) then
+             tem = qeso(i,k)/qeso(i,kbcon(i))
+             fent1(i,k) = tem**2
+             fent2(i,k) = tem**3
+           endif
+         enddo
+       enddo
+    !
+    !  final entrainment rate as the sum of turbulent part and organized entrainment
+    !    depending on the environmental relative humidity
+    !    (Bechtold et al., 2008)
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.(k.ge.kbcon(i))) then
+              tem = cxlamu * frh(i,k) * fent2(i,k)
+              xlamb(i,k) = xlamb(i,k)*fent1(i,k) + tem
+           endif
+         enddo
+       enddo
+    !
+    ! determine updraft mass flux
+    !
+       do k = kts,kte
+         do i = its,ite
+          if(cnvflg(i)) then
+             eta(i,k) = 1.
+           endif
+         enddo
+       enddo
+    !
+       do k = kbmax,kts1,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.kbcon(i).and.k.ge.kb(i)) then
+             dz = zi(i,k+2) - zi(i,k+1)
+             ptem     = 0.5*(xlamb(i,k)+xlamb(i,k+1))-xlamud(i)
+             eta(i,k) = eta(i,k+1) / (1. + ptem * dz)
+           endif
+         enddo
+       enddo
+      do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.kbcon(i)) then
+             dz  = zi(i,k+1) - zi(i,k)
+             ptem = 0.5*(xlamb(i,k)+xlamb(i,k-1))-xlamud(i)
+             eta(i,k) = eta(i,k-1) * (1 + ptem * dz)
+           endif
+         enddo
+       enddo
+       do i = its,ite
+         if(cnvflg(i)) then
+           dz = zi(i,3) - zi(i,2)
+           ptem     = 0.5*(xlamb(i,1)+xlamb(i,2))-xlamud(i)
+           eta(i,1) = eta(i,2) / (1. + ptem * dz)
+         endif
+       enddo
+    !
+    ! work up updraft cloud properties
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           indx = kb(i)
+           hcko(i,indx) = hkbo(i)
+           qcko(i,indx) = qkbo(i)
+           ucko(i,indx) = uo(i,indx)
+           vcko(i,indx) = vo(i,indx)
+           pwavo(i) = 0.
+         endif
+       enddo
+    !
+    ! cloud property below cloud base is modified by the entrainment proces
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.kb(i)) then
+             dz   = zi(i,k+1) - zi(i,k)
+             tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1)) * dz
+             tem1 = 0.5 * xlamud(i) * dz
+             factor = 1. + tem - tem1
+             ptem = 0.5 * tem + pgcon
+             ptem1= 0.5 * tem - pgcon
+             hcko(i,k) = ((1.-tem1)*hcko(i,k-1)+tem*0.5*                          &
+                         (heo(i,k)+heo(i,k-1)))/factor
+             ucko(i,k) = ((1.-tem1)*ucko(i,k-1)+ptem*uo(i,k)                      &
+                         +ptem1*uo(i,k-1))/factor
+             vcko(i,k) = ((1.-tem1)*vcko(i,k-1)+ptem*vo(i,k)                      &
+                         +ptem1*vo(i,k-1))/factor
+             dbyo(i,k) = hcko(i,k) - heso(i,k)
+           endif
+         enddo
+       enddo
+    !
+    !   taking account into convection inhibition due to existence of
+    !    dry layers below cloud base
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         kbcon1(i) = kmax
+       enddo
+    !
+       do k = kts1,kmax
+         do i = its,ite
+           if(flg(i).and.k.ge.kbcon(i).and.dbyo(i,k).gt.0.) then
+             kbcon1(i) = k
+             flg(i) = .false.
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           if(kbcon1(i).eq.kmax) cnvflg(i) = .false.
+         endif
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           tem = p(i,kbcon(i)) - p(i,kbcon1(i))
+           if(tem.gt.dthk) then
+              cnvflg(i) = .false.
+           endif
+         endif
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !
+    !  determine cloud top
+    !
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         ktcon(i) = 1
+       enddo
+    !
+    !   check inversion
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(dbyo(i,k).lt.0..and.flg(i).and.k.gt. kbcon1(i)) then
+             ktcon(i) = k
+             flg(i)   = .false.
+           endif
+         enddo
+       enddo
+    !
+    !
+    ! check cloud depth
+    !
+       do i = its,ite
+         if(cnvflg(i).and.(p(i,kbcon(i)) - p(i,ktcon(i))).lt.150.)                 &
+                cnvflg(i) = .false.
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !
+    !  search for downdraft originating level above theta-e minimum
+    !
+       do i = its,ite 
+         if(cnvflg(i)) then
+           hmin(i) = heo(i,kbcon1(i))
+           lmin(i) = kbmax
+           jmin(i) = kbmax
+        endif
+       enddo
+    !
+       do k = kts1,kbmax 
+         do i = its,ite 
+           if(cnvflg(i).and.k.gt.kbcon1(i).and.heo(i,k).lt.hmin(i)) then
+             lmin(i) = k + 1
+             hmin(i) = heo(i,k)
+           endif
+         enddo
+       enddo
+    !
+    ! make sure that jmin is within the cloud
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           jmin(i) = min(lmin(i),ktcon(i)-1)
+           jmin(i) = max(jmin(i),kbcon1(i)+1)
+           if(jmin(i).ge.ktcon(i)) cnvflg(i) = .false.
+         endif
+       enddo
+    !
+    !  specify upper limit of mass flux at cloud base
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           k = kbcon(i)
+           dp = 1000. * del(i,k)
+           xmbmax(i) = dp / (g_ * dt2)
+         endif
+       enddo
+    !
+    !
+    ! compute cloud moisture property and precipitation
+    !
+       do i = its,ite
+         aa1(i) = 0.
+       enddo
+    !
+       do k = kts1,kmax
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.kb(i).and.k.lt.ktcon(i)) then
+             dz = .5 * (zl(i,k+1) - zl(i,k-1))
+             dz1 = (zi(i,k+1) - zi(i,k))
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             qrch = qeso(i,k)                                                      &
+                  + gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+             tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1)) * dz1
+             tem1 = 0.5 * xlamud(i) * dz1
+             factor = 1. + tem - tem1
+             qcko(i,k) = ((1.-tem1)*qcko(i,k-1)+tem*0.5*                           & 
+                        (qo(i,k)+qo(i,k-1)))/factor
+             qcirs(i,k) = eta(i,k) * qcko(i,k) - eta(i,k) * qrch
+    !
+    ! check if there is excess moisture to release latent heat
+    !
+             if(qcirs(i,k).gt.0. .and. k.ge.kbcon(i)) then
+               etah = .5 * (eta(i,k) + eta(i,k-1))
+               if(ncloud.gt.0..and.k.gt.jmin(i)) then
+                 dp = 1000. * del(i,k)
+                 qlk = qcirs(i,k) / (eta(i,k) + etah * (c0 + c1) * dz1)
+                 dellal(i,k) = etah * c1 * dz1 * qlk * g_ / dp
+               else
+                 qlk = qcirs(i,k) / (eta(i,k) + etah * c0 * dz1)
+               endif
+               aa1(i) = aa1(i) - dz1 * g_ * qlk
+               qc = qlk + qrch
+               pwo(i,k) = etah * c0 * dz1 * qlk
+               qcko(i,k) = qc
+               pwavo(i) = pwavo(i) + pwo(i,k)
+             endif
+           endif
+         enddo
+       enddo
+    !
+    ! calculate cloud work function at t+dt
+    !
+       do k = kts1,kmax 
+         do i = its,ite 
+           if(cnvflg(i).and.k.ge.kbcon(i).and.k.lt.ktcon(i)) then
+             dz1 = zl(i,k+1) - zl(i,k)
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             rfact =  1. + fv_ * cp_ * gamma* to(i,k) / hvap_
+             aa1(i) = aa1(i) +dz1 * (g_ / (cp_ * to(i,k)))                         &
+                      * dbyo(i,k) / (1. + gamma)* rfact
+             aa1(i) = aa1(i)+dz1 * g_ * fv_ *                                      &
+                      max(0.,(qeso(i,k) - qo(i,k)))
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i).and.aa1(i).le.0.) cnvflg(i) = .false.
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !    estimate the convective overshooting as the level
+    !    where the [aafac * cloud work function] becomes zero,
+    !    which is the final cloud top
+    !
+       do i = its,ite
+         if (cnvflg(i)) then
+           aa2(i) = aafac * aa1(i)
+         endif
+       enddo
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         ktcon1(i) = kmax1
+       enddo
+    !
+       do k = kts1,kmax
+         do i = its, ite
+           if (flg(i)) then
+             if(k.ge.ktcon(i).and.k.lt.kmax) then
+               dz1 = zl(i,k+1) - zl(i,k)
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               rfact =  1. + fv_ * cp_ * gamma* to(i,k) / hvap_
+               aa2(i) = aa2(i) +dz1 * (g_ / (cp_ * to(i,k)))                    &
+                           * dbyo(i,k) / (1. + gamma)* rfact
+               if(aa2(i).lt.0.) then
+                 ktcon1(i) = k
+                 flg(i) = .false.
+               endif
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  compute cloud moisture property, detraining cloud water
+    !  and precipitation in overshooting layers
+    !
+       do k = kts1,kmax
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.ge.ktcon(i).and.k.lt.ktcon1(i)) then
+               dz = (zi(i,k+1) - zi(i,k))
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               qrch = qeso(i,k)+ gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+               tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1)) * dz
+               tem1 = 0.5 * xlamud(i) * dz
+               factor = 1. + tem - tem1
+               qcko(i,k) = ((1.-tem1)*qcko(i,k-1)+tem*0.5*                         & 
+                          (qo(i,k)+qo(i,k-1)))/factor
+               qcirs(i,k) = eta(i,k) * qcko(i,k) - eta(i,k) * qrch
+    !
+    !  check if there is excess moisture to release latent heat
+    !
+               if(qcirs(i,k).gt.0.) then
+                 etah = .5 * (eta(i,k) + eta(i,k-1))
+                 if(ncloud.gt.0.) then
+                   dp = 1000. * del(i,k)
+                   qlk = qcirs(i,k) / (eta(i,k) + etah * (c0 + c1) * dz)
+                   dellal(i,k) = etah * c1 * dz * qlk * g_ / dp
+                 else
+                   qlk = qcirs(i,k) / (eta(i,k) + etah * c0 * dz)
+                 endif
+                 qc = qlk + qrch
+                 pwo(i,k) = etah * c0 * dz * qlk
+                 qcko(i,k) = qc
+                 pwavo(i) = pwavo(i) + pwo(i,k)
+               endif
+             endif
+           endif
+         enddo
+       enddo
+    !
+    ! exchange ktcon with ktcon1
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           kk = ktcon(i)
+           ktcon(i) = ktcon1(i)
+           ktcon1(i) = kk
+         endif
+       enddo
+    !
+    ! this section is ready for cloud water
+    !
+       if (ncloud.gt.0) then
+    !
+    !  compute liquid and vapor separation at cloud top
+    ! 
+         do i = its,ite
+           if(cnvflg(i)) then
+             k = ktcon(i)-1
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             qrch = qeso(i,k)                                                      &
+                    + gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+             dq = qcko(i,k) - qrch
+    !
+    !  check if there is excess moisture to release latent heat
+    !
+             if(dq.gt.0.) then
+               qlko_ktcon(i) = dq
+               qcko(i,k) = qrch
+             endif
+           endif
+         enddo
+       endif
+    !
+    ! ..... downdraft calculations .....
+    !
+    ! determine downdraft strength in terms of wind shear
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           vshear(i) = 0.
+         endif
+       enddo
+    !
+       do k = kts1,kmax
+         do i = its,ite
+           if(k.gt.kb(i).and.k.le.ktcon(i).and.cnvflg(i)) then
+             shear= sqrt((uo(i,k)-uo(i,k-1)) ** 2                                  & 
+                           + (vo(i,k)-vo(i,k-1)) ** 2)
+             vshear(i) = vshear(i) + shear
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           vshear(i) = 1.e3 * vshear(i) / (zi(i,ktcon(i)+1)-zi(i,kb(i)+1))
+           e1 = 1.591-.639*vshear(i)                                               &
+               +.0953*(vshear(i)**2)-.00496*(vshear(i)**3)
+           edt(i)  = 1.-e1
+    !
+           edt(i)  = min(edt(i),.9)
+           edt(i)  = max(edt(i),.0)
+           edto(i) = edt(i)
+           edtx(i) = edt(i)
+         endif
+       enddo
+    !
+    ! determine detrainment rate between 1 and kbdtr
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           sumx(i) = 0.
+         endif
+       enddo
+    !
+       do k = kts,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.ge.1.and.k.lt.kbcon(i)) then
+             dz = zi(i,k+2) - zi(i,k+1)
+             sumx(i) = sumx(i) + dz
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         kbdtr(i) = kbcon(i)
+         beta = betas
+         if(slimsk(i).eq.1.) beta = betal
+         if(cnvflg(i)) then
+           kbdtr(i) = kbcon(i)
+           kbdtr(i) = max(kbdtr(i),1)
+           dz =(sumx(i)+zi(i,2))/float(kbcon(i))
+           tem = 1./float(kbcon(i))
+           xlamd(i) = (1.-beta**tem)/dz
+         endif
+       enddo
+    !
+    ! determine downdraft mass flux
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i)) then
+             etad(i,k) = 1.
+           endif
+           qrcdo(i,k) = 0.
+           qrcd(i,k) = 0.
+         enddo
+       enddo
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i)) then
+             if(k.lt.jmin(i).and.k.ge.kbcon(i))then
+               dz = (zi(i,k+2) - zi(i,k+1))
+               ptem = xlamdd-xlamde
+               etad(i,k) = etad(i,k+1) * (1.-ptem * dz)
+             elseif(k.lt.kbcon(i))then
+               dz = (zi(i,k+2) - zi(i,k+1))
+               ptem = xlamd(i)+xlamdd-xlamde
+               etad(i,k) = etad(i,k+1) * (1.-ptem * dz)
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !
+    ! downdraft moisture properties
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+          pwevo(i) = 0.
+         endif
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i))  then 
+           jmn = jmin(i)
+           hcdo(i,jmn) = heo(i,jmn)
+           qcdo(i,jmn) = qo(i,jmn)
+           qrcdo(i,jmn) = qeso(i,jmn)
+           ucdo(i,jmn) = uo(i,jmn)
+           vcdo(i,jmn) = vo(i,jmn)
+         endif
+       enddo
+    !
+       do k = kmax1,kts,-1 
+         do i = its,ite 
+           if (cnvflg(i) .and. k.lt.jmin(i)) then
+             dz = zi(i,k+2) - zi(i,k+1)
+             if(k.ge.kbcon(i)) then
+               tem  = xlamde * dz
+               tem1 = 0.5 * xlamdd * dz
+             else
+               tem  = xlamde * dz
+               tem1 = 0.5 * (xlamd(i)+xlamdd) * dz
+              endif
+              factor = 1. + tem - tem1
+              ptem = 0.5 * tem - pgcon
+              ptem1= 0.5 * tem + pgcon
+              hcdo(i,k) = ((1.-tem1)*hcdo(i,k+1)+tem*0.5*                     & 
+                          (heo(i,k)+heo(i,k+1)))/factor
+              ucdo(i,k) = ((1.-tem1)*ucdo(i,k+1)+ptem*uo(i,k+1)               & 
+                         +ptem1*uo(i,k))/factor
+              vcdo(i,k) = ((1.-tem1)*vcdo(i,k+1)+ptem*vo(i,k+1)               & 
+                         +ptem1*vo(i,k))/factor
+              dbyo(i,k) = hcdo(i,k) - heso(i,k)
+           endif
+         enddo
+       enddo
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.jmin(i)) then
+             dq = qeso(i,k)
+             dt = to(i,k)
+             gamma = el2orc * dq / dt**2
+             qrcdo(i,k)=dq+(1./hvap_)*(gamma/(1.+gamma))*dbyo(i,k)
+             detad = etad(i,k+1) - etad(i,k)
+             dz = zi(i,k+2) - zi(i,k+1)
+             if(k.ge.kbcon(i)) then
+                tem  = xlamde * dz
+                tem1 = 0.5 * xlamdd * dz
+             else
+                tem  = xlamde * dz
+                tem1 = 0.5 * (xlamd(i)+xlamdd) * dz
+             endif
+             factor = 1. + tem - tem1
+             qcdo(i,k) = ((1.-tem1)*qcdo(i,k+1)+tem*0.5*                      & 
+                         (qo(i,k)+qo(i,k+1)))/factor
+             pwdo(i,k) = etad(i,k+1) * qcdo(i,k) -etad(i,k+1) * qrcdo(i,k)
+             qcdo(i,k) = qrcdo(i,k)
+             pwevo(i) = pwevo(i) + pwdo(i,k)
+           endif
+         enddo
+       enddo
+    !
+    ! final downdraft strength dependent on precip
+    ! efficiency (edt), normalized condensate (pwav), and
+    ! evaporate (pwev)
+    !
+       do i = its,ite
+         edtmax = edtmaxl
+         if(slimsk(i).eq.2.) edtmax = edtmaxs
+         if(cnvflg(i)) then
+           if(pwevo(i).lt.0.) then
+             edto(i) = -edto(i) * pwavo(i) / pwevo(i)
+             edto(i) = min(edto(i),edtmax)
+           else
+             edto(i) = 0.
+           endif
+         endif
+       enddo
+    !
+    ! downdraft cloudwork functions
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.jmin(i)) then
+             gamma = el2orc * qeso(i,k) / to(i,k)**2
+             dhh=hcdo(i,k)
+             dt=to(i,k)
+             dg=gamma
+             dh=heso(i,k)
+             dz=-1.*(zl(i,k+1)-zl(i,k))
+             aa1(i)=aa1(i)+edto(i)*dz*(g_/(cp_*dt))*((dhh-dh)/(1.+dg))             &
+                    *(1.+fv_*cp_*dg*dt/hvap_)
+             aa1(i)=aa1(i)+edto(i)*dz*g_*fv_*max(0.,(qeso(i,k)-qo(i,k)))
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i).and.aa1(i).le.0.) cnvflg(i) = .false.
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    ! what would the change be, that a cloud with unit mass
+    ! will do to the environment?
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i)) then
+             dellah(i,k) = 0.
+             dellaq(i,k) = 0.
+             dellau(i,k) = 0.
+             dellav(i,k) = 0.
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           dp = 1000. * del(i,1)
+           dellah(i,1) = edto(i) * etad(i,1) * (hcdo(i,1)                          &
+                       - heo(i,1)) * g_ / dp
+           dellaq(i,1) = edto(i) * etad(i,1) * (qcdo(i,1)                          &
+                       - qo(i,1)) * g_ / dp
+           dellau(i,1) = edto(i) * etad(i,1) * (ucdo(i,1)                          &
+                       - uo(i,1)) * g_ / dp
+           dellav(i,1) = edto(i) * etad(i,1) * (vcdo(i,1)                          &
+                       - vo(i,1)) * g_ / dp
+         endif
+       enddo
+    !
+    ! changed due to subsidence and entrainment
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.ktcon(i)) then
+             aup = 1.
+             if(k.le.kb(i)) aup = 0.
+             adw = 1.
+             if(k.gt.jmin(i)) adw = 0.
+             dv1= heo(i,k)
+             dv2 = .5 * (heo(i,k) + heo(i,k-1))
+             dv3= heo(i,k-1)
+             dv1q= qo(i,k)
+             dv2q = .5 * (qo(i,k) + qo(i,k-1))
+             dv3q= qo(i,k-1)
+             dv1u = uo(i,k)
+             dv2u = .5 * (uo(i,k) + uo(i,k-1))
+             dv3u = uo(i,k-1)
+             dv1v = vo(i,k)
+             dv2v = .5 * (vo(i,k) + vo(i,k-1))
+             dv3v = vo(i,k-1)
+             dp = 1000. * del(i,k)
+             dz = zi(i,k+1) - zi(i,k)
+             tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1))
+             tem1 = xlamud(i)
+             if(k.le.kbcon(i)) then
+               ptem  = xlamde
+               ptem1 = xlamd(i)+xlamdd
+             else
+               ptem  = xlamde
+               ptem1 = xlamdd
+             endif
+             deta = eta(i,k) - eta(i,k-1)
+             detad = etad(i,k) - etad(i,k-1)
+             dellah(i,k) = dellah(i,k) +                                           &
+                 ((aup * eta(i,k) - adw * edto(i) * etad(i,k)) * dv1               &
+             - (aup * eta(i,k-1) - adw * edto(i) * etad(i,k-1))* dv3               &
+             - (aup*tem*eta(i,k-1)+adw*edto(i)*ptem*etad(i,k))*dv2*dz              & 
+             +  aup*tem1*eta(i,k-1)*.5*(hcko(i,k)+hcko(i,k-1))*dz                  & 
+             +  adw*edto(i)*ptem1*etad(i,k)*.5*(hcdo(i,k)+hcdo(i,k-1))*dz) *g_/dp
+             dellaq(i,k) = dellaq(i,k) +                                           &
+                 ((aup * eta(i,k) - adw * edto(i) * etad(i,k)) * dv1q              &
+             - (aup * eta(i,k-1) - adw * edto(i) * etad(i,k-1))* dv3q              &
+             - (aup*tem*eta(i,k-1)+adw*edto(i)*ptem*etad(i,k))*dv2q*dz             & 
+             +  aup*tem1*eta(i,k-1)*.5*(qcko(i,k)+qcko(i,k-1))*dz                  & 
+             +  adw*edto(i)*ptem1*etad(i,k)*.5*(qrcdo(i,k)+qrcdo(i,k-1))*dz) *g_/dp
+             dellau(i,k) = dellau(i,k) +                                           &
+                 ((aup * eta(i,k) - adw * edto(i) * etad(i,k)) * dv1u              &
+             - (aup * eta(i,k-1) - adw * edto(i) * etad(i,k-1))* dv3u              &
+             - (aup*tem*eta(i,k-1)+adw*edto(i)*ptem*etad(i,k))*dv2u*dz             & 
+             +  aup*tem1*eta(i,k-1)*.5*(ucko(i,k)+ucko(i,k-1))*dz                  & 
+             +  adw*edto(i)*ptem1*etad(i,k)*.5*(ucdo(i,k)+ucdo(i,k-1))*dz          & 
+             -  pgcon*(aup*eta(i,k-1)-adw*edto(i)*etad(i,k))*(dv1u-dv3u))*g_/dp
+    !
+             dellav(i,k) = dellav(i,k) +                                           &
+                 ((aup * eta(i,k) - adw * edto(i) * etad(i,k)) * dv1v              &
+             - (aup * eta(i,k-1) - adw * edto(i) * etad(i,k-1))* dv3v              &
+             - (aup*tem*eta(i,k-1)+adw*edto(i)*ptem*etad(i,k))*dv2v*dz             & 
+             +  aup*tem1*eta(i,k-1)*.5*(vcko(i,k)+vcko(i,k-1))*dz                  & 
+             +  adw*edto(i)*ptem1*etad(i,k)*.5*(vcdo(i,k)+vcdo(i,k-1))*dz          & 
+             -  pgcon*(aup*eta(i,k-1)-adw*edto(i)*etad(i,k))*(dv1v-dv3v))*g_/dp
+           endif
+         enddo
+       enddo
+    !
+    ! cloud top
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           indx = ktcon(i)
+           dp = 1000. * del(i,indx)
+           dv1 = heo(i,indx-1)
+           dellah(i,indx) = eta(i,indx-1) *                                        &
+                            (hcko(i,indx-1) - dv1) * g_ / dp
+           dvq1 = qo(i,indx-1)
+           dellaq(i,indx) = eta(i,indx-1) *                                        &
+                            (qcko(i,indx-1) - dvq1) * g_ / dp
+           dv1u = uo(i,indx-1)
+           dellau(i,indx) = eta(i,indx-1) *                                        &
+                            (ucko(i,indx-1) - dv1u) * g_ / dp
+           dv1v = vo(i,indx-1)
+           dellav(i,indx) = eta(i,indx-1) *                                        &
+                            (vcko(i,indx-1) - dv1v) * g_ / dp
+    !
+    !  cloud water
+    !
+           dellal(i,indx) = eta(i,indx-1) * qlko_ktcon(i) * g_ / dp
+         endif
+       enddo
+    !
+    ! final changed variable per unit mass flux
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.ktcon(i)) then
+             qo(i,k) = q1(i,k)
+             to(i,k) = t1(i,k)
+           endif
+           if(cnvflg(i).and.k.le.ktcon(i)) then
+             qo(i,k) = dellaq(i,k) * mbdt + q1(i,k)
+             dellat  = (dellah(i,k) - hvap_ * dellaq(i,k)) / cp_
+             to(i,k) = dellat * mbdt + t1(i,k)
+             qo(i,k) = max(qo(i,k),1.0e-10)
+           endif
+         enddo
+       enddo
+    !
+    !------------------------------------------------------------------------------
+    !
+    ! the above changed environment is now used to calulate the
+    ! effect the arbitrary cloud (with unit mass flux)
+    ! which then is used to calculate the real mass flux,
+    ! necessary to keep this change in balance with the large-scale
+    ! destabilization.
+    !
+    ! environmental conditions again
+    !
+    !------------------------------------------------------------------------------
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i)) then
+             qeso(i,k)=0.01* fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (p(i,k) + (eps-1.) * qeso(i,k))
+             qeso(i,k) = max(qeso(i,k),qmin_)
+             tvo(i,k)  = to(i,k) + fv_ * to(i,k) * max(qo(i,k),qmin_)
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           xaa0(i) = 0.
+           xpwav(i) = 0.
+         endif
+       enddo
+    !
+    ! moist static energy
+    !
+       do k = kts,kmax1
+         do i = its,ite
+           if(cnvflg(i)) then
+             dz = .5 * (zl(i,k+1) - zl(i,k))
+             dp = .5 * (p(i,k+1) - p(i,k))
+             es =0.01*fpvs(to(i,k+1),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             pprime = p(i,k+1) + (eps-1.) * es
+             qs = eps * es / pprime
+             dqsdp = - qs / pprime
+             desdt = es * (fact1 / to(i,k+1) + fact2 / (to(i,k+1)**2))
+             dqsdt = qs * p(i,k+1) * desdt / (es * pprime)
+             gamma = el2orc * qeso(i,k+1) / (to(i,k+1)**2)
+             dt = (g_ * dz + hvap_ * dqsdp * dp) / (cp_ * (1. + gamma))
+             dq = dqsdt * dt + dqsdp * dp
+             to(i,k) = to(i,k+1) + dt
+             qo(i,k) = qo(i,k+1) + dq
+             po = .5 * (p(i,k) + p(i,k+1))
+             qeso(i,k) =0.01* fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (po + (eps-1.) * qeso(i,k))
+             qeso(i,k) = max(qeso(i,k),qmin_)
+             qo(i,k)   = max(qo(i,k), 1.0e-10)
+             heo(i,k) = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                          &
+                         cp_ * to(i,k) + hvap_ * qo(i,k)
+             heso(i,k) = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                         &
+                         cp_ * to(i,k) + hvap_ * qeso(i,k)
+           endif
+         enddo
+       enddo
+    !
+       k = kmax
+       do i = its,ite
+         if(cnvflg(i)) then
+           heo(i,k)  = g_ * zl(i,k) + cp_ * to(i,k) + hvap_ * qo(i,k)
+           heso(i,k) = g_ * zl(i,k) + cp_ * to(i,k) + hvap_ * qeso(i,k)
+         endif
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           xaa0(i) = 0.
+           xpwav(i) = 0.
+           indx = kb(i)
+           xhkb(i) = heo(i,indx)
+           xqkb(i) = qo(i,indx)
+           hcko(i,indx) = xhkb(i)
+           qcko(i,indx) = xqkb(i)
+         endif
+       enddo
+    !
+    ! ..... static control .....
+    !
+    ! moisture and cloud work functions
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.kb(i).and.k.le.ktcon(i)) then
+             dz = zi(i,k+1) - zi(i,k)
+             tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1)) * dz
+             tem1 = 0.5 * xlamud(i) * dz
+             factor = 1. + tem - tem1
+             hcko(i,k) = ((1.-tem1)*hcko(i,k-1)+tem*0.5*                         & 
+                        (heo(i,k)+heo(i,k-1)))/factor
+           endif
+         enddo
+       enddo
+    !
+       do k = kts1,kmax1
+         do i = its,ite
+           if(cnvflg(i).and.k.gt.kb(i).and.k.lt.ktcon(i)) then
+             dz = zi(i,k+1) - zi(i,k)
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             xdby = hcko(i,k) - heso(i,k)
+             xqrch = qeso(i,k)                                                     &
+                  + gamma * xdby / (hvap_ * (1. + gamma))
+             tem  = 0.5 * (xlamb(i,k)+xlamb(i,k-1)) * dz
+             tem1 = 0.5 * xlamud(i) * dz
+             factor = 1. + tem - tem1
+             qcko(i,k) = ((1.-tem1)*qcko(i,k-1)+tem*0.5*(qo(i,k)+qo(i,k-1)))/factor
+             dq = eta(i,k) * qcko(i,k) - eta(i,k) * xqrch
+             if(k.ge.kbcon(i).and.dq.gt.0.) then
+               etah = .5 * (eta(i,k) + eta(i,k-1))
+               if(ncloud.gt.0..and.k.gt.jmin(i)) then
+                 qlk = dq / (eta(i,k) + etah * (c0 + c1) * dz)
+               else
+                 qlk = dq / (eta(i,k) + etah * c0 * dz)
+               endif
+               if(k.lt.ktcon1(i)) then
+                 xaa0(i) = xaa0(i) - dz * g_ * qlk
+               endif
+               qcko(i,k) = qlk + xqrch
+               xpw = etah * c0 * dz * qlk
+               xpwav(i) = xpwav(i) + xpw
+             endif
+           endif
+           if(cnvflg(i).and.k.ge.kbcon(i).and.k.lt.ktcon1(i)) then
+             dz1 = zl(i,k+1) - zl(i,k)
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             rfact =  1. + fv_ * cp_ * gamma                                       &
+                      * to(i,k) / hvap_
+             xdby = hcko(i,k) - heso(i,k)
+             xaa0(i) = xaa0(i)                                                     &
+                     + dz1 * (g_ / (cp_ * to(i,k)))                                &
+                     * xdby / (1. + gamma)                                         &
+                     * rfact
+             xaa0(i)=xaa0(i)+                                                      &
+                      dz1 * g_ * fv_ *                                             &
+                      max(0.,(qeso(i,k) - qo(i,k)))
+           endif
+         enddo
+       enddo
+    !
+    ! ..... downdraft calculations .....
+    !
+    !
+    ! downdraft moisture properties
+    !
+       do i = its,ite
+         xpwev(i) = 0.
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           jmn = jmin(i)
+           xhcd(i,jmn) = heo(i,jmn)
+           xqcd(i,jmn) = qo(i,jmn)
+           qrcd(i,jmn) = qeso(i,jmn)
+         endif
+       enddo
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.jmin(i)) then
+             dz = zi(i,k+2) - zi(i,k+1)
+             if(k.ge.kbcon(i)) then
+                tem  = xlamde * dz
+                tem1 = 0.5 * xlamdd * dz
+             else
+                tem  = xlamde * dz
+                tem1 = 0.5 * (xlamd(i)+xlamdd) * dz
+             endif
+             factor = 1. + tem - tem1
+             xhcd(i,k) = ((1.-tem1)*xhcd(i,k+1)+tem*0.5*                        & 
+                        (heo(i,k)+heo(i,k+1)))/factor
+           endif
+         enddo
+       enddo
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.jmin(i)) then
+             dq = qeso(i,k)
+             dt = to(i,k)
+             gamma = el2orc * dq / dt**2
+             dh = xhcd(i,k) - heso(i,k)
+             qrcd(i,k)=dq+(1./hvap_)*(gamma/(1.+gamma))*dh
+             dz = zi(i,k+2) - zi(i,k+1)
+             if(k.ge.kbcon(i)) then
+               tem  = xlamde * dz
+               tem1 = 0.5 * xlamdd * dz
+             else
+               tem  = xlamde * dz
+               tem1 = 0.5 * (xlamd(i)+xlamdd) * dz
+             endif
+             factor = 1. + tem - tem1
+             xqcd(i,k) = ((1.-tem1)*xqcd(i,k+1)+tem*0.5*                           & 
+                       (qo(i,k)+qo(i,k+1)))/factor
+             xpwd     = etad(i,k+1) * (xqcd(i,k) - qrcd(i,k))
+             xqcd(i,k)= qrcd(i,k)
+             xpwev(i) = xpwev(i) + xpwd
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         edtmax = edtmaxl
+         if(slimsk(i).eq.2.) edtmax = edtmaxs
+         if(cnvflg(i)) then
+           if(xpwev(i).ge.0.) then
+             edtx(i) = 0.
+           else
+             edtx(i) = -edtx(i) * xpwav(i) / xpwev(i)
+             edtx(i) = min(edtx(i),edtmax)
+           endif
+         endif
+       enddo
+    !
+    ! downdraft cloudwork functions
+    !
+       do k = kmax1,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.jmin(i)) then
+             gamma = el2orc * qeso(i,k) / to(i,k)**2
+             dhh=xhcd(i,k)
+             dt= to(i,k)
+             dg= gamma
+             dh= heso(i,k)
+             dz=-1.*(zl(i,k+1)-zl(i,k))
+             xaa0(i)=xaa0(i)+edtx(i)*dz*(g_/(cp_*dt))*((dhh-dh)/(1.+dg))           &
+                     *(1.+fv_*cp_*dg*dt/hvap_)
+             xaa0(i)=xaa0(i)+edtx(i)*                                              &
+                      dz*g_*fv_*max(0.,(qeso(i,k)-qo(i,k)))
+           endif
+         enddo
+       enddo
+    !
+    ! calculate critical cloud work function
+    !
+       do i = its,ite
+         acrt(i) = 0.
+         if(cnvflg(i)) then
+           if(p(i,ktcon(i)).lt.pcrit(15))then
+             acrt(i)=acrit(15)*(975.-p(i,ktcon(i)))/(975.-pcrit(15))
+           else if(p(i,ktcon(i)).gt.pcrit(1))then
+             acrt(i)=acrit(1)
+           else
+             k = int((850. - p(i,ktcon(i)))/50.) + 2
+             k = min(k,15)
+             k = max(k,2)
+             acrt(i)=acrit(k)+(acrit(k-1)-acrit(k))*                               &
+                  (p(i,ktcon(i))-pcrit(k))/(pcrit(k-1)-pcrit(k))
+            endif
+          endif
+        enddo
+    !
+       do i = its,ite
+         acrtfct(i) = 1.
+         w1 = w1s
+         w2 = w2s
+         w3 = w3s
+         w4 = w4s
+         if(slimsk(i).eq.1.) then
+           w1 = w1l
+           w2 = w2l
+           w3 = w3l
+           w4 = w4l
+         endif
+         if(cnvflg(i)) then
+           if(pdot(i).le.w4) then
+             acrtfct(i) = (pdot(i) - w4) / (w3 - w4)
+           elseif(pdot(i).ge.-w4) then
+           acrtfct(i) = - (pdot(i) + w4) / (w4 - w3)
+           else
+             acrtfct(i) = 0.
+           endif
+           acrtfct(i) = max(acrtfct(i),-1.)
+           acrtfct(i) = min(acrtfct(i),1.)
+           acrtfct(i) = 1. - acrtfct(i)
+           dtconv(i) = dt2 + max((1800. - dt2),0.) * (pdot(i) - w2) / (w1 - w2)   
+           dtconv(i) = max(dtconv(i),dtmin)
+           dtconv(i) = min(dtconv(i),dtmax)
+    !
+         endif
+       enddo
+    !
+    ! large scale forcing
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           f(i) = (aa1(i) - acrt(i) * acrtfct(i)) / dtconv(i)
+           if(f(i).le.0.) cnvflg(i) = .false.
+         endif
+         if(cnvflg(i)) then
+           xk(i) = (xaa0(i) - aa1(i)) / mbdt
+           if(xk(i).ge.0.) cnvflg(i) = .false.
+         endif
+    !
+    ! kernel, cloud base mass flux
+    !
+         if(cnvflg(i)) then
+           xmb(i) = -f(i) / xk(i)
+           xmb(i) = min(xmb(i),xmbmax(i))
+         endif
+    !
+         if(cnvflg(i)) then
+         endif
+    !
+       enddo
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    ! restore t0 and qo to t1 and q1 in case convection stops
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if (cnvflg(i)) then
+           to(i,k) = t1(i,k)
+           qo(i,k) = q1(i,k)
+           uo(i,k) = u1(i,k)
+           vo(i,k) = v1(i,k)
+           qeso(i,k) = 0.01*fpvs(t1(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+           qeso(i,k) = eps * qeso(i,k) / (p(i,k) + (eps-1.) * qeso(i,k))
+           qeso(i,k) = max(qeso(i,k),qmin_)
+           endif
+         enddo
+       enddo
+    !
+    ! feedback: simply the changes from the cloud with unit mass flux
+    !           multiplied by  the mass flux necessary to keep the
+    !           equilibrium with the larger-scale.
+    !
+       do i = its,ite
+         delhbar(i) = 0.
+         delqbar(i) = 0.
+         deltbar(i) = 0.
+         qcond(i) = 0.
+         qrski(i) = 0.
+         delubar(i) = 0.
+         delvbar(i) = 0.
+       enddo
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i).and.k.le.ktcon(i)) then
+             aup = 1.
+             if(k.le.kb(i)) aup = 0.
+             adw = 1.
+             if(k.gt.jmin(i)) adw = 0.
+             dellat = (dellah(i,k) - hvap_ * dellaq(i,k)) / cp_
+             t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
+             q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
+             tem=1./rcs
+             u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
+             v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem 
+             dp = 1000. * del(i,k)
+             delhbar(i) = delhbar(i) + dellah(i,k)*xmb(i)*dp/g_
+             delqbar(i) = delqbar(i) + dellaq(i,k)*xmb(i)*dp/g_
+             deltbar(i) = deltbar(i) + dellat*xmb(i)*dp/g_
+             delubar(i) = delubar(i) + dellau(i,k)*xmb(i)*dp/g_
+             delvbar(i) = delvbar(i) + dellav(i,k)*xmb(i)*dp/g_
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+         endif
+       enddo
+    !
+       do k = kts,kmax 
+         do i = its,ite 
+           if (cnvflg(i) .and. k.le.ktcon(i)) then
+             qeso(i,k)=0.01* fpvs(t1(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k)/(p(i,k) + (eps-1.)*qeso(i,k))
+             qeso(i,k) = max(qeso(i,k), qmin_ )
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite 
+         rntot(i) = 0.
+         delqev(i) = 0.
+         delq2(i) = 0.
+         flg(i) = cnvflg(i) 
+       enddo
+    !
+    !  comptute rainfall  
+    !
+       do k = kmax,kts,-1
+         do i = its,ite
+           if(cnvflg(i).and.k.lt.ktcon(i)) then
+             aup = 1.
+             if(k.le.kb(i)) aup = 0.
+             adw = 1.
+             if(k.ge.jmin(i)) adw = 0.
+             rntot(i) = rntot(i)                                                   &
+                   + (aup * pwo(i,k) + adw * edto(i) * pwdo(i,k))                  &
+                   * xmb(i) * .001 * dt2
+           endif
+         enddo
+       enddo
+    !
+    !  conversion rainfall (m) and compute the evaporation of falling raindrops 
+    !
+       do k = kmax,kts,-1
+         do i = its,ite
+           delq(i) = 0.0
+           deltv(i) = 0.0
+           qevap(i) = 0.0
+           if(cnvflg(i).and.k.lt.ktcon(i)) then
+             aup = 1.
+             if(k.le.kb(i)) aup = 0.
+             adw = 1.
+             if(k.ge.jmin(i)) adw = 0.
+             rain(i) = rain(i)                                                     &
+                   + (aup * pwo(i,k) + adw * edto(i) * pwdo(i,k))                  &
+                   * xmb(i) * .001 * dt2
+           endif
+           if(cnvflg(i).and.flg(i).and.k.lt.ktcon(i)) then
+    !
+             evef = edt(i) * evfacts
+             if(slimsk(i).eq.1.) evef = edt(i) * evfactl
+             qcond(i) = evef * (q1(i,k) - qeso(i,k)) / (1. + el2orc *              &
+                      qeso(i,k) / t1(i,k)**2)
+             dp = 1000. * del(i,k)
+             if(rain(i).gt.0..and.qcond(i).lt.0.) then
+               qevap(i) = -qcond(i) * (1. - exp(-.32 * sqrt(dt2 * rain(i))))
+               qevap(i) = min(qevap(i), rain(i)*1000.*g_/dp)
+               delq2(i) = delqev(i) + .001 * qevap(i) * dp / g_
+               if (delq2(i).gt.rntot(i)) then
+                 qevap(i) = 1000.* g_ * (rntot(i) - delqev(i)) / dp
+                 flg(i) = .false.
+               endif 
+             endif
+             if(rain(i).gt.0..and.qevap(i).gt.0.) then
+               q1(i,k) = q1(i,k) + qevap(i)
+               t1(i,k) = t1(i,k) - (hvap_/cp_) * qevap(i)
+               rain(i) = rain(i) - .001 * qevap(i) * dp / g_
+               delqev(i) = delqev(i) + .001*dp*qevap(i)/g_
+               deltv(i) =  - (hvap_/cp_)*qevap(i)/dt2
+               delq(i) =  + qevap(i)/dt2
+             endif
+             dellaq(i,k) = dellaq(i,k) + delq(i)/xmb(i)
+             delqbar(i)  = delqbar(i) + delq(i)*dp/g_
+             deltbar(i)  = deltbar(i) + deltv(i)*dp/g_
+           endif
+         enddo
+       enddo
+    !
+    !
+    ! consider the negative rain in the event of rain evaporation and downdrafts
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           if(rain(i).lt.0..and..not.flg(i)) rain(i) = 0.
+           if(rain(i).le.0.) then
+             rain(i) = 0.
+           else
+             ktop(i) = ktcon(i)
+             kbot(i) = kbcon(i)
+             icps(i) = 1
+           endif
+         endif
+       enddo
+    !
+       do k = kts,kmax
+         do i = its,ite
+           if(cnvflg(i).and.rain(i).le.0.) then
+              t1(i,k) = to(i,k)
+              q1(i,k) = qo(i,k)
+              u1(i,k) = uo(i,k)
+              v1(i,k) = vo(i,k)
+           endif
+         enddo
+       enddo
+    !
+    !  detrainment of cloud water and ice
+    !
+       if (ncloud.gt.0) then
+         do k = kts,kmax 
+           do i = its,ite 
+             if (cnvflg(i) .and. rain(i).gt.0.) then
+               if (k.ge.kbcon(i).and.k.le.ktcon(i)) then
+                 tem  = dellal(i,k) * xmb(i) * dt2
+                 tem1 = max(0.0, min(1.0, (tcr-t1(i,k))*tcrf))
+                 if (ncloud.ge.2) then
+                   qi2(i,k) = qi2(i,k) + tem * tem1            ! ice
+                   qc2(i,k) = qc2(i,k) + tem *(1.0-tem1)       ! water
+                 else
+                   qc2(i,k) = qc2(i,k) + tem
+                 endif
+               endif
+             endif
+           enddo
+         enddo
+       endif
+    !
+       end subroutine nsas2d
+    !-------------------------------------------------------------------------------
+       REAL FUNCTION fpvs(t,ice,rd,rv,cvap,cliq,cice,hvap,hsub,psat,t0c)
+    !-------------------------------------------------------------------------------
+       IMPLICIT NONE
+    !-------------------------------------------------------------------------------
+       REAL :: t,rd,rv,cvap,cliq,cice,hvap,hsub,psat,t0c,dldt,xa,xb,dldti,         &
+               xai,xbi,ttp,tr
+       INTEGER :: ice
+    !
+       ttp=t0c+0.01
+       dldt=cvap-cliq
+       xa=-dldt/rv
+       xb=xa+hvap/(rv*ttp)
+       dldti=cvap-cice
+       xai=-dldti/rv
+       xbi=xai+hsub/(rv*ttp)
+       tr=ttp/t
+       if(t.lt.ttp.and.ice.eq.1) then
+         fpvs=psat*(tr**xai)*exp(xbi*(1.-tr))
+       else
+         fpvs=psat*(tr**xa)*exp(xb*(1.-tr))
+       endif
+    !
+       if (t.lt.180.) then
+         tr=ttp/180.
+         if(t.lt.ttp.and.ice.eq.1) then
+           fpvs=psat*(tr**xai)*exp(xbi*(1.-tr))
+         else
+           fpvs=psat*(tr**xa)*exp(xb*(1.-tr))
+         endif
+       endif
+    !
+       if (t.ge.330.) then
+         tr=ttp/330
+         if(t.lt.ttp.and.ice.eq.1) then
+           fpvs=psat*(tr**xai)*exp(xbi*(1.-tr))
+         else
+           fpvs=psat*(tr**xa)*exp(xb*(1.-tr))
+         endif
+       endif
+    !
+       END FUNCTION fpvs
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+       subroutine nsasinit(rthcuten,rqvcuten,rqccuten,rqicuten,                    &
+                          rucuten,rvcuten,                                         &  
+                          restart,p_qc,p_qi,p_first_scalar,                        &
+                          allowed_to_read,                                         &
+                          ids, ide, jds, jde, kds, kde,                            &
+                          ims, ime, jms, jme, kms, kme,                            &
+                          its, ite, jts, jte, kts, kte                  )
+    !-------------------------------------------------------------------------------
+       implicit none
+    !-------------------------------------------------------------------------------
+       logical , intent(in)           ::  allowed_to_read,restart
+       integer , intent(in)           ::  ids, ide, jds, jde, kds, kde,            &
+                                          ims, ime, jms, jme, kms, kme,            &
+                                          its, ite, jts, jte, kts, kte
+       integer , intent(in)           ::  p_first_scalar, p_qi, p_qc
+       real,     dimension( ims:ime , kms:kme , jms:jme ) , intent(out) ::         &
+                                                                  rthcuten,        &
+                                                                  rqvcuten,        &
+                                                                   rucuten,        &
+                                                                   rvcuten,        &
+                                                                  rqccuten,        &
+                                                                  rqicuten
+       integer :: i, j, k, itf, jtf, ktf
+    !
+       jtf=min0(jte,jde-1)
+       ktf=min0(kte,kde-1)  ! so no need for -1 in nsasinit call?
+       itf=min0(ite,ide-1)
+    !
+       if(.not.restart)then
+         do j = jts,jtf
+           do k = kts,ktf
+             do i = its,itf
+               rthcuten(i,k,j)=0.
+               rqvcuten(i,k,j)=0.
+               rucuten(i,k,j)=0.   
+               rvcuten(i,k,j)=0.   
+             enddo
+           enddo
+         enddo
+    !
+         if (p_qc .ge. p_first_scalar) then
+           do j = jts,jtf
+             do k = kts,ktf
+               do i = its,itf
+                 rqccuten(i,k,j)=0.
+               enddo
+             enddo
+           enddo
+         endif
+    !
+         if (p_qi .ge. p_first_scalar) then
+           do j = jts,jtf
+             do k = kts,ktf
+               do i = its,itf
+                 rqicuten(i,k,j)=0.
+               enddo
+             enddo
+           enddo
+         endif
+       endif
+    !
+       end subroutine nsasinit
+    !
+    !-------------------------------------------------------------------------------
+    ! NCEP SCV (Shallow Convection Scheme)
+    !-------------------------------------------------------------------------------
+       subroutine nscv2d(delt,del,prsl,prsi,prslk,zl,                              &
+                     ncloud,qc2,qi2,q1,t1,rain,kbot,ktop,                          &
+                     icps,                                                         &
+                     slimsk,dot,u1,v1,                                             &
+                     cp_,cliq_,cvap_,g_,hvap_,rd_,rv_,fv_,ep2,                     &
+                     cice,xls,psat,                                                &
+                     hpbl,hfx,qfx,                                                 &
+                     pgcon,                                                        &
+                     ids,ide, jds,jde, kds,kde,                                    &
+                     ims,ime, jms,jme, kms,kme,                                    &
+                     its,ite, jts,jte, kts,kte)
+    !-------------------------------------------------------------------------------
+    ! subprogram:    nscv2d           computes shallow-convective heating and moisng
+    !
+    ! abstract: computes non-precipitating convective heating and moistening 
+    !   using a one cloud type arakawa-schubert convection scheme as in the ncep
+    !   sas scheme. the scheme has been operational at ncep gfs model since july 2010
+    !   the scheme includes updraft and downdraft effects, but the cloud depth is 
+    !   limited less than 150 hpa. 
+    !
+    ! developed by jong-il han and hua-lu pan 
+    !   implemented into wrf by jiheon jang and songyou hong
+    !   module with cpp-based options is available in grims
+    !
+    ! program history log:
+    !   10-07-01 jong-il han  initial operational implementation at ncep gfs
+    !   10-12-01 jihyeon jang implemented into wrf
+    !
+    ! subprograms called:
+    !   fpvs     - function to compute saturation vapor pressure
+    !
+    ! references:
+    !   han and pan (2010, wea. forecasting)
+    !   
+    !-------------------------------------------------------------------------------
+       implicit none
+    !-------------------------------------------------------------------------------
+    !
+    !  in/out variables
+    !
+       integer         ::  ids,ide, jds,jde, kds,kde,                              &
+                           ims,ime, jms,jme, kms,kme,                              &
+                           its,ite, jts,jte, kts,kte
+       real            ::  cp_,cliq_,cvap_,g_,hvap_,rd_,rv_,fv_,ep2
+       real            ::  pi_,qmin_,t0c_
+       real            ::  cice,xlv0,xls,psat
+    !
+       real            ::  delt
+       real            ::  del(its:ite,kts:kte),                                   &
+                           prsl(its:ite,kts:kte),prslk(ims:ime,kms:kme),           &
+                           prsi(its:ite,kts:kte+1),zl(its:ite,kts:kte)
+       integer         ::  ncloud
+       real            ::  slimsk(ims:ime)
+       real            ::  dot(its:ite,kts:kte)
+       real            ::  hpbl(ims:ime)
+       real            ::  rcs
+       real            ::  hfx(ims:ime),qfx(ims:ime)
+    !
+       real            ::  qi2(its:ite,kts:kte),qc2(its:ite,kts:kte)
+       real            ::  q1(its:ite,kts:kte),                                    &
+                           t1(its:ite,kts:kte),                                    &
+                           u1(its:ite,kts:kte),                                    &
+                           v1(its:ite,kts:kte)
+       integer         ::  icps(its:ite)
+    !
+       real            ::  rain(its:ite)
+       integer         ::  kbot(its:ite),ktop(its:ite)
+    !
+    !  local variables and arrays
+    !
+       integer         ::  i,j,indx, jmn, k, kk, km1
+       integer         ::  kpbl(its:ite)
+    !
+       real            ::  dellat,                                                 &
+                           desdt,   deta,    detad,   dg,                          &
+                           dh,      dhh,     dlnsig,  dp,                          &
+                           dq,      dqsdp,   dqsdt,   dt,                          &
+                           dt2,     dtmax,   dtmin,                                &
+                           dv1h,    dv2h,    dv3h,                                 &
+                           dv1q,    dv2q,    dv3q,                                 &
+                           dv1u,    dv2u,    dv3u,                                 &
+                           dv1v,    dv2v,    dv3v,                                 &
+                           dz,      dz1,     e1,      clam,                        &
+                           aafac,                                                  &
+                           es,      etah,                                          &
+                           evef,    evfact,  evfactl,                              &
+                           factor,  fjcap,                                         &
+                           gamma,   pprime,  betaw,                                &
+                           qlk,     qrch,    qs,                                   &
+                           rfact,   shear,   tem1,                                 &
+                           tem2,    val,     val1,                                 &
+                           val2,    w1,      w1l,     w1s,                         &
+                           w2,      w2l,     w2s,     w3,                          &
+                           w3l,     w3s,     w4,      w4l,                         &
+                           w4s,     tem,     ptem,    ptem1,                       &
+                           pgcon
+    !
+       integer         ::  kb(its:ite), kbcon(its:ite), kbcon1(its:ite),           &
+                           ktcon(its:ite), ktcon1(its:ite),                        &
+                           kbm(its:ite), kmax(its:ite)
+    !
+       real            ::  aa1(its:ite),                                           &
+                           delhbar(its:ite), delq(its:ite),                        &
+                           delq2(its:ite),   delqev(its:ite), rntot(its:ite),      &
+                           delqbar(its:ite), deltbar(its:ite),                     &
+                           deltv(its:ite),   edt(its:ite),                         &
+                           wstar(its:ite),   sflx(its:ite),                        &
+                           pdot(its:ite),    po(its:ite,kts:kte),                  &
+                           qcond(its:ite),   qevap(its:ite),  hmax(its:ite),       &
+                           vshear(its:ite),                                        &
+                           xlamud(its:ite),  xmb(its:ite),    xmbmax(its:ite)
+       real            ::  delubar(its:ite), delvbar(its:ite)
+    !
+       real            ::  cincr
+    !
+       real            ::  thx(its:ite, kts:kte)
+       real            ::  rhox(its:ite)
+       real            ::  tvcon
+    !
+       real            ::  p(its:ite,kts:kte),       to(its:ite,kts:kte),          &
+                           qo(its:ite,kts:kte),      qeso(its:ite,kts:kte),        &
+                           uo(its:ite,kts:kte),      vo(its:ite,kts:kte)
+    !
+    !  cloud water
+    !
+       real            ::  qlko_ktcon(its:ite),     dellal(its:ite,kts:kte),       &
+                           dbyo(its:ite,kts:kte),                                  &
+                           xlamue(its:ite,kts:kte),                                &
+                           heo(its:ite,kts:kte),    heso(its:ite,kts:kte),         &
+                           dellah(its:ite,kts:kte), dellaq(its:ite,kts:kte),       &
+                           dellau(its:ite,kts:kte), dellav(its:ite,kts:kte),       &
+                           ucko(its:ite,kts:kte),   vcko(its:ite,kts:kte),         &
+                           hcko(its:ite,kts:kte),   qcko(its:ite,kts:kte),         &
+                           eta(its:ite,kts:kte),    zi(its:ite,kts:kte+1),         &
+                           pwo(its:ite,kts:kte)
+    !
+       logical         ::  totflg, cnvflg(its:ite), flg(its:ite)
+    !
+    !  physical parameters
+    !
+       real,parameter  ::  c0=.002,c1=5.e-4
+       real,parameter  ::  cincrmax=180.,cincrmin=120.,dthk=25.
+       real            ::  el2orc,fact1,fact2,eps
+       real,parameter  ::  h1=0.33333333
+       real,parameter  ::  tf=233.16, tcr=263.16, tcrf=1.0/(tcr-tf)
+    !-------------------------------------------------------------------------------
+       pi_ = 3.14159
+       qmin_ = 1.0e-30
+       t0c_ = 273.15
+       xlv0 = hvap_
+       km1 = kte - 1
+    !
+    !  compute surface buoyancy flux
+    !
+       do k = kts,kte
+         do i = its,ite
+           thx(i,k) = t1(i,k)/prslk(i,k)
+         enddo
+       enddo
+    !
+       do i = its,ite
+         tvcon = (1.+fv_*q1(i,1))
+         rhox(i) = prsl(i,1)*1.e3/(rd_*t1(i,1)*tvcon)
+       enddo
+    !
+       do i = its,ite
+    !    sflx(i) = heat(i)+fv_*t1(i,1)*evap(i)
+         sflx(i) = hfx(i)/rhox(i)/cp_ + qfx(i)/rhox(i)*fv_*thx(i,1)
+       enddo
+    !
+    !  initialize arrays
+    !
+       do i = its,ite
+         cnvflg(i) = .true.
+         if(icps(i).eq.1) cnvflg(i) = .false.
+         if(sflx(i).le.0.) cnvflg(i) = .false.
+         if(cnvflg(i)) then
+           kbot(i)=kte+1
+           ktop(i)=0
+         endif
+         rain(i)=0.
+         kbcon(i)=kte
+         ktcon(i)=1
+         kb(i)=kte
+         pdot(i) = 0.
+         qlko_ktcon(i) = 0.
+         edt(i)  = 0.
+         aa1(i)  = 0.
+         vshear(i) = 0.
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+       dt2   =  delt
+       val   =         1200.
+       dtmin = max(dt2, val )
+       val   =         3600.
+       dtmax = max(dt2, val )
+    !
+    !  model tunable parameters are all here
+    !
+       clam    = .3
+       aafac   = .1
+       betaw   = .03
+       evfact  = 0.3
+       evfactl = 0.3
+       val     = 1.
+    !
+    ! define miscellaneous values
+    !
+       el2orc = hvap_*hvap_/(rv_*cp_)
+       eps    = rd_/rv_ 
+       fact1  = (cvap_-cliq_)/rv_
+       fact2  = hvap_/rv_-fact1*t0c_
+    !
+       w1l     = -8.e-3
+       w2l     = -4.e-2
+       w3l     = -5.e-3
+       w4l     = -5.e-4
+       w1s     = -2.e-4
+       w2s     = -2.e-3
+       w3s     = -1.e-3
+       w4s     = -2.e-5
+    !
+    !  define top layer for search of the downdraft originating layer
+    !  and the maximum thetae for updraft
+    !
+       do i = its,ite
+         kbm(i)   = kte
+         kmax(i)  = kte
+       enddo
+    !     
+       do k = kts,kte
+         do i = its,ite
+           if (prsl(i,k).gt.prsi(i,1)*0.70) kbm(i) = k + 1
+           if (prsl(i,k).gt.prsi(i,1)*0.60) kmax(i) = k + 1
+         enddo
+       enddo
+    !
+       do i = its,ite
+         kbm(i)   = min(kbm(i),kmax(i))
+       enddo
+    !
+    !  hydrostatic height assume zero terr and compute
+    !  updraft entrainment rate as an inverse function of height
+    !
+       do k = kts+1,kte
+         do i = its,ite
+           zi(i,k) = 0.5*(zl(i,k-1)+zl(i,k))
+         enddo
+       enddo
+    !
+       do k = kts,km1
+         do i = its,ite
+           xlamue(i,k) = clam / zi(i,k+1)
+         enddo
+       enddo
+    !
+       do i = its,ite
+         xlamue(i,kte) = xlamue(i,km1)
+       enddo
+    !
+    !  pbl height
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         kpbl(i)= 1
+       enddo
+    !
+       do k = kts+1,km1
+         do i = its,ite
+           if (flg(i).and.zl(i,k).le.hpbl(i)) then 
+             kpbl(i) = k
+           else
+             flg(i) = .false.
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         kpbl(i)= min(kpbl(i),kbm(i))
+       enddo
+    !
+    !   convert surface pressure to mb from cb
+    !
+       rcs = 1.
+       do k = kts,kte
+         do i = its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)) then
+             p(i,k) = prsl(i,k) * 10.0
+             eta(i,k)  = 1.
+             hcko(i,k) = 0.
+             qcko(i,k) = 0.
+             ucko(i,k) = 0.
+             vcko(i,k) = 0.
+             dbyo(i,k) = 0.
+             pwo(i,k)  = 0.
+             dellal(i,k) = 0.
+             to(i,k)   = t1(i,k)
+             qo(i,k)   = q1(i,k)
+             uo(i,k)   = u1(i,k) * rcs
+             vo(i,k)   = v1(i,k) * rcs
+           endif
+         enddo
+       enddo
+    !
+    !
+    !  column variables
+    !  p is pressure of the layer (mb)
+    !  t is temperature at t-dt (k)..tn
+    !  q is mixing ratio at t-dt (kg/kg)..qn
+    !  to is temperature at t+dt (k)... this is after advection and turbulan
+    !  qo is mixing ratio at t+dt (kg/kg)..q1
+    !
+       do k = kts, kte
+         do i=its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)) then
+             qeso(i,k) = 0.01 * fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (p(i,k) + (eps-1.)*qeso(i,k))
+             val1      =             1.e-8
+             qeso(i,k) = max(qeso(i,k), val1)
+             val2      =           1.e-10
+             qo(i,k)   = max(qo(i,k), val2 )
+           endif
+         enddo
+       enddo
+    !
+    !  compute moist static energy
+    !
+       do k = kts,kte
+         do i=its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)) then
+             tem       = g_ * zl(i,k) + cp_ * to(i,k)
+             heo(i,k)  = tem  + hvap_ * qo(i,k)
+             heso(i,k) = tem  + hvap_ * qeso(i,k)
+           endif
+         enddo
+       enddo
+    !
+    !  determine level with largest moist static energy within pbl
+    !  this is the level where updraft starts
+    !
+       do i=its,ite
+         if (cnvflg(i)) then
+           hmax(i) = heo(i,1)
+           kb(i) = 1
+         endif
+       enddo
+    !
+       do k = kts+1, kte
+         do i=its,ite
+           if (cnvflg(i).and.k.le.kpbl(i)) then
+             if(heo(i,k).gt.hmax(i)) then
+               kb(i)   = k
+               hmax(i) = heo(i,k)
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do k = kts, km1
+         do i=its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)-1) then
+             dz      = .5 * (zl(i,k+1) - zl(i,k))
+             dp      = .5 * (p(i,k+1) - p(i,k))
+             es = 0.01*fpvs(to(i,k+1),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             pprime  = p(i,k+1) + (eps-1.) * es
+             qs      = eps * es / pprime
+             dqsdp   = - qs / pprime
+             desdt   = es * (fact1 / to(i,k+1) + fact2 / (to(i,k+1)**2))
+             dqsdt   = qs * p(i,k+1) * desdt / (es * pprime)
+             gamma   = el2orc * qeso(i,k+1) / (to(i,k+1)**2)
+             dt      = (g_ * dz + hvap_ * dqsdp * dp) / (cp_ * (1. + gamma))
+             dq      = dqsdt * dt + dqsdp * dp
+             to(i,k) = to(i,k+1) + dt
+             qo(i,k) = qo(i,k+1) + dq
+             po(i,k) = .5 * (p(i,k) + p(i,k+1))
+           endif
+         enddo
+       enddo
+    !
+       do k = kts, km1
+         do i=its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)-1) then
+             qeso(i,k)=0.01*fpvs(to(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (po(i,k) + (eps-1.) * qeso(i,k))
+             val1      =             1.e-8
+             qeso(i,k) = max(qeso(i,k), val1)
+             val2      =           1.e-10
+             qo(i,k)   = max(qo(i,k), val2 )
+             heo(i,k)  = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                         &
+                            cp_ * to(i,k) + hvap_ * qo(i,k)
+             heso(i,k) = .5 * g_ * (zl(i,k) + zl(i,k+1)) +                         &
+                            cp_ * to(i,k) + hvap_ * qeso(i,k)
+             uo(i,k)   = .5 * (uo(i,k) + uo(i,k+1))
+             vo(i,k)   = .5 * (vo(i,k) + vo(i,k+1))
+           endif
+         enddo
+       enddo
+    !
+    !  look for the level of free convection as cloud base
+    !
+       do i=its,ite
+         flg(i)   = cnvflg(i)
+         if(flg(i)) kbcon(i) = kmax(i)
+       enddo
+    !
+       do k = kts+1, km1
+         do i=its,ite
+           if (flg(i).and.k.lt.kbm(i)) then
+             if(k.gt.kb(i).and.heo(i,kb(i)).gt.heso(i,k)) then
+               kbcon(i) = k
+               flg(i)   = .false.
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i=its,ite
+         if(cnvflg(i)) then
+           if(kbcon(i).eq.kmax(i)) cnvflg(i) = .false.
+         endif
+       enddo
+    !
+       totflg = .true.
+       do i=its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !  determine critical convective inhibition
+    !  as a function of vertical velocity at cloud base.
+    !
+       do i=its,ite
+         if(cnvflg(i)) then
+           pdot(i)  = 10.* dot(i,kbcon(i))
+         endif
+       enddo
+    !
+       do i=its,ite
+         if(cnvflg(i)) then
+           if(slimsk(i).eq.1.) then
+             w1 = w1l
+             w2 = w2l
+             w3 = w3l
+             w4 = w4l
+           else
+             w1 = w1s
+             w2 = w2s
+             w3 = w3s
+             w4 = w4s
+           endif
+           if(pdot(i).le.w4) then
+             ptem = (pdot(i) - w4) / (w3 - w4)
+           elseif(pdot(i).ge.-w4) then
+             ptem = - (pdot(i) + w4) / (w4 - w3)
+           else
+             ptem = 0.
+           endif
+           val1    =             -1.
+           ptem = max(ptem,val1)
+           val2    =             1.
+           ptem = min(ptem,val2)
+           ptem = 1. - ptem
+           ptem1= .5*(cincrmax-cincrmin)
+           cincr = cincrmax - ptem * ptem1
+           tem1 = p(i,kb(i)) - p(i,kbcon(i))
+           if(tem1.gt.cincr) then
+             cnvflg(i) = .false.
+           endif
+         endif
+       enddo
+    !
+       totflg = .true.
+       do i=its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !  assume the detrainment rate for the updrafts to be same as 
+    !  the entrainment rate at cloud base
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           xlamud(i) = xlamue(i,kbcon(i))
+         endif
+       enddo
+    !
+    !  determine updraft mass flux for the subcloud layers
+    !
+       do k = km1, kts, -1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.lt.kbcon(i).and.k.ge.kb(i)) then
+               dz       = zi(i,k+2) - zi(i,k+1)
+               ptem     = 0.5*(xlamue(i,k)+xlamue(i,k+1))-xlamud(i)
+               eta(i,k) = eta(i,k+1) / (1. + ptem * dz)
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  compute mass flux above cloud base
+    !
+       do k = kts+1, km1
+         do i = its,ite
+           if(cnvflg(i))then
+             if(k.gt.kbcon(i).and.k.lt.kmax(i)) then
+               dz       = zi(i,k+1) - zi(i,k)
+               ptem     = 0.5*(xlamue(i,k)+xlamue(i,k-1))-xlamud(i)
+               eta(i,k) = eta(i,k-1) * (1 + ptem * dz)
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  compute updraft cloud property
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           indx         = kb(i)
+           hcko(i,indx) = heo(i,indx)
+           ucko(i,indx) = uo(i,indx)
+           vcko(i,indx) = vo(i,indx)
+         endif
+       enddo
+    !
+       do k = kts+1, km1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.lt.kmax(i)) then
+               dz   = zi(i,k+1) - zi(i,k)
+               tem  = 0.5 * (xlamue(i,k)+xlamue(i,k-1)) * dz
+               tem1 = 0.5 * xlamud(i) * dz
+               factor = 1. + tem - tem1
+               ptem = 0.5 * tem + pgcon
+               ptem1= 0.5 * tem - pgcon
+               hcko(i,k) = ((1.-tem1)*hcko(i,k-1)+tem*0.5*                         &
+                           (heo(i,k)+heo(i,k-1)))/factor
+               ucko(i,k) = ((1.-tem1)*ucko(i,k-1)+ptem*uo(i,k)                     &
+                           +ptem1*uo(i,k-1))/factor
+               vcko(i,k) = ((1.-tem1)*vcko(i,k-1)+ptem*vo(i,k)                     &
+                           +ptem1*vo(i,k-1))/factor
+               dbyo(i,k) = hcko(i,k) - heso(i,k)
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !   taking account into convection inhibition due to existence of
+    !    dry layers below cloud base
+    !
+       do i=its,ite
+         flg(i) = cnvflg(i)
+         kbcon1(i) = kmax(i)
+       enddo
+    !
+       do k = kts+1, km1
+         do i=its,ite
+           if (flg(i).and.k.lt.kbm(i)) then
+             if(k.ge.kbcon(i).and.dbyo(i,k).gt.0.) then
+               kbcon1(i) = k
+               flg(i)    = .false.
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i=its,ite
+         if(cnvflg(i)) then
+           if(kbcon1(i).eq.kmax(i)) cnvflg(i) = .false.
+         endif
+       enddo
+    !
+       do i=its,ite
+         if(cnvflg(i)) then
+           tem = p(i,kbcon(i)) - p(i,kbcon1(i))
+           if(tem.gt.dthk) then
+             cnvflg(i) = .false.
+           endif
+         endif
+       enddo
+    !
+       totflg = .true.
+       do i = its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !  determine first guess cloud top as the level of zero buoyancy
+    !    limited to the level of sigma=0.7
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         if(flg(i)) ktcon(i) = kbm(i)
+       enddo
+    !
+       do k = kts+1, km1
+         do i=its,ite
+           if (flg(i).and.k .lt. kbm(i)) then
+             if(k.gt.kbcon1(i).and.dbyo(i,k).lt.0.) then
+               ktcon(i) = k
+               flg(i)   = .false.
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  specify upper limit of mass flux at cloud base
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           k = kbcon(i)
+           dp = 1000. * del(i,k)
+           xmbmax(i) = dp / (g_ * dt2)
+         endif
+       enddo
+    !
+    !  compute cloud moisture property and precipitation
+    !
+       do i = its,ite
+         if (cnvflg(i)) then
+           aa1(i) = 0.
+           qcko(i,kb(i)) = qo(i,kb(i))
+         endif
+       enddo
+    !
+       do k = kts+1, km1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.lt.ktcon(i)) then
+               dz    = zi(i,k+1) - zi(i,k)
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               qrch = qeso(i,k) + gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+               tem  = 0.5 * (xlamue(i,k)+xlamue(i,k-1)) * dz
+               tem1 = 0.5 * xlamud(i) * dz
+               factor = 1. + tem - tem1
+               qcko(i,k) = ((1.-tem1)*qcko(i,k-1)+tem*0.5*                         &
+                           (qo(i,k)+qo(i,k-1)))/factor
+               dq = eta(i,k) * (qcko(i,k) - qrch)
+    !
+    !          rhbar(i) = rhbar(i) + qo(i,k) / qeso(i,k)
+    !
+    !  below lfc check if there is excess moisture to release latent heat
+    !
+               if(k.ge.kbcon(i).and.dq.gt.0.) then
+                 etah = .5 * (eta(i,k) + eta(i,k-1))
+                 if(ncloud.gt.0) then
+                   dp = 1000. * del(i,k)
+                   qlk = dq / (eta(i,k) + etah * (c0 + c1) * dz)
+                   dellal(i,k) = etah * c1 * dz * qlk * g_ / dp
+                 else
+                   qlk = dq / (eta(i,k) + etah * c0 * dz)
+                 endif
+                 aa1(i) = aa1(i) - dz * g_ * qlk
+                 qcko(i,k)= qlk + qrch
+                 pwo(i,k) = etah * c0 * dz * qlk
+               endif
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  calculate cloud work function
+    !
+       do k = kts+1, km1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.ge.kbcon(i).and.k.lt.ktcon(i)) then
+               dz1 = zl(i,k+1) - zl(i,k)        
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               rfact =  1. + fv_ * cp_ * gamma * to(i,k) / hvap_
+               aa1(i) = aa1(i) + dz1 * (g_ / (cp_ * to(i,k)))                      &
+                      * dbyo(i,k) / (1. + gamma) * rfact
+               val = 0.
+               aa1(i)=aa1(i)+ dz1 * g_ * fv_ * max(val,(qeso(i,k) - qo(i,k)))
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i).and.aa1(i).le.0.) cnvflg(i) = .false.
+       enddo
+    !
+       totflg = .true.
+       do i=its,ite
+         totflg = totflg .and. (.not. cnvflg(i))
+       enddo
+       if(totflg) return
+    !
+    !  estimate the convective overshooting as the level
+    !    where the [aafac * cloud work function] becomes zero,
+    !    which is the final cloud top limited to the level of sigma=0.7
+    !
+       do i = its,ite
+         if (cnvflg(i)) then
+           aa1(i) = aafac * aa1(i)
+         endif
+       enddo
+    !
+       do i = its,ite
+         flg(i) = cnvflg(i)
+         ktcon1(i) = kbm(i)
+       enddo
+    !
+       do k = kts+1,km1
+         do i = its,ite
+           if (flg(i)) then
+             if(k.ge.ktcon(i).and.k.lt.kbm(i)) then
+               dz1 = zl(i,k+1) - zl(i,k)
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               rfact =  1. + fv_ * cp_ * gamma                                     &
+                       * to(i,k) / hvap_
+               aa1(i) = aa1(i) +                                                   &
+                       dz1 * (g_ / (cp_ * to(i,k)))                                &
+                       * dbyo(i,k) / (1. + gamma) * rfact
+               if(aa1(i).lt.0.) then
+                 ktcon1(i) = k
+                 flg(i) = .false.
+               endif
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !  compute cloud moisture property, detraining cloud water
+    !    and precipitation in overshooting layers
+    !
+       do k = kts+1,km1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.ge.ktcon(i).and.k.lt.ktcon1(i)) then
+               dz    = zi(i,k+1) - zi(i,k)
+               gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+               qrch = qeso(i,k)                                                    &
+                    + gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+               tem  = 0.5 * (xlamue(i,k)+xlamue(i,k-1)) * dz
+               tem1 = 0.5 * xlamud(i) * dz
+               factor = 1. + tem - tem1
+               qcko(i,k) = ((1.-tem1)*qcko(i,k-1)+tem*0.5*                         &
+                           (qo(i,k)+qo(i,k-1)))/factor
+               dq = eta(i,k) * (qcko(i,k) - qrch)
+    !
+    !  check if there is excess moisture to release latent heat
+    !
+               if(dq.gt.0.) then
+                 etah = .5 * (eta(i,k) + eta(i,k-1))
+                 if(ncloud.gt.0) then
+                   dp = 1000. * del(i,k)
+                   qlk = dq / (eta(i,k) + etah * (c0 + c1) * dz)
+                   dellal(i,k) = etah * c1 * dz * qlk * g_ / dp
+                 else
+                   qlk = dq / (eta(i,k) + etah * c0 * dz)
+                 endif
+                 qcko(i,k) = qlk + qrch
+                 pwo(i,k) = etah * c0 * dz * qlk
+               endif
+             endif
+           endif
+         enddo
+       enddo
+    !
+    ! exchange ktcon with ktcon1
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           kk = ktcon(i)
+           ktcon(i) = ktcon1(i)
+           ktcon1(i) = kk
+         endif
+       enddo
+    !
+    !  this section is ready for cloud water
+    !
+       if(ncloud.gt.0) then
+    !
+    !  compute liquid and vapor separation at cloud top
+    !
+         do i = its,ite
+           if(cnvflg(i)) then
+             k = ktcon(i) - 1
+             gamma = el2orc * qeso(i,k) / (to(i,k)**2)
+             qrch = qeso(i,k)                                                      &
+                  + gamma * dbyo(i,k) / (hvap_ * (1. + gamma))
+             dq = qcko(i,k) - qrch
+    !
+    !  check if there is excess moisture to release latent heat
+    !
+             if(dq.gt.0.) then
+               qlko_ktcon(i) = dq
+               qcko(i,k) = qrch
+             endif
+           endif
+         enddo
+    !
+       endif
+    !
+    !--- compute precipitation efficiency in terms of windshear
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           vshear(i) = 0.
+         endif
+       enddo
+    !
+       do k = kts+1,kte
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.le.ktcon(i)) then
+               shear= sqrt((uo(i,k)-uo(i,k-1)) ** 2 + (vo(i,k)-vo(i,k-1)) ** 2)
+               vshear(i) = vshear(i) + shear
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           vshear(i) = 1.e3 * vshear(i) / (zi(i,ktcon(i)+1)-zi(i,kb(i)+1))
+           e1=1.591-.639*vshear(i)                                                 &
+                 +.0953*(vshear(i)**2)-.00496*(vshear(i)**3)
+           edt(i)=1.-e1
+           val =         .9
+           edt(i) = min(edt(i),val)
+           val =         .0
+           edt(i) = max(edt(i),val)
+         endif
+       enddo
+    !
+    !--- what would the change be, that a cloud with unit mass
+    !--- will do to the environment?
+    !
+       do k = kts,kte
+         do i = its,ite
+           if(cnvflg(i) .and. k .le. kmax(i)) then
+             dellah(i,k) = 0.
+             dellaq(i,k) = 0.
+             dellau(i,k) = 0.
+             dellav(i,k) = 0.
+           endif
+         enddo
+       enddo
+    !
+    !--- changed due to subsidence and entrainment
+    !
+       do k = kts+1,km1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.lt.ktcon(i)) then
+               dp = 1000. * del(i,k)
+               dz = zi(i,k+1) - zi(i,k)
+    !
+               dv1h = heo(i,k)
+               dv2h = .5 * (heo(i,k) + heo(i,k-1))
+               dv3h = heo(i,k-1)
+               dv1q = qo(i,k)
+               dv2q = .5 * (qo(i,k) + qo(i,k-1))
+               dv3q = qo(i,k-1)
+               dv1u = uo(i,k)
+               dv2u = .5 * (uo(i,k) + uo(i,k-1))
+               dv3u = uo(i,k-1)
+               dv1v = vo(i,k)
+               dv2v = .5 * (vo(i,k) + vo(i,k-1))
+               dv3v = vo(i,k-1)
+    !
+               tem  = 0.5 * (xlamue(i,k)+xlamue(i,k-1))
+               tem1 = xlamud(i)
+    !
+               dellah(i,k) = dellah(i,k) +                                         &
+              ( eta(i,k)*dv1h - eta(i,k-1)*dv3h                                    &
+             -  tem*eta(i,k-1)*dv2h*dz                                             &
+             +  tem1*eta(i,k-1)*.5*(hcko(i,k)+hcko(i,k-1))*dz ) *g_/dp
+    !
+               dellaq(i,k) = dellaq(i,k) +                                         &
+              ( eta(i,k)*dv1q - eta(i,k-1)*dv3q                                    &
+             -  tem*eta(i,k-1)*dv2q*dz                                             &
+             +  tem1*eta(i,k-1)*.5*(qcko(i,k)+qcko(i,k-1))*dz ) *g_/dp
+    !
+               dellau(i,k) = dellau(i,k) +                                         &
+              ( eta(i,k)*dv1u - eta(i,k-1)*dv3u                                    &
+             -  tem*eta(i,k-1)*dv2u*dz                                             &
+             +  tem1*eta(i,k-1)*.5*(ucko(i,k)+ucko(i,k-1))*dz                      &
+             -  pgcon*eta(i,k-1)*(dv1u-dv3u) ) *g_/dp
+    !
+               dellav(i,k) = dellav(i,k) +                                         &
+              ( eta(i,k)*dv1v - eta(i,k-1)*dv3v                                    &
+             -  tem*eta(i,k-1)*dv2v*dz                                             &
+             +  tem1*eta(i,k-1)*.5*(vcko(i,k)+vcko(i,k-1))*dz                      &
+             -  pgcon*eta(i,k-1)*(dv1v-dv3v) ) *g_/dp
+    !
+             endif
+           endif
+         enddo
+       enddo
+    !
+    !------- cloud top
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           indx = ktcon(i)
+           dp = 1000. * del(i,indx)
+           dv1h = heo(i,indx-1)
+           dellah(i,indx) = eta(i,indx-1) *                                        &
+                           (hcko(i,indx-1) - dv1h) * g_ / dp
+           dv1q = qo(i,indx-1)
+           dellaq(i,indx) = eta(i,indx-1) *                                        &
+                           (qcko(i,indx-1) - dv1q) * g_ / dp
+           dv1u = uo(i,indx-1)
+           dellau(i,indx) = eta(i,indx-1) *                                        &
+                           (ucko(i,indx-1) - dv1u) * g_ / dp
+           dv1v = vo(i,indx-1)
+           dellav(i,indx) = eta(i,indx-1) *                                        &
+                           (vcko(i,indx-1) - dv1v) * g_ / dp
+    !
+    !  cloud water
+    !
+           dellal(i,indx) = eta(i,indx-1) *                                        &
+                           qlko_ktcon(i) * g_ / dp
+         endif
+       enddo
+    !
+    !  mass flux at cloud base for shallow convection
+    !  (Grant, 2001)
+    !
+       do i= its,ite
+         if(cnvflg(i)) then
+           k = kbcon(i)
+           ptem = g_*sflx(i)*hpbl(i)/t1(i,1)
+           wstar(i) = ptem**h1
+           tem = po(i,k)*100. / (rd_*t1(i,k))
+           xmb(i) = betaw*tem*wstar(i)
+           xmb(i) = min(xmb(i),xmbmax(i))
+         endif
+       enddo
+    !
+       do k = kts,kte
+         do i = its,ite
+           if (cnvflg(i) .and. k .le. kmax(i)) then
+             qeso(i,k)=0.01* fpvs(t1(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls,psat,t0c_)
+             qeso(i,k) = eps * qeso(i,k) / (p(i,k) + (eps-1.)*qeso(i,k))
+             val     =             1.e-8
+             qeso(i,k) = max(qeso(i,k), val )
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         delhbar(i) = 0.
+         delqbar(i) = 0.
+         deltbar(i) = 0.
+         delubar(i) = 0.
+         delvbar(i) = 0.
+         qcond(i) = 0.
+       enddo
+    !
+       do k = kts,kte
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.le.ktcon(i)) then
+               dellat = (dellah(i,k) - hvap_ * dellaq(i,k)) / cp_
+               t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
+               q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
+               tem = 1./rcs
+               u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
+               v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem
+               dp = 1000. * del(i,k)
+               delhbar(i) = delhbar(i) + dellah(i,k)*xmb(i)*dp/g_
+               delqbar(i) = delqbar(i) + dellaq(i,k)*xmb(i)*dp/g_
+               deltbar(i) = deltbar(i) + dellat*xmb(i)*dp/g_
+               delubar(i) = delubar(i) + dellau(i,k)*xmb(i)*dp/g_
+               delvbar(i) = delvbar(i) + dellav(i,k)*xmb(i)*dp/g_
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do k = kts,kte
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.gt.kb(i).and.k.le.ktcon(i)) then
+               qeso(i,k)=0.01* fpvs(t1(i,k),1,rd_,rv_,cvap_,cliq_,cice,xlv0,xls    &
+                         ,psat,t0c_)
+               qeso(i,k) = eps * qeso(i,k)/(p(i,k) + (eps-1.)*qeso(i,k))
+               val     =             1.e-8
+               qeso(i,k) = max(qeso(i,k), val )
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         rntot(i) = 0.
+         delqev(i) = 0.
+         delq2(i) = 0.
+         flg(i) = cnvflg(i)
+       enddo
+    !
+       do k = kte,kts,-1
+         do i = its,ite
+           if (cnvflg(i)) then
+             if(k.lt.ktcon(i).and.k.gt.kb(i)) then
+               rntot(i) = rntot(i) + pwo(i,k) * xmb(i) * .001 * dt2
+             endif
+           endif
+         enddo
+       enddo
+    !
+    ! evaporating rain
+    !
+       do k = kte,kts,-1
+         do i = its,ite
+           if (k .le. kmax(i)) then
+             deltv(i) = 0.
+             delq(i) = 0.
+             qevap(i) = 0.
+             if(cnvflg(i)) then
+               if(k.lt.ktcon(i).and.k.gt.kb(i)) then
+                 rain(i) = rain(i) + pwo(i,k) * xmb(i) * .001 * dt2
+               endif
+             endif
+             if(flg(i).and.k.lt.ktcon(i)) then
+               evef = edt(i) * evfact
+               if(slimsk(i).eq.1.) evef=edt(i) * evfactl
+               qcond(i) = evef * (q1(i,k) - qeso(i,k))                             &
+                        / (1. + el2orc * qeso(i,k) / t1(i,k)**2)
+               dp = 1000. * del(i,k)
+               if(rain(i).gt.0..and.qcond(i).lt.0.) then
+                 qevap(i) = -qcond(i) * (1.-exp(-.32*sqrt(dt2*rain(i))))
+                 qevap(i) = min(qevap(i), rain(i)*1000.*g_/dp)
+                 delq2(i) = delqev(i) + .001 * qevap(i) * dp / g_
+               endif
+               if(rain(i).gt.0..and.qcond(i).lt.0..and.delq2(i).gt.rntot(i)) then
+                 qevap(i) = 1000.* g_ * (rntot(i) - delqev(i)) / dp
+                 flg(i) = .false.
+               endif
+               if(rain(i).gt.0..and.qevap(i).gt.0.) then
+                 tem  = .001 * dp / g_
+                 tem1 = qevap(i) * tem
+                 if(tem1.gt.rain(i)) then
+                   qevap(i) = rain(i) / tem
+                   rain(i) = 0.
+                 else
+                   rain(i) = rain(i) - tem1
+                 endif
+                 q1(i,k) = q1(i,k) + qevap(i)
+                 t1(i,k) = t1(i,k) - (hvap_/cp_) * qevap(i)
+                 deltv(i) = - (hvap_/cp_)*qevap(i)/dt2
+                 delq(i) =  + qevap(i)/dt2
+                 delqev(i) = delqev(i) + .001*dp*qevap(i)/g_
+               endif
+               dellaq(i,k) = dellaq(i,k) + delq(i) / xmb(i)
+               delqbar(i) = delqbar(i) + delq(i)*dp/g_
+               deltbar(i) = deltbar(i) + deltv(i)*dp/g_
+             endif
+           endif
+         enddo
+       enddo
+    !
+       do i = its,ite
+         if(cnvflg(i)) then
+           if(rain(i).lt.0..or..not.flg(i)) rain(i) = 0.
+           ktop(i) = ktcon(i)
+           kbot(i) = kbcon(i)
+           icps(i) = 0
+         endif
+       enddo
+    !
+    ! cloud water
+    !
+       if (ncloud.gt.0) then
+    !
+         do k = kts,km1
+           do i = its,ite
+             if (cnvflg(i)) then
+               if (k.ge.kbcon(i).and.k.le.ktcon(i)) then
+                 tem  = dellal(i,k) * xmb(i) * dt2
+                 tem1 = max(0.0, min(1.0, (tcr-t1(i,k))*tcrf))
+                 if (ncloud.ge.2) then
+                   qi2(i,k) = qi2(i,k) + tem * tem1            ! ice
+                   qc2(i,k) = qc2(i,k) + tem *(1.0-tem1)       ! water
+                 else
+                   qc2(i,k) = qc2(i,k) + tem
+                 endif
+               endif
+             endif
+           enddo
+         enddo
+    !
+       endif
+    !
+          end subroutine nscv2d
+    !-------------------------------------------------------------------------------
+    !
+    END MODULE module_cu_nsas
+    !
+    

--- a/src/utilities/debug_utils.f90
+++ b/src/utilities/debug_utils.f90
@@ -47,6 +47,14 @@ contains
             return
         endif
 
+        if (any(ieee_is_nan(var))) then
+            n = COUNT(ieee_is_nan(var))
+            ! ALLOCATE(IsNanIdx(n))
+            ! IsNanIdx = PACK( (/(i,i=1,SIZE(var))/), MASK=IsNan(var) )  ! if someone can get this to work it would be nice to have.
+            write(*,*) trim(msg)
+            write(*,*) trim(name)//" has", n," NaN(s) "
+        endif
+
         if (present(greater_than)) then
             vmax = maxval(var)
             if (vmax > greater_than) then

--- a/src/utilities/debug_utils.f90
+++ b/src/utilities/debug_utils.f90
@@ -1,6 +1,7 @@
 module debug_module
     use domain_interface, only  : domain_t
     use string,           only  : str
+    use ieee_arithmetic
 
     implicit none
 contains
@@ -38,6 +39,7 @@ contains
         character(len=*),   intent(in)                      :: name, msg
         real,               intent(in),    optional         :: greater_than, less_than
         logical,            intent(in),    optional         :: fix
+        integer :: n
         real :: vmax, vmin
         logical :: printed
 


### PR DESCRIPTION


TYPE:  enhancement, new feature

KEYWORDS: convection, NSAS, BMJ

SOURCE: Bert Kruyt, NCAR RAL

DESCRIPTION OF CHANGES: this PR includes the addition of the NSAS as BMJ convection schemes. Both schemes were copied from the WRF 4.4 code base, and modified to prevent out of bound errors in the case of low model tops.


TESTS CONDUCTED: Runs as before. BMJ significantly increases convective precipitation compared to Tiedtke.

NOTES: both NSAS and BMJ require PBL height (absolute or in the form of a z-level index (in the case of BMJ) ) as an input. Currently , the PBL scheme in ICAR does not compute a PBL height. Therefore, the PBL height is hardcoded as a arbitrary, uniform, fixed value above the ground in cu_driver.f90. Sensitivity tests will be conducted to see how sensitive the schemes are to these values, and if this warrants the implementation of a more sophisticated PBL scheme to calculate the PBL height properly. 


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Fully documented
