### PR TITLE
removal of  BMJ 'low modeltop' warning

### DIFF
--- a/src/physics/cu_bmj.f90
+++ b/src/physics/cu_bmj.f90
@@ -1437,7 +1437,8 @@
     !---------------------------SHALLOW CLOUD TOP---------------------------
             ! BK 2022/06/28: Warning and adjustment in case of low model top:
             if (LTOP<2) then 
-                write(*,*) "   CU_BMJ WARNING: model top likely too low for correct convection simulation."!, LTOP, LBOT, LTP1,"[", this_image(),"]"
+                ! commented out the warning below because it clogs up the log files. 
+                ! write(*,*) "   CU_BMJ WARNING: model top likely too low for correct convection simulation."!, LTOP, LBOT, LTP1,"[", this_image(),"]"
                 LTOP=max(LTOP, 2)
             endif
             LBM1=LBOT-1


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: BMJ, warning, logfile

SOURCE: Bert Kruyt, NCAR

DESCRIPTION OF CHANGES: BMJ convection scheme was modified to prevent crash with a low modeltop. This outputted a warning for each time this condition was met, leading to many, many warnings in the model output or logfile, even potentially crashing it on long runs. This warning is now commented out so the model output is clean. 


TESTS CONDUCTED: None. just a write(*,*) statement removed.




### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
