### PR TITLE
Feature/ysu

### DIFF
--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -136,6 +136,7 @@ module icar_constants
         integer :: ustar
         integer :: coeff_momentum_drag
         integer :: coeff_heat_exchange
+        integer :: coeff_heat_exchange_3d
         integer :: surface_rad_temperature
         integer :: temperature_2m
         integer :: humidity_2m
@@ -210,8 +211,11 @@ module icar_constants
         integer :: tend_qv_pbl
         integer :: tend_qv
         integer :: tend_th
+        integer :: tend_th_pbl
         integer :: tend_qc
+        integer :: tend_qc_pbl
         integer :: tend_qi
+        integer :: tend_qi_pbl
         integer :: tend_qs
         integer :: tend_qr
         integer :: tend_u
@@ -252,7 +256,7 @@ module icar_constants
                                                             171, 172, 173, 174, 175, 176, 177, 178, 179, 180,  &
                                                             181, 182, 183, 184, 185, 186, 187, 188, 189, 190,  &
                                                             191, 192, 193, 194, 195, 196, 197, 198, 199, 200,  &
-                                                            201)
+                                                            201, 202, 203, 204, 205)
 
     integer, parameter :: kINTEGER_BITS     = storage_size(kINTEGER_BITS)
     integer, parameter :: kMAX_STORAGE_VARS = storage_size(kVARS) / kINTEGER_BITS

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -232,6 +232,8 @@ module icar_constants
         integer :: temperature_interface
         integer :: cosine_zenith_angle
         integer :: tend_swrad
+        integer :: kpbl
+        integer :: hpbl
         integer :: last_var
     end type var_constants_type
 
@@ -256,7 +258,7 @@ module icar_constants
                                                             171, 172, 173, 174, 175, 176, 177, 178, 179, 180,  &
                                                             181, 182, 183, 184, 185, 186, 187, 188, 189, 190,  &
                                                             191, 192, 193, 194, 195, 196, 197, 198, 199, 200,  &
-                                                            201, 202, 203, 204, 205)
+                                                            201, 202, 203, 204, 205, 206, 207)
 
     integer, parameter :: kINTEGER_BITS     = storage_size(kINTEGER_BITS)
     integer, parameter :: kMAX_STORAGE_VARS = storage_size(kVARS) / kINTEGER_BITS

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -282,7 +282,7 @@ module icar_constants
                                                             191, 192, 193, 194, 195, 196, 197, 198, 199, 200,  &
                                                             201, 202, 203, 204, 205, 206, 207, 208, 209, 210,  &
                                                             211, 212, 213, 214, 215, 216, 217, 218, 219, 220,  &
-                                                            221, 222, 223, 224, 225, 226, 227, 228, 229, 230)
+                                                            221, 222, 223, 224, 225, 226, 227, 228, 229)
 
     integer, parameter :: kINTEGER_BITS     = storage_size(kINTEGER_BITS)
     integer, parameter :: kMAX_STORAGE_VARS = storage_size(kVARS) / kINTEGER_BITS

--- a/src/constants/wrf_constants.f90
+++ b/src/constants/wrf_constants.f90
@@ -72,12 +72,12 @@
    REAL    , PARAMETER :: DEGRAD       = piconst/180.
    REAL    , PARAMETER :: DPD          = 360./365.
 
-   ! REAL    , PARAMETER ::  SVP1=0.6112
-   ! REAL    , PARAMETER ::  SVP2=17.67
-   ! REAL    , PARAMETER ::  SVP3=29.65
-   ! REAL    , PARAMETER ::  SVPT0=273.15
-   REAL    , PARAMETER ::  EP_1=R_v/R_d-1.
-   ! REAL    , PARAMETER ::  EP_2=R_d/R_v
+!    REAL    , PARAMETER ::  SVP1=0.6112    ! for YSU pbl 
+!    REAL    , PARAMETER ::  SVP2=17.67
+!    REAL    , PARAMETER ::  SVP3=29.65
+!    REAL    , PARAMETER ::  SVPT0=273.15
+!    REAL    , PARAMETER ::  EP_1=R_v/R_d-1. !-- ep1         constant for virtual temperature (r_v/r_d - 1) (dimensionless)
+!    REAL    , PARAMETER ::  EP_2=R_d/R_v    !-- ep2         constant for specific humidity calculation
    ! REAL    , PARAMETER ::  KARMAN=0.4
    REAL    , PARAMETER ::  EOMEG=7.2921E-5
    REAL    , PARAMETER ::  STBOLT=5.67051E-8

--- a/src/io/default_output_metadata.f90
+++ b/src/io/default_output_metadata.f90
@@ -2089,6 +2089,28 @@ contains
                                attribute_t("coordinates",   "lat lon")]
         end associate
         !>------------------------------------------------------------
+        !!  PBL height
+        !!------------------------------------------------------------
+        associate(var=>var_meta(kVARS%hpbl))
+            var%name        = "hpbl"
+            var%dimensions  = two_d_t_dimensions
+            var%unlimited_dim=.True.
+            var%attributes  = [attribute_t("non_standard_name", "height_of_planetary_boundary_layer"), &
+                               attribute_t("units",         "m"),                                      &
+                               attribute_t("coordinates",   "lat lon")]
+        end associate
+        !>------------------------------------------------------------
+        !!  PBL layer index
+        !!------------------------------------------------------------
+        associate(var=>var_meta(kVARS%kpbl))
+            var%name        = "kpbl"
+            var%dimensions  = two_d_t_dimensions
+            var%unlimited_dim=.True.
+            var%attributes  = [attribute_t("non_standard_name", "index_of_planetary_boundary_layer_height"), &
+                               attribute_t("units",         "-"),                                      &
+                               attribute_t("coordinates",   "lat lon")]
+        end associate
+        !>------------------------------------------------------------
         !!  Land surface radiative skin temperature
         !!------------------------------------------------------------
         associate(var=>var_meta(kVARS%skin_temperature))

--- a/src/io/default_output_metadata.f90
+++ b/src/io/default_output_metadata.f90
@@ -2078,6 +2078,17 @@ contains
                                attribute_t("coordinates",   "lat lon")]
         end associate
         !>------------------------------------------------------------
+        !!  Sensible Heat Exchange Coefficient 3d
+        !!------------------------------------------------------------
+        associate(var=>var_meta(kVARS%coeff_heat_exchange_3d))
+            var%name        = "coeff_heat_exchange_3d"
+            var%dimensions  = three_d_t_dimensions
+            var%unlimited_dim=.True.
+            var%attributes  = [attribute_t("non_standard_name", "sensible_heat_exchange_coefficient_3d"), &
+                               attribute_t("units",         "1"),                                      &
+                               attribute_t("coordinates",   "lat lon")]
+        end associate
+        !>------------------------------------------------------------
         !!  Land surface radiative skin temperature
         !!------------------------------------------------------------
         associate(var=>var_meta(kVARS%skin_temperature))

--- a/src/main/data_structures.f90
+++ b/src/main/data_structures.f90
@@ -199,11 +199,11 @@ module data_structures
     ! ------------------------------------------------
     type tendencies_type
         ! 3D atmospheric field tendencies
-        ! These are used by various physics parameterizations
+        ! These are used by various physics parameterizations 
         real,   allocatable, dimension(:,:,:) :: th,qv,qc,qi,u,v,qr,qs
 
-        ! advection and pbl tendencies that need to be saved for the cumulus scheme
-        real, allocatable, dimension(:,:,:) :: qv_adv,qv_pbl
+        ! advection and pbl tendencies that need to be saved for the cumulus/pbl scheme
+        real, allocatable, dimension(:,:,:) :: qv_adv,qv_pbl, th_pbl, qi_pbl, qc_pbl
         real, allocatable, dimension(:,:,:) :: th_lwrad, th_swrad
     end type tendencies_type
 

--- a/src/main/time_step.f90
+++ b/src/main/time_step.f90
@@ -476,8 +476,7 @@ contains
                 if (options%parameters%debug) call domain_check(domain, "img: "//trim(str(this_image()))//" lsm")
 
                 call pbl(domain, options, real(dt%seconds()))!, halo=1)
-
-                ! balance u/v after winds have been modified by pbl:
+                ! balance u/v and re-calculate dt after winds have been modified by pbl:
                 if (options%physics%boundarylayer==kPBL_YSU) then
                     call balance_uvw(   domain%u%data_3d,   domain%v%data_3d,   domain%w%data_3d,       &
                                         domain%jacobian_u,  domain%jacobian_v,  domain%jacobian_w,      &
@@ -489,7 +488,6 @@ contains
                         dt = end_time - domain%model_time
                     endif
                 endif
-
                 if (options%parameters%debug) call domain_check(domain, "img: "//trim(str(this_image()))//" pbl")
 
                 call convect(domain, options, real(dt%seconds()))!, halo=1)

--- a/src/makefile
+++ b/src/makefile
@@ -374,6 +374,7 @@ OBJS=	\
 		$(BUILD)boundary_obj.o		\
 		$(BUILD)assertions.o		\
 		$(BUILD)atm_utilities.o		\
+		$(BUILD)pbl_utilities.o		\
 		$(BUILD)co_utilities.o		\
 		$(BUILD)default_output_metadata.o\
 		$(BUILD)output_h.o			\
@@ -385,6 +386,7 @@ OBJS=	\
 		$(BUILD)lt_lut_io.o			\
 		$(BUILD)pbl_driver.o		\
 		$(BUILD)pbl_simple.o		\
+		$(BUILD)pbl_ysu.o			\
 		$(BUILD)ra_driver.o			\
 		$(BUILD)ra_simple.o			\
 		$(BUILD)ra_rrtmg_lw.o           \
@@ -535,10 +537,10 @@ caf_no_forcing_test: $(BUILD)test_caf_no_forcing.o							\
 					$(BUILD)exchangeable_h.o $(BUILD)exchangeable_obj.o \
 					$(BUILD)icar_constants.o $(BUILD)io_routines.o		\
 					$(BUILD)model_tracking.o $(BUILD)string.o           \
-					$(BUILD)assertions.o	 $(BUILD)atm_utilities.o    \
+					$(BUILD)assertions.o	 $(BUILD)atm_utilities.o    \ $(BUILD)pbl_utilities.o		\
 					$(BUILD)co_utilities.o   $(BUILD)default_output_metadata.o \
 					$(BUILD)ra_driver.o      $(BUILD)ra_simple.o		\
-					$(BUILD)pbl_driver.o     $(BUILD)pbl_simple.o		\
+					$(BUILD)pbl_driver.o     $(BUILD)pbl_simple.o		$(BUILD)pbl_ysu.o		\
 					$(BUILD)mp_driver.o      $(BUILD)mp_simple.o		\
 					$(BUILD)mp_thompson.o	 $(BUILD)mp_thompson_aer.o   $(BUILD)mp_wsm6.o\
 					$(BUILD)cu_driver.o		 $(BUILD)cu_tiedtke.o      $(BUILD)cu_nsas.o	$(BUILD)cu_bmj.o			\
@@ -730,6 +732,9 @@ $(BUILD)array_utilities.o:$(UTIL)array_utilities.f90
 $(BUILD)atm_utilities.o:$(UTIL)atm_utilities.f90 $(BUILD)icar_constants.o 	\
 					$(BUILD)data_structures.o $(BUILD)options_h.o $(BUILD)mp_thompson.o
 
+$(BUILD)pbl_utilities.o:$(UTIL)pbl_utilities.f90 $(BUILD)icar_constants.o 	\
+					$(BUILD)data_structures.o 
+
 
 ###################################################################
 #	I/O routines
@@ -833,7 +838,8 @@ $(BUILD)lsm_noahmp_glacier.o: $(PHYS)lsm_noahmp_glacier.f90
 ###################################################################
 #	Planetary Boundary Layer code
 ###################################################################
-$(BUILD)pbl_driver.o: $(PHYS)pbl_driver.f90 $(BUILD)pbl_simple.o $(BUILD)domain_h.o $(BUILD)options_h.o $(BUILD)data_structures.o
+$(BUILD)pbl_driver.o: $(PHYS)pbl_driver.f90 $(BUILD)pbl_simple.o $(BUILD)pbl_ysu.o $(BUILD)domain_h.o \
+					$(BUILD)options_h.o $(BUILD)lsm_driver.o $(BUILD)data_structures.o $(BUILD)atm_utilities.o $(BUILD)pbl_utilities.o 
 
 $(BUILD)pbl_simple.o: $(PHYS)pbl_simple.f90 $(BUILD)domain_h.o $(BUILD)options_h.o $(BUILD)data_structures.o
 

--- a/src/objects/domain_h.f90
+++ b/src/objects/domain_h.f90
@@ -78,12 +78,13 @@ module domain_interface
     type(variable_t) :: terrain
     type(variable_t) :: forcing_terrain  ! BK 05/2020: The forcing terrain interpolated 2d to the hi-res grid. In order to calculate difference in slope
     type(variable_t) :: forcing_terrain2 ! test 9-6-2020
-        ! type(variable_t) :: forcing_terrain_u1 ! test 9-6-2020
     type(variable_t) :: u_10m
     type(variable_t) :: v_10m
     type(variable_t) :: coeff_momentum_drag
     type(variable_t) :: coeff_heat_exchange
     type(variable_t) :: coeff_heat_exchange_3d ! used in YSU pbl
+    integer,allocatable :: kpbl(:,:)  ! used in YSU pbl / BMJ cu
+    type(variable_t) :: hpbl          ! used in YSU pbl /NSAS cu
     type(variable_t) :: surface_rad_temperature
     type(variable_t) :: temperature_2m
     type(variable_t) :: humidity_2m

--- a/src/objects/domain_h.f90
+++ b/src/objects/domain_h.f90
@@ -83,6 +83,7 @@ module domain_interface
     type(variable_t) :: v_10m
     type(variable_t) :: coeff_momentum_drag
     type(variable_t) :: coeff_heat_exchange
+    type(variable_t) :: coeff_heat_exchange_3d ! used in YSU pbl
     type(variable_t) :: surface_rad_temperature
     type(variable_t) :: temperature_2m
     type(variable_t) :: humidity_2m

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -291,7 +291,8 @@ contains
         if (0<opt%vars_to_allocate( kVARS%v_10m) )                      call setup(this%v_10m,                    this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%coeff_momentum_drag) )        call setup(this%coeff_momentum_drag,      this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%coeff_heat_exchange) )        call setup(this%coeff_heat_exchange,      this%grid2d)
-        if (0<opt%vars_to_allocate( kVARS%coeff_heat_exchange_3d) )        call setup(this%coeff_heat_exchange_3d,      this%grid) ! for pbl ysu - test
+        if (0<opt%vars_to_allocate( kVARS%coeff_heat_exchange_3d) )     call setup(this%coeff_heat_exchange_3d,   this%grid)    ! for pbl ysu 
+        if (0<opt%vars_to_allocate( kVARS%hpbl) )                       call setup(this%hpbl,                     this%grid2d)    ! for pbl ysu 
         if (0<opt%vars_to_allocate( kVARS%surface_rad_temperature) )    call setup(this%surface_rad_temperature,  this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%temperature_2m) )             call setup(this%temperature_2m,           this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%humidity_2m) )                call setup(this%humidity_2m,              this%grid2d)
@@ -371,6 +372,7 @@ contains
         if (0<opt%vars_to_allocate( kVARS%irr_eventno_micro) )          allocate(this%irr_eventno_micro        (ims:ime, jms:jme),          source=0)
         if (0<opt%vars_to_allocate( kVARS%irr_eventno_flood) )          allocate(this%irr_eventno_flood        (ims:ime, jms:jme),          source=0)
         if (0<opt%vars_to_allocate( kVARS%plant_growth_stage) )         allocate(this%plant_growth_stage       (ims:ime, jms:jme),          source=0)
+        if (0<opt%vars_to_allocate( kVARS%kpbl) )                       allocate(this%kpbl                     (ims:ime, jms:jme),          source=0) ! for pbl ysu 
 
         ! tendency variables that don't need to be output... maybe these should be set up the same way
         if (0<opt%vars_to_allocate( kVARS%tend_qv_adv) )                allocate(this%tend%qv_adv(ims:ime, kms:kme, jms:jme),   source=0.0)

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -291,6 +291,7 @@ contains
         if (0<opt%vars_to_allocate( kVARS%v_10m) )                      call setup(this%v_10m,                    this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%coeff_momentum_drag) )        call setup(this%coeff_momentum_drag,      this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%coeff_heat_exchange) )        call setup(this%coeff_heat_exchange,      this%grid2d)
+        if (0<opt%vars_to_allocate( kVARS%coeff_heat_exchange_3d) )        call setup(this%coeff_heat_exchange_3d,      this%grid) ! for pbl ysu - test
         if (0<opt%vars_to_allocate( kVARS%surface_rad_temperature) )    call setup(this%surface_rad_temperature,  this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%temperature_2m) )             call setup(this%temperature_2m,           this%grid2d)
         if (0<opt%vars_to_allocate( kVARS%humidity_2m) )                call setup(this%humidity_2m,              this%grid2d)
@@ -376,6 +377,9 @@ contains
         if (0<opt%vars_to_allocate( kVARS%tend_qv_pbl) )                allocate(this%tend%qv_pbl(ims:ime, kms:kme, jms:jme),   source=0.0)
         if (0<opt%vars_to_allocate( kVARS%tend_qv) )                    allocate(this%tend%qv(ims:ime, kms:kme, jms:jme),       source=0.0)
         if (0<opt%vars_to_allocate( kVARS%tend_th) )                    allocate(this%tend%th(ims:ime, kms:kme, jms:jme),       source=0.0)
+        if (0<opt%vars_to_allocate( kVARS%tend_th_pbl) )                allocate(this%tend%th_pbl(ims:ime, kms:kme, jms:jme),       source=0.0)
+        if (0<opt%vars_to_allocate( kVARS%tend_qc_pbl) )                allocate(this%tend%qc_pbl(ims:ime, kms:kme, jms:jme),       source=0.0)
+        if (0<opt%vars_to_allocate( kVARS%tend_qi_pbl) )                allocate(this%tend%qi_pbl(ims:ime, kms:kme, jms:jme),       source=0.0)
         if (0<opt%vars_to_allocate( kVARS%tend_qc) )                    allocate(this%tend%qc(ims:ime, kms:kme, jms:jme),       source=0.0)
         if (0<opt%vars_to_allocate( kVARS%tend_qi) )                    allocate(this%tend%qi(ims:ime, kms:kme, jms:jme),       source=0.0)
         if (0<opt%vars_to_allocate( kVARS%tend_qs) )                    allocate(this%tend%qs(ims:ime, kms:kme, jms:jme),       source=0.0)
@@ -1906,6 +1910,7 @@ contains
         if (associated(this%canopy_temperature%data_2d)) this%canopy_temperature%data_2d=280
         if (associated(this%coeff_momentum_drag%data_2d)) this%coeff_momentum_drag%data_2d=0
         if (associated(this%coeff_heat_exchange%data_2d)) this%coeff_heat_exchange%data_2d=0
+        if (associated(this%coeff_heat_exchange_3d%data_3d)) this%coeff_heat_exchange_3d%data_3d=0.01
         if (associated(this%canopy_fwet%data_2d)) this%canopy_fwet%data_2d=0
         if (associated(this%snow_water_eq_prev%data_2d)) this%snow_water_eq_prev%data_2d=0
         if (associated(this%snow_albedo_prev%data_2d)) this%snow_albedo_prev%data_2d=0.65

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -14,6 +14,7 @@ submodule(options_interface) options_implementation
     use microphysics,               only : mp_var_request
     use advection,                  only : adv_var_request
     use wind,                       only : wind_var_request
+    use planetary_boundary_layer,   only : pbl_var_request
 
     use output_metadata,            only : get_varname
 
@@ -93,6 +94,7 @@ contains
 
         call ra_var_request(options)
         call lsm_var_request(options)
+        call pbl_var_request(options)
         call cu_var_request(options)
         call mp_var_request(options)
         call adv_var_request(options)

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -24,14 +24,14 @@ module convection
     logical,allocatable, dimension(:,:) ::  CU_ACT_FLAG
     real,   allocatable, dimension(:,:) ::  XLAND, RAINCV, PRATEC, NCA
     real,   allocatable, dimension(:,:,:):: W0AVG, w_stochastic
-    real,   allocatable, dimension(:,:)::   lowest_convection_layer, highest_convection_layer, hpbl  ! pbl height I guess? Used in NSAS.
+    real,   allocatable, dimension(:,:)::   lowest_convection_layer, highest_convection_layer! , hpbl  ! pbl height I guess? Used in NSAS.
     real,   allocatable, dimension(:,:)::   CLDEFI ! precipitation efficiency (for BMJ scheme) (dimensionless)
     real,   allocatable, dimension(:,:)::   CUBOT,CUTOP, CONVCLD  ! for BMJ scheme
     real,   allocatable, dimension(:,:,:):: CCLDFRA, QCCONV, QICONV ! for BMJ scheme
     integer :: ids,ide,jds,jde,kds,kde ! Domain dimensions
     integer :: ims,ime,jms,jme,kms,kme ! Local Memory dimensions
     integer :: its,ite,jts,jte,kts,kte ! Processing Tile dimensions
-    integer, allocatable, dimension(:,:) :: lowlyr, kpbl  ! for bmj scheme
+    integer, allocatable, dimension(:,:) :: lowlyr   ! for bmj scheme!, kpbl
     logical :: bmj_rad_feedback
 
 contains
@@ -63,14 +63,14 @@ contains
                          kVARS%exner, kVARS%dz_interface, kVARS%density, kVARS%pressure_interface, kVARS%pressure,  &
                          kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%w, kVARS%land_mask,        &
                          kVARS%tend_qv, kVARS%tend_th, kVARS%tend_qc, kVARS%tend_qi, kVARS%tend_qs, kVARS%tend_qr,  &
-                         kVARS%tend_u, kVARS%tend_v])
+                         kVARS%tend_u, kVARS%tend_v, kVARS%hpbl])
 
              call options%advect_vars([kVARS%potential_temperature, kVARS%water_vapor])
 
              call options%restart_vars( &
                          [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
                          kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
-                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure, kVARS%hpbl])
 
         else if (options%physics%convection == kCU_BMJ) then  ! Not checked thoroughly yet
             call options%alloc_vars( &
@@ -79,14 +79,14 @@ contains
                          kVARS%exner, kVARS%dz_interface, kVARS%density, kVARS%pressure_interface, kVARS%pressure,  &
                          kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%w, kVARS%land_mask,        &
                          kVARS%tend_qv, kVARS%tend_th, kVARS%tend_qc, kVARS%tend_qi, kVARS%tend_qs, kVARS%tend_qr,  &
-                         kVARS%tend_u, kVARS%tend_v])
+                         kVARS%tend_u, kVARS%tend_v, kVARS%kpbl])
 
              call options%advect_vars([kVARS%potential_temperature, kVARS%water_vapor])
 
              call options%restart_vars( &
                          [kVARS%water_vapor, kVARS%potential_temperature, kVARS%temperature,                        &
                          kVARS%cloud_water, kVARS%cloud_ice, kVARS%precipitation, kVARS%convective_precipitation,   &
-                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure])
+                         kVARS%sensible_heat, kVARS%latent_heat, kVARS%u, kVARS%v, kVARS%pressure, kVARS%kpbl])
 
         endif
 
@@ -173,16 +173,18 @@ contains
         else if (options%physics%convection==kCU_NSAS) then
             if (this_image()==1) write(*,*) "     NSAS Cumulus scheme"
 
-            allocate(hpbl(ims:ime,jms:jme))  ! ?? PBL height I assume? 
+            ! allocate(hpbl(ims:ime,jms:jme))  ! ?? PBL height I assume? 
             allocate(lowest_convection_layer(ims:ime,jms:jme))
             allocate(highest_convection_layer(ims:ime,jms:jme))
 
             ! NSAS expects a PBL height, But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
-            do i=ims,ime
-                do j=jms,jme
-                    hpbl(i,j)=1000.  ! or take terrain height into account?
+            if (options%physics%boundarylayer/=kPBL_YSU) then
+                do i=ims,ime
+                    do j=jms,jme
+                        domain%hpbl%data_2d(i,j)=1000.  ! or take terrain height into account?
+                    enddo
                 enddo
-            enddo
+            endif
 
             call nsasinit(  rthcuten=domain%tend%th                             &
                             ,rqvcuten=domain%tend%qv                            &
@@ -203,11 +205,6 @@ contains
         else if (options%physics%convection==kCU_BMJ) then
             if (this_image()==1) write(*,*) "     BMJ Cumulus scheme"
 
-            ! TO DO:
-            !   - add kCU_BMJ to options
-            !   - kpbl (layer index of the pbl (top? bottom? ....))
-            !   - ...
-
             allocate( CLDEFI(ims:ime,jms:jme) )
             allocate( CUBOT(IMS:IME,JMS:JME) )
             allocate( CUTOP(IMS:IME,JMS:JME) )  ! INTENT:OUT
@@ -216,17 +213,19 @@ contains
             allocate( QICONV(ims:ime,jms:jme,kms:kme) )
             allocate( CONVCLD(ims:ime,jms:jme) )
             allocate( lowlyr(ims:ime,jms:jme) )
-            allocate( kpbl(ims:ime,jms:jme) )
+            ! allocate( kpbl(ims:ime,jms:jme) ) ! domain%kpbl%data_2d when YSU is selected
 
 
             ! ----- the values below are just educated (or not) guesses. Need to refine.  -------
-            ! INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) :: KPBL,LOWLYR
             do i=ims,ime
                 do j=jms,jme
-                    lowlyr(i,j) = 1 ! ???? 
-                    kpbl(i,j) = 10 !????
+                    lowlyr(i,j) = 1 ! ???
+                    if (options%physics%boundarylayer/=kPBL_YSU) domain%kpbl(i,j) = 10 ! without YSU, we assign a stationary value to kpbl
                 enddo
             enddo
+
+
+
             bmj_rad_feedback = .true.  !??
 
             call BMJINIT( rthcuten=domain%tend%th                               &
@@ -355,10 +354,6 @@ subroutine convect(domain,options,dt_in)
 
     elseif (options%physics%convection==kCU_NSAS) then
 
-        ! TO DO:
-        !  - calculate height of PBL
-        !  - use wrf_constants.f90 ?
-
         ! set dx_factor_nsas (cu_nsas.f90 line 567):
         if (domain%dx.le.1000) then
             dx_factor_nsas=1  !       if (dx_factor_nsas == 1) then   dx_factor = 250. / delx ! assume 2.5 ms-1 (1km) and 1.125 cms-1 (200km) (cu_nsas.f90 line 567)
@@ -395,7 +390,7 @@ subroutine convect(domain,options,dt_in)
             ,w=W0AVG                                             & !-- w           vertical velocity (m/s)
             ,u3d=domain%u_mass%data_3d                           & !-- u3d         3d u-velocity interpolated to theta points (m/s)
             ,v3d=domain%v_mass%data_3d                           & !-- v3d         3d v-velocity interpolated to theta points (m/s)
-            ,hpbl=hpbl  &  ! ?? PBL height I assume? But since ICAR does not currently compute this, fix at rough esitmate of 1000m ?
+            ,hpbl=domain%hpbl%data_2d                            &  ! ?? PBL height I assume?
             ,hfx=domain%sensible_heat%data_2d                     & !  HFX  - net upward heat flux at the surface (W/m^2)
             ,qfx=domain%latent_heat%data_2d/LH_vaporization       & !  QFX  - net upward moisture flux at the surface (kg/m^2/s)
             ,mp_physics=5        & ! - sets ncloud: - integer no_cloud(0),no_ice(1),cloud+ice(2) (see ln 141 cu_nsas.f90)  use options%physics%microphysics?
@@ -446,7 +441,7 @@ subroutine convect(domain,options,dt_in)
                 ,dt=dt_in                                       & !-- dt          time step (s)
                 ,ITIMESTEP=itimestep ,STEPCU=stepcu             &
                 ,CUTOP=CUTOP, CUBOT=CUBOT                       &
-                ,KPBL=kpbl                                      &!-- KPBL          layer index of the PBL
+                ,KPBL=domain%kpbl                                      &!-- KPBL INTENT(IN)          layer index of the PBL?
                 ,dz8w=domain%dz_interface%data_3d               &!-- dz8w          dz between full levels (m)
                 ,PINT=domain%pressure_interface%data_3d         &  !-- p8w           pressure at full levels (Pa)
                 ,PMID=domain%pressure%data_3d                   &!-- Pcps        3D hydrostatic pressure at half levels (Pa)

--- a/src/physics/cu_driver.f90
+++ b/src/physics/cu_driver.f90
@@ -411,8 +411,8 @@ subroutine convect(domain,options,dt_in)
             ,xlv=2.5E6                                           & ! from wrf_constants.f90
             ,r_d=287.                                            & ! from wrf_constants.f90
             ,r_v=461.6                                           & ! from wrf_constants.f90
-            ,ep_1=461.6/287.-1.                                  & ! EP_1=R_v/R_d-1. (wrf_constants.f90)
-            ,ep_2=287./461.6                                     & ! EP_2=R_d/R_v
+            ,ep_1=EP1                                  & ! EP_1=R_v/R_d-1. (wrf_constants.f90) 461.6/287.-1.
+            ,ep_2=EP2                                     & ! EP_2=R_d/R_v  = 287./461.6
             ,cice=2106.                                           & ! from wrf_constants.f90                                          &
             ,xls=2.85E6                                           & ! from wrf_constants.f90
             ,psat=610.78                                           & ! from wrf_constants.f90
@@ -452,7 +452,7 @@ subroutine convect(domain,options,dt_in)
                 ,PMID=domain%pressure%data_3d                   &!-- Pcps        3D hydrostatic pressure at half levels (Pa)
                 ,PI=domain%exner%data_3d                        &   ! exner
                 ,CP=cp ,R=r_d ,ELWV=xlv ,ELIV=xls ,G=gravity    &
-                ,TFRZ=svpt0 ,D608=ep_1 ,CLDEFI=cldefi           &
+                ,TFRZ=svpt0 ,D608=EP1 ,CLDEFI=cldefi           &
                 ,LOWLYR=lowlyr                                  &
                 ,XLAND=XLAND                                    &
                 ,CU_ACT_FLAG=CU_ACT_FLAG                        &

--- a/src/physics/lsm_driver.f90
+++ b/src/physics/lsm_driver.f90
@@ -332,10 +332,6 @@ contains
                   th            => domain%potential_temperature%data_3d, &
                   qv            => domain%water_vapor%data_3d    &
             )
-        ! if (options%parameters%debug) then
-        !     if(this_image()==1) write(*,*) "   B_Fx: nr Nans in th, dz_i: ", COUNT(ieee_is_nan(th)) , COUNT(ieee_is_nan(dz))!,  COUNT(ieee_is_nan(domain%potential_temperature%data_3d))
-        !     if(this_image()==1) write(*,*) "   B_Fx: nr Nans in  hfx, qfx: ",  COUNT(ieee_is_nan(sensible_heat)),   COUNT(ieee_is_nan(domain%latent_heat%data_2d))
-        ! endif    
 
         ! convert sensible heat flux to a temperature delta term
         ! (J/(s*m^2) * s / (J/(kg*K)) => kg*K/m^2) ... /((kg/m^3) * m) => K
@@ -353,11 +349,6 @@ contains
 
         ! enforce some minimum water vapor content... just in case
         where(qv(its:ite,kts,jts:jte) < SMALL_QV) qv(its:ite,kts,jts:jte) = SMALL_QV
-
-        ! if (options%parameters%debug) then
-        !     if(this_image()==1) write(*,*) "   A_Fx: nr Nans in th, dz_i: ", COUNT(ieee_is_nan(th)) , COUNT(ieee_is_nan(dz))!,  COUNT(ieee_is_nan(domain%potential_temperature%data_3d))
-        !     if(this_image()==1) write(*,*) "   A_Fx: nr Nans in  hfx, qfx: ",  COUNT(ieee_is_nan(sensible_heat)),   COUNT(ieee_is_nan(domain%latent_heat%data_2d))
-        ! endif
 
         end associate
 
@@ -470,7 +461,6 @@ contains
 
         if (this_image()==1) write(*,*) "Initializing LSM"
 
-        
         if (this_image()==1) write(*,*) "    max soil_deep_temperature on init: ", maxval(domain%soil_deep_temperature%data_2d)
         if (this_image()==1) write(*,*) "    max skin_temperature on init: ", maxval(domain%skin_temperature%data_2d)
 
@@ -1088,7 +1078,7 @@ contains
                              domain%cosine_zenith_angle%data_2d,       &
                              domain%latitude%data_2d,                  &
                              domain%longitude%data_2d,                 &
-                             domain%dz_interface%data_3d/2.,              &
+                             domain%dz_interface%data_3d / 2.,              & ! domain%dz_interface%data_3d,              & ! 
                              lsm_dt,                                   &
                              DZS,                                      &
                              num_soil_layers,                          &

--- a/src/physics/lsm_driver.f90
+++ b/src/physics/lsm_driver.f90
@@ -1088,7 +1088,7 @@ contains
                              domain%cosine_zenith_angle%data_2d,       &
                              domain%latitude%data_2d,                  &
                              domain%longitude%data_2d,                 &
-                             domain%dz_interface%data_3d,              &
+                             domain%dz_interface%data_3d/2.,              &
                              lsm_dt,                                   &
                              DZS,                                      &
                              num_soil_layers,                          &

--- a/src/physics/lsm_driver.f90
+++ b/src/physics/lsm_driver.f90
@@ -51,7 +51,7 @@ module land_surface
     implicit none
 
     private
-    public :: lsm_init, lsm, lsm_var_request, calc_exchange_coefficient
+    public :: lsm_init, lsm, lsm_var_request
 
     ! Noah LSM required variables.  Some of these should be stored in domain, but tested here for now
     integer :: ids,ide,jds,jde,kds,kde ! Domain dimensions
@@ -144,7 +144,7 @@ contains
                          kVARS%humidity_2m, kVARS%surface_pressure, kVARS%longwave_up, kVARS%ground_heat_flux,          &
                          kVARS%soil_totalmoisture, kVARS%soil_deep_temperature, kVARS%roughness_z0, kVARS%ustar,        &
                          kVARS%snow_height, kVARS%canopy_vapor_pressure, kVARS%canopy_temperature,                      &
-                         kVARS%veg_leaf_temperature, kVARS%coeff_momentum_drag, kVARS%coeff_heat_exchange,              & ! kVARS%coeff_heat_exchange_3d, & ! 
+                         kVARS%veg_leaf_temperature, kVARS%coeff_momentum_drag, kVARS%coeff_heat_exchange,              &
                          kVARS%canopy_fwet, kVARS%snow_water_eq_prev, kVARS%water_table_depth, kVARS%water_aquifer,     &
                          kVARS%mass_leaf, kVARS%mass_root, kVARS%mass_stem, kVARS%mass_wood, kVARS%soil_carbon_fast,    &
                          kVARS%soil_carbon_stable, kVARS%eq_soil_moisture, kVARS%smc_watertable_deep, kVARS%recharge,   &
@@ -207,7 +207,7 @@ contains
 
     end subroutine lsm_var_request
 
-    subroutine calc_exchange_coefficient(wind,tskin,airt,exchange_C)  ! BK maybe move this to atm_utilities b/c YSU pbl also wants to use this??
+    subroutine calc_exchange_coefficient(wind,tskin,airt,exchange_C)
         implicit none
         real, dimension(:,:),intent(inout) :: wind,tskin
         real, dimension(:,:,:),intent(inout) :: airt
@@ -218,8 +218,8 @@ contains
         exchange_C = 0
 
         Ri = gravity/airt(:,1,:) * (airt(:,1,:)-tskin)*z_atm/(wind**2)
-        ! Ri now is a function in atm_utlilities: 
-        ! Ri = calc_Richardson_nr(airt, tskin, z_atm, wind) 
+        ! Ri now is a function in atm_utlilities:
+        ! calc_Richardson_nr(Ri, airt, tskin, z_atm, wind)
 
         ! "--------------------------------------------------"
         !  "Surface Richardson number"
@@ -743,7 +743,7 @@ contains
                                 domain%canopy_vapor_pressure%data_2d,   &
                                 domain%canopy_temperature%data_2d,      &
                                 domain%coeff_momentum_drag%data_2d,     &
-                                domain%coeff_heat_exchange%data_2d,     & !domain%coeff_heat_exchange_3d%data_3d(:,1,:),     & !
+                                domain%coeff_heat_exchange%data_2d,     &
                                 domain%canopy_fwet%data_2d,             &
                                 domain%snow_water_eq_prev%data_2d,      &
                                 domain%snow_albedo_prev%data_2d,        &
@@ -1157,7 +1157,7 @@ contains
                              domain%canopy_vapor_pressure%data_2d,     &
                              domain%canopy_temperature%data_2d,        &
                              domain%coeff_momentum_drag%data_2d,       &
-                             domain%coeff_heat_exchange%data_2d,     & ! domain%coeff_heat_exchange_3d%data_3d(:,1,:),     & !
+                             domain%coeff_heat_exchange%data_2d,       &
                              domain%canopy_fwet%data_2d,               &
                              domain%snow_water_eq_prev%data_2d,        &
                              domain%snow_albedo_prev%data_2d,          &

--- a/src/physics/pbl_driver.f90
+++ b/src/physics/pbl_driver.f90
@@ -33,7 +33,6 @@ module planetary_boundary_layer
     use mod_atm_utilities, only : calc_Richardson_nr
     use mod_wrf_constants, only : EOMEG
     use icar_constants !, only : karman,stefan_boltzmann
-    use land_surface, only : calc_exchange_coefficient   ! maybe move this to atm_utilities? (some work)
     use mod_pbl_utilities, only : da_sfc_wtq
     use ieee_arithmetic ! for debugging 
     use array_utilities, only : array_offset_x_3d, array_offset_y_3d

--- a/src/physics/pbl_ysu.f90
+++ b/src/physics/pbl_ysu.f90
@@ -9,7 +9,6 @@
 !
 !
 module module_bl_ysu
-  use ieee_arithmetic
 contains
 !
 !-------------------------------------------------------------------
@@ -201,12 +200,9 @@ contains
 !
 !local
    integer ::  i,j,k
-   real,     dimension( its:ite, kts:kte )  ::                       rqibl2dt, & ! org
+   real,     dimension( its:ite, kts:kte )  ::                       rqibl2dt, &
                                                                           pdh
    real,     dimension( its:ite, kts:kte+1 )  ::                         pdhi
-  !  real,     dimension( ims:ime, kts:kte )  ::                       rqibl2dt, &
-  !                                                                         pdh
-  !  real,     dimension( ims:ime, kts:kte+1 )  ::                         pdhi
 
 !
    do j = jts,jte
@@ -226,8 +222,7 @@ contains
           enddo
         enddo
       endif
-      ! write(*,*)" pdhi(its,kts) shape:", shape(pdhi(its,kts))
-      ! write(*,*)" pdhi(i,k) shape:", shape(pdhi(i,k))
+
       call ysu2d(J=j,ux=u3d(ims,kms,j),vx=v3d(ims,kms,j)                       &
               ,tx=t3d(ims,kms,j)                                               &
               ,qx=qv3d(ims,kms,j),qcx=qc3d(ims,kms,j)                          &
@@ -886,7 +881,6 @@ contains
        endif
      enddo
    enddo
-  !  write(*,*)"   min/max xkzh (below pbl)", minval(xkzh),maxval(xkzh) !BK debug
 !
 !     compute diffusion coefficients over pbl (free atmosphere)
 !
@@ -918,14 +912,12 @@ contains
            sri = sqrt(-ri)
            xkzm(i,k) = xkzo+dk*(1+8.*(-ri)/(1+1.746*sri))
            xkzh(i,k) = xkzo+dk*(1+8.*(-ri)/(1+1.286*sri))
-          !  write(*,*)"   unstable xkzh (above pbl)", xkzh(i,k) !BK debug
          else
 ! stable regime
            xkzh(i,k) = xkzo+dk/(1+5.*ri)**2
            prnum = 1.0+2.1*ri
            prnum = min(prnum,prmax)
            xkzm(i,k) = (xkzh(i,k)-xkzo)*prnum+xkzo
-          !  write(*,*)"   stable xkzh", xkzh(i,k)!BK debug
          endif
 !
          xkzm(i,k) = min(xkzm(i,k),xkzmax)

--- a/src/physics/pbl_ysu.f90
+++ b/src/physics/pbl_ysu.f90
@@ -540,7 +540,6 @@ contains
           dzq(i,k) = zq(i,k+1)-zq(i,k)
           del(i,k) = p2di(i,k)-p2di(i,k+1)
         enddo
-        ! if(this_image()==1) write(*,*) "   541: nr Nans in del(:,k), k: ", COUNT(ieee_is_nan(del(:,k))), k 
       enddo
 !
       do i = its,ite
@@ -1008,13 +1007,8 @@ contains
        ad(i,k+1) = 1.-al(i,k)
        exch_hx(i,k) = xkzh(i,k)
      enddo
-    !  if(this_image()==1) write(*,*) "   1009: nr Nans in al (k): ", COUNT(ieee_is_nan(al(:,k))) ,k
-    !  if(this_image()==1) write(*,*) "   1009: nr Nans in del (k): ", COUNT(ieee_is_nan(del(:,k))) ,k
-    !  if(this_image()==1) write(*,*) "   1009: nr Nans in dsdz2 (k): ", COUNT(ieee_is_nan(dsdz2(:,k))) ,k
-
-    !  dtodsd*dsdz2
    enddo
-   
+
 !
    if(ncloud.ge.2) then
      do ic = 2,ncloud
@@ -1053,20 +1047,15 @@ contains
 !
 !     recover tendencies of heat and moisture
 !
-  ! if(this_image()==1) write(*,*) "   1049: nr Nans in f3: ", COUNT(ieee_is_nan(f3)) ! yes
-  ! if(this_image()==1) write(*,*) "   1049: nr Nans in qx: ", COUNT(ieee_is_nan(qx)) ! no
-    
    do k = kte,kts,-1
      do i = its,ite
        ttend = (f1(i,k)-thx(i,k)+300.)*rdt*pi2d(i,k)
        qtend = (f3(i,k,1)-qx(i,k))*rdt
        ttnp(i,k) = ttnp(i,k)+ttend
        qtnp(i,k) = qtnp(i,k)+qtend
-      !  if(this_image()==1) write(*,*) "   1055: qtend isNan: ", (ieee_is_nan(qtend)) ! yes
      enddo
    enddo
-  !  if(this_image()==1) write(*,*) "   1055: nr Nans in qtnp: ", COUNT(ieee_is_nan(qtnp)) 
-   
+
 !
    if(ncloud.ge.2) then
      do ic = 2,ncloud

--- a/src/physics/wind.f90
+++ b/src/physics/wind.f90
@@ -23,7 +23,7 @@ module wind
 
     implicit none
     private
-    public::update_winds, init_winds, wind_var_request
+    public::update_winds, init_winds, wind_var_request, balance_uvw
     real, parameter::deg2rad=0.017453293 !2*pi/360
 contains
 

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -1046,4 +1046,33 @@ contains
 
     END SUBROUTINE adjust_cloudFinal
 
+    !+---+-----------------------------------------------------------------+
+    !
+    !   Calculate the (Bulk?) Richardson number (for use in pbl_driver, lsm_driver)
+    !
+
+    subroutine calc_Richardson_nr(Ri,airt_3d, tskin, z_atm, wind_2d)
+        IMPLICIT NONE
+        REAL, DIMENSION(:,:), INTENT(OUT):: Ri
+        REAL, DIMENSION(:,:,:), INTENT(IN):: airt_3d
+        REAL, DIMENSION(:,:), INTENT(IN):: tskin, wind_2d, z_atm
+        ! ! Richardson number (from lsm driver)
+        ! where(wind_2d==0) wind_2d=1e-5
+        Ri = gravity/airt_3d(:,1,:) * (airt_3d(:,1,:)-tskin)*z_atm/(wind_2d**2)
+    end subroutine calc_Richardson_nr
+
+    ! elemental function calc_Richardson_nr(airt_3d, tskin, z_atm, wind_2d) result(Ri)
+    !     IMPLICIT NONE
+    !     ! REAL, DIMENSION(:,:), INTENT(INOUT):: Ri
+    !     REAL, DIMENSION(:,:,:), INTENT(IN):: airt_3d
+    !     REAL, DIMENSION(:,:), INTENT(IN):: tskin, wind_2d, z_atm
+    !     real :: Ri
+
+    !     where(wind_2d==0) wind_2d=1e-5
+
+    !     Ri = gravity/airt_3d(:,1,:) * (airt_3d(:,1,:)-tskin)*z_atm/(wind_2d**2)
+
+    ! end function
+
 end module mod_atm_utilities
+

--- a/src/utilities/atm_utilities.f90
+++ b/src/utilities/atm_utilities.f90
@@ -1061,18 +1061,6 @@ contains
         Ri = gravity/airt_3d(:,1,:) * (airt_3d(:,1,:)-tskin)*z_atm/(wind_2d**2)
     end subroutine calc_Richardson_nr
 
-    ! elemental function calc_Richardson_nr(airt_3d, tskin, z_atm, wind_2d) result(Ri)
-    !     IMPLICIT NONE
-    !     ! REAL, DIMENSION(:,:), INTENT(INOUT):: Ri
-    !     REAL, DIMENSION(:,:,:), INTENT(IN):: airt_3d
-    !     REAL, DIMENSION(:,:), INTENT(IN):: tskin, wind_2d, z_atm
-    !     real :: Ri
-
-    !     where(wind_2d==0) wind_2d=1e-5
-
-    !     Ri = gravity/airt_3d(:,1,:) * (airt_3d(:,1,:)-tskin)*z_atm/(wind_2d**2)
-
-    ! end function
 
 end module mod_atm_utilities
 

--- a/src/utilities/debug_utils.f90
+++ b/src/utilities/debug_utils.f90
@@ -30,8 +30,18 @@ contains
         call check_var(domain%graupel_number%data_3d,        name="ngrau",   msg=error_msg, less_than    =-1e-1, fix=fix_data)
         call check_var(domain%w%data_3d,                     name="w",       msg=error_msg, less_than    =-1e5,  fix=fix_data)
         call check_var(domain%w%data_3d,                     name="w",       msg=error_msg, greater_than =1e5,   fix=fix_data)
+        call check_var2d(domain%sensible_heat%data_2d,       name="hfx",     msg=error_msg) ! check for NaN's only.
+        call check_var2d(domain%latent_heat%data_2d,         name="lfx",     msg=error_msg)
+        call check_var2d(domain%skin_temperature%data_2d,    name="tskin",   msg=error_msg)
+        call check_var2d(domain%roughness_z0%data_2d,        name="z0",      msg=error_msg)
+        call check_var2d(domain%surface_pressure%data_2d,    name="psfc",    msg=error_msg)
+        ! call check_var2d(domain%ustar,                       name="ustar", msg=error_msg)
+        call check_var(domain%exner%data_3d,                 name="pii",     msg=error_msg)
+        call check_var(domain%pressure_interface%data_3d,    name="pi",      msg=error_msg)
+        call check_var(domain%pressure%data_3d,              name="p",       msg=error_msg)
 
     end subroutine domain_check
+
 
     subroutine check_var(var, name, msg, greater_than, less_than, fix)
         implicit none
@@ -116,6 +126,31 @@ contains
         endif
 
     end subroutine check_var
+
+    subroutine check_var2d(var, name, msg, greater_than, less_than, fix)
+        implicit none
+        real,               intent(inout), dimension(:,:), pointer :: var
+        character(len=*),   intent(in)                      :: name, msg
+        real,               intent(in),    optional         :: greater_than, less_than
+        logical,            intent(in),    optional         :: fix
+        integer :: n
+        real :: vmax, vmin
+        logical :: printed
+
+        printed = .False.
+
+        if (.not.associated(var)) then
+            return
+        endif
+
+        if (any(ieee_is_nan(var))) then
+            n = COUNT(ieee_is_nan(var))
+            ! ALLOCATE(IsNanIdx(n))
+            ! IsNanIdx = PACK( (/(i,i=1,SIZE(var))/), MASK=IsNan(var) )  ! if someone can get this to work it would be nice to have.
+            write(*,*) trim(msg)
+            write(*,*) trim(name)//" has", n," NaN(s) "
+        endif
+    end subroutine check_var2d
 
     ! subroutine domain_fix(domain)
     !     implicit none

--- a/src/utilities/pbl_utilities.f90
+++ b/src/utilities/pbl_utilities.f90
@@ -1,0 +1,823 @@
+! ------------------------------------------------------------------------------
+!  copied from WRF/var/da/da_physics/da_sfc_wtq.inc to support the YSU pbl scheme. 
+!  Specifically the calculation of psim, psih, which are made output vars here. 
+!
+!  Bert Kruyt 2022
+!
+! ------------------------------------------------------------------------------
+module mod_pbl_utilities
+    use icar_constants,           only : pi, gravity, Rd, Rw, cp, LH_vaporization,SVPT0
+    ! use data_structures
+    ! use domain_interface,   only : domain_t
+    ! use options_interface,  only : options_t
+
+    implicit none
+
+contains
+
+subroutine da_tp_to_qs( t, p, es, qs)
+
+    !---------------------------------------------------------------------------
+    ! Purpose: Convert T/p to saturation specific humidity.
+    !
+    !  Method: qs = es_alpha * es / ( p - ( 1 - rd_over_rv ) * es ).
+    !          use Rogers & Yau (1989) formula: es = a exp( bTc / (T_c + c) )
+    !--------------------------------------------------------------------------
+ 
+    implicit none
+ 
+    real, intent(in)  :: t, p
+    real, intent(out) :: es, qs
+    
+    real              :: t_c              ! T in degreesC.
+    real, parameter   :: es_alpha = 611.2 ! (= SVP1*1000)
+    real, parameter   :: es_beta = 17.67  ! (= SVP2 = 17.67 )
+    real, parameter   :: es_gamma = 243.5
+    real, parameter    :: rd_over_rv = Rd / Rw! gas_constant / gas_constant_v
+    real, parameter    :: rd_over_rv1 = 1.0 - rd_over_rv
+    real, parameter    :: t_kelvin =SVPT0
+    ! if (trace_use_dull) call da_trace_entry("da_tp_to_qs")
+ 
+    !---------------------------------------------------------------------------
+    ! [1.0] initialise:
+    !---------------------------------------------------------------------------
+    ! write(*,*) "t_kelvin",t_kelvin
+    ! write(*,*) "t ",t
+    t_c = t - t_kelvin
+    
+    !---------------------------------------------------------------------------
+    ! [2.0] Calculate saturation vapour pressure:
+    !---------------------------------------------------------------------------
+ 
+    es = es_alpha * exp( es_beta * t_c / ( t_c + es_gamma ) )
+     
+    !---------------------------------------------------------------------------
+    ! [3.0] Calculate saturation specific humidity:
+    !---------------------------------------------------------------------------
+ 
+    qs = rd_over_rv * es / ( p - rd_over_rv1 * es )
+ 
+    ! if (trace_use_dull) call da_trace_exit("da_tp_to_qs")
+ 
+ end subroutine da_tp_to_qs
+ 
+
+
+
+
+
+subroutine da_sfc_wtq (psfc, tg, ps, ts, qs, us, vs, &
+    hs, roughness, xland, dx, u10, v10, t2, q2, regime, psim, psih,  &
+    has_lsm, regime_wrf, qsfc_wrf, znt_wrf, ust_wrf, mol_wrf, hfx, qfx, pblh, ims, ime, jms, jme)
+ 
+    !---------------------------------------------------------------------------
+    ! Purpose: Calculate the  10m wind, 2m temperature and moisture based on the
+    ! similarity theory/
+    !
+    !  The unit for pressure   : psfc, ps          is Pa.
+    !  The unit for temperature: tg, ts, t2        is K.
+    !  The unit for moisture   : qs, q2            is kg/kg.
+    !  The unit for wind       : us, vs, u10, v10  is m/s.
+    !  The unit for height     : hs, roughness     is m.
+    !  xland and regime are dimensionless. (BK: unitless?)
+    !
+    ! History: Nov 2010 - improve calculation consistency with WRF model (Eric Chiang)
+    !          Jul 2015 - further improvement on consistency
+    !
+    ! Reference:
+    ! ---------
+    !
+    !  input Variables:
+    ! 
+    !   psfc, tg               : surface pressure and ground temperature
+    !   ps, ts, qs, us, vs, hs : model variable at lowlest half sigma level
+    !   dx  (m)                : horizontal resolution
+    !
+    !
+    !  Constants:
+    !
+    !   hs                     : height at the lowest half sigma level
+    !   roughness              : roughness
+    !   xland                  : land-water-mask (=2 water, =1 land)
+    !
+    !  output Variables:
+    !
+    !   regime                 : PBL regime
+    !   u10, v10               : 10-m high observed wind components
+    !   t2 , q2                : 2-m high observed temperature and mixing ratio
+    !
+    !---------------------------------------------------------------------------
+    !  (BK 2022 made psim and psih outputs.)
+    !                      psim  : mechanical psi at lowlest sigma level
+    !                      psim2 : mechanical psi at 2m 
+    !                      psimz : mechanical psi at 10m 
+    !
+    !---------------------------------------------------------------------------
+ 
+    implicit none
+ 
+    real, dimension( ims:ime, jms:jme ),    intent (in)  :: ps , ts , qs , us, vs
+    real, dimension( ims:ime, jms:jme ),    intent (in)  :: psfc, tg
+    real, dimension( ims:ime, jms:jme ),    intent (in)  :: hs, roughness , xland
+    ! integer, dimension(:,:), intent(in) :: xland
+    real, dimension( ims:ime, jms:jme ),    intent (out) :: regime
+    real, dimension( ims:ime, jms:jme ),    intent (out) :: psim, psih
+    real, dimension( ims:ime, jms:jme ),    intent (out) :: u10, v10, t2, q2
+    logical,                        intent(in), optional :: has_lsm
+    real,                           intent(in), optional :: regime_wrf, qsfc_wrf, znt_wrf,  mol_wrf
+    real,                           intent(in), optional ::  pblh
+    real,    dimension( ims:ime, jms:jme ), intent(in), optional :: hfx, qfx, ust_wrf
+    integer,                                 intent(in) :: ims, ime, jms, jme
+ 
+    ! logical :: use_table = .true.
+    logical :: use_ust_wrf = .false.
+    logical :: vconv_wrf
+    integer :: nn, nz, n2, i, j
+    real    :: rr, rz, r2
+    real    :: cqs2, chs2, rho, rhox, fluxc, visc, restar, z0t, z0q
+ 
+    ! h10 is the height of 10m where the wind observed
+    ! h2  is the height of 2m where the temperature and 
+    !        moisture observed.
+ 
+    real, parameter :: h10 = 10.0, h2 = 2.0
+    
+    ! Default roughness over the land
+ 
+    real, parameter :: zint0 = 0.01 
+    
+    ! Von Karman constant
+ 
+    real, parameter :: k_kar = 0.4
+    
+    ! Working variables
+ 
+    real :: Vc2, Va2, V2, vc, wspd
+    real :: rib, rcp, xx, yy, cc
+    real :: psiw, psiz, mol, ust, hol, holz, hol2
+    real :: psimz, psim2, psihz, psih2  !psim, psih, ! BK 2022 now output vars for YSU
+    real :: psit, psit2, psiq, psiq2
+    real :: gzsoz0, gz10oz0, gz2oz0
+    real :: eg, qg, tvg, tvs, tvs2
+    real :: ths, thg, thvs, thvg, thvs2, vsgd, vsgd2, dx
+    real :: zq0, z0, gas_constant
+
+    real, parameter :: ka = 2.4E-5
+
+    ! if (trace_use_dull) call da_trace_entry("da_sfc_wtq")
+    gas_constant=Rd
+    rcp = gas_constant/cp
+
+
+    do j=jms,jme ! BK added these loops to make 2d
+        do i=ims,ime
+
+            ! 1 Compute the roughness length based upon season and land use 
+        
+            ! 1.1 Define the roughness length
+        
+            z0 = roughness(i,j)
+        
+            if (z0 < 0.0001) z0 = 0.0001
+        
+            if ( present(znt_wrf) ) then
+            if ( znt_wrf > 0.0 ) then
+                z0 = znt_wrf
+            end if
+            end if
+        
+            ! 1.2 Define the rouhgness length for moisture
+        
+            if (xland(i,j) .ge. 1.5) then
+            zq0 = z0
+            else
+            zq0 =  zint0
+            end if
+        
+            ! 1.3 Define the some constant variable for psi
+        
+            gzsoz0 = log(hs(i,j)/z0)
+        
+            gz10oz0 = log(h10/z0)
+        
+            gz2oz0 = log(h2/z0)
+        
+        
+            ! 2. Calculate the virtual temperature
+        
+            ! 2.1 Compute Virtual temperature on the lowest half sigma level
+        
+            tvs  = ts(i,j) * (1.0 + 0.608 * qs(i,j))
+        
+            ! 2.2 Convert ground virtual temperature assuming it's saturated
+            ! write(*,*)"tg(i,j)", tg(i,j)
+
+            call da_tp_to_qs(tg(i,j), psfc(i,j), eg, qg) !output qg is specific humidity
+            qg = qg*(1.0-qg) !hcl convert to mixing ratio
+            if ( present(qsfc_wrf) ) then
+            if ( qsfc_wrf > 0.0 ) then
+                qg = qsfc_wrf
+            end if
+            endif
+        
+            tvg  = tg(i,j) * (1.0 + 0.608 * qg)
+        
+            ! 3.  Compute the potential temperature
+        
+            ! 3.1 Potential temperature on the lowest half sigma level
+        
+            ths  = ts(i,j) * (1000.0 / (ps(i,j)/100.0)) ** rcp
+        
+            ! 3.2 Potential temperature at the ground
+        
+            thg  = tg(i,j) * (1000.0 / (psfc(i,j)/100.0)) ** rcp
+        
+            ! 4. Virtual potential temperature
+        
+            ! 4.1 Virtual potential temperature on the lowest half sigma level
+        
+            thvs = tvs * (1000.0 / (ps(i,j)/100.0)) ** rcp
+        
+            ! 4.2 Virtual potential temperature at ground
+        
+            thvg = tvg * (1000.0 / (psfc(i,j)/100.0)) ** rcp
+        
+        
+            ! 5.  BULK RICHARDSON NUMBER AND MONI-OBUKOV LENGTH
+        
+            ! 5.1 Velocity
+            
+            !     Wind speed:
+        
+            Va2 =   us(i,j)*us(i,j) + vs(i,j)*vs(i,j)
+            !  
+            !     Convective velocity:
+        
+            vconv_wrf = .false.
+            if ( present(hfx) .and. present(qfx) .and. present(pblh) ) then
+            ! calculating vconv over land following wrf method
+            if ( pblh > 0.0 ) then
+                vconv_wrf = .true.
+            end if
+            end if
+        
+            if (thvg >= thvs) then
+            ! prior to V3.7, Vc2 = 4.0 * (thvg - thvs)
+            Vc2 = thvg - thvs
+            else
+            Vc2 = 0.0
+            end if
+            if ( xland(i,j) < 1.5 ) then !land
+            if ( vconv_wrf ) then
+                ! following the calculation as in module_sf_sfclay.F
+                rhox = psfc(i,j)/(gas_constant*tvg)
+                fluxc = max(hfx(i,j)/rhox/cp+0.608*tvg*qfx(i,j)/rhox, 0.0)
+                vc = (gravity/tg(i,j)*pblh*fluxc)**0.33
+                vc2 = vc*vc
+            end if
+            end if
+        
+            ! Calculate Mahrt and Sun low-res correction         ! Add by Eric Chiang ( July 2010 )
+            vsgd = 0.32 * (max(dx/5000.-1.,0.))**0.33            ! Add by Eric Chiang ( July 2010 )
+            vsgd2 = vsgd * vsgd                                  ! Add by Eric Chiang ( July 2010 )
+            
+            V2  = Va2 + Vc2 + vsgd2                              ! Add by Eric Chiang ( July 2010 )  
+            wspd = sqrt(v2)
+            wspd = max(wspd,0.1)
+            v2 = wspd*wspd
+        
+            ! 5.2 Bulk richardson number
+        
+            rib = (gravity * hs(i,j) / ths) * (thvs - thvg) / V2
+        
+            ! if previously unstable, do not let into regime 1 and 2
+            if ( present(mol_wrf) ) then
+            if ( mol_wrf < 0.0 ) rib = min(rib, 0.0)
+            end if
+        
+            !  Calculate   ust, m/L (mol), h/L (hol)
+        
+            psim(i,j) = 0.0
+            psih(i,j) = 0.0
+        
+            ! Friction speed
+        
+            if ( present(ust_wrf) ) then
+            if ( ust_wrf(i,j) > 0.0 ) then
+                use_ust_wrf = .true.
+                ust = ust_wrf(i,j)
+            end if
+            end if
+            if ( .not. use_ust_wrf ) then
+            !ust = 0.0001  !init value as in phys/module_physics_init.F
+            ust = k_kar * sqrt(v2) /(gzsoz0 - psim(i,j))
+            end if
+        
+            ! Heat flux factor
+        
+            if ( present(mol_wrf) ) then
+            mol = mol_wrf
+            else
+            mol = k_kar * (ths - thg)/(gzsoz0 - psih(i,j))
+            !mol = 0.0
+            end if
+        
+            ! set regimes based on rib
+            if (rib .GE. 0.2) then
+            ! Stable conditions (REGIME 1)
+            regime(i,j) = 1.1
+            else if ((rib .LT. 0.2) .AND. (rib .GT. 0.0)) then
+            ! Mechanically driven turbulence (REGIME 2)
+            regime(i,j) = 2.1
+            else if (rib .EQ. 0.0) then
+            ! Unstable Forced convection (REGIME 3)
+            regime(i,j) = 3.1
+            else 
+            ! Free convection (REGIME 4)
+            regime(i,j) = 4.1
+            end if
+        
+            if ( present(regime_wrf) ) then
+            if ( regime_wrf > 0.0 ) then
+                regime(i,j) = regime_wrf
+            end if
+            end if
+        
+            ! 6.  CALCULATE PSI BASED UPON REGIME
+        
+            !if (rib .GE. 0.2) then
+            if ( nint(regime(i,j)) == 1 ) then
+            ! 6.1 Stable conditions (regime(i,j) 1)
+            !     ---------------------------
+            regime(i,j) = 1.1
+            psim(i,j) = -10.0*gzsoz0
+            psim(i,j) = max(psim(i,j),-10.0)
+            psimz = h10/hs(i,j) * psim(i,j)
+            psimz = max(psimz,-10.0)
+            psim2 = h2 /hs(i,j) * psim(i,j)
+            psim2 = max(psim2,-10.0)
+            psih(i,j) = psim(i,j)
+            psihz = psimz
+            psih2 = psim2
+        
+            !else if ((rib .LT. 0.2) .AND. (rib .GT. 0.0)) then
+            else if ( nint(regime(i,j)) == 2 ) then
+        
+            ! 6.2 Mechanically driven turbulence (regime(i,j) 2)
+        
+            regime(i,j) = 2.1
+            psim(i,j) = (-5.0 * rib) * gzsoz0 / (1.1 - 5.0*rib)
+            psim(i,j) = max(psim(i,j),-10.0)
+            psimz = h10/hs(i,j) * psim(i,j)
+            psimz = max(psimz,-10.0)
+            psim2 = h2 /hs(i,j) * psim(i,j)
+            psim2 = max(psim2,-10.0)
+            psih(i,j) = psim(i,j)
+            psihz = psimz
+            psih2 = psim2
+        
+            !else if (rib .EQ. 0.0) then
+            else if ( nint(regime(i,j)) == 3 ) then
+            ! 6.3 Unstable Forced convection (regime(i,j) 3)
+        
+            regime(i,j) = 3.1
+            psim(i,j) = 0.0
+            psimz = 0.0
+            psim2 = 0.0
+            psih(i,j) = psim(i,j)
+            psihz = psimz
+            psih2 = psim2
+        
+            else 
+            ! 6.4 Free convection (regime(i,j) 4)
+            regime(i,j) = 4.1
+        
+            cc = 2.0 * atan(1.0)
+        
+            ! Ratio of PBL height to Monin-Obukhov length
+        
+            if (ust .LT. 0.01) then
+                hol = rib * gzsoz0
+            else
+                hol = k_kar * gravity * hs(i,j) * mol / (ths * ust * ust)
+            end if
+        
+            ! 6.4.2  Calculate n, nz, R, Rz
+        
+            holz = (h10 / hs(i,j)) * hol
+            hol2 = (h2 / hs(i,j)) * hol
+        
+            hol = min(hol,0.0)
+            hol = max(hol,-9.9999)
+        
+            holz = min(holz,0.0)
+            holz = max(holz,-9.9999)
+        
+            hol2 = min(hol2,0.0)
+            hol2 = max(hol2,-9.9999)
+        
+            ! 6.4.3 Calculate Psim & psih(i,j)
+        
+            !    if ( use_table ) then
+            !       ! Using the look-up table:
+            !       nn = int(-100.0 * hol)
+            !       rr = (-100.0 * hol) - nn
+            !       psim = psimtb(nn) + rr * (psimtb(nn+1) - psimtb(nn))
+            !       psih(i,j) = psihtb(nn) + rr * (psihtb(nn+1) - psihtb(nn))
+            !    else
+                ! Using the continuous function:
+                xx = (1.0 - 16.0 * hol) ** 0.25
+                yy = log((1.0+xx*xx)/2.0)
+                psim(i,j) = 2.0 * log((1.0+xx)/2.0) + yy - 2.0 * atan(xx) + cc
+                psih(i,j) = 2.0 * yy
+            !    end if
+        
+            !    if ( use_table ) then
+            !       ! Using the look-up table:
+            !       nz = int(-100.0 * holz)
+            !       rz = (-100.0 * holz) - nz
+            !       psimz = psimtb(nz) + rz * (psimtb(nz+1) - psimtb(nz))
+            !       psihz = psihtb(nz) + rz * (psihtb(nz+1) - psihtb(nz))
+            !    else
+                ! Using the continuous function:
+                xx = (1.0 - 16.0 * holz) ** 0.25
+                yy = log((1.0+xx*xx)/2.0)
+                psimz = 2.0 * log((1.0+xx)/2.0) + yy - 2.0 * atan(xx) + cc
+                psihz = 2.0 * yy
+            !    end if
+        
+            !    if ( use_table ) then
+            !       ! Using the look-up table:
+            !       n2 = int(-100.0 * hol2)
+            !       r2 = (-100.0 * hol2) - n2
+            !       psim2 = psimtb(n2) + r2 * (psimtb(n2+1) - psimtb(n2))
+            !       psih2 = psihtb(n2) + r2 * (psihtb(n2+1) - psihtb(n2))
+            !    else
+                ! Using the continuous function:
+                xx = (1.0 - 16.0 * hol2) ** 0.25
+                yy = log((1.0+xx*xx)/2.0)
+                psim2 = 2.0 * log((1.0+xx)/2.0) + yy - 2.0 * atan(xx) + cc
+                psih2 = 2.0 * yy
+            !    end if
+        
+            ! 6.4.4 Define the limit value for psim & psih(i,j)
+        
+            psim(i,j) = min(psim(i,j),0.9*gzsoz0)
+            psimz = min(psimz,0.9*gz10oz0)
+            psim2 = min(psim2,0.9*gz2oz0)
+            psih(i,j) = min(psih(i,j),0.9*gzsoz0)
+            psihz = min(psihz,0.9*gz10oz0)
+            psih2 = min(psih2,0.9*gz2oz0)
+            end if  ! regime(i,j)
+        
+            ! 7.  Calculate psi for wind, temperature and moisture
+        
+            psiw = gzsoz0 - psim(i,j)
+            psiz = gz10oz0 - psimz
+            psit = max(gzsoz0-psih(i,j), 2.0)
+            psit2 = gz2oz0 - psih2
+        
+            if ( .not. use_ust_wrf ) then
+            ! re-calculate ust since psim(i,j) is now available
+            ust = k_kar * sqrt(v2) /(gzsoz0 - psim(i,j))
+            end if
+        
+            psiq  = log(k_kar*ust*hs(i,j)/ka + hs(i,j) / zq0) - psih(i,j)
+            psiq2 = log(k_kar*ust*h2/ka + h2 / zq0) - psih2
+        
+            !V3.7, as in module_sf_sfclay.F
+            if ( xland(i,j) >= 1.5 ) then !water
+            visc = (1.32+0.009*(ts(i,j)-273.15))*1.e-5
+            restar = ust*z0/visc
+            z0t = (5.5e-5)*(restar**(-0.60))
+            z0t = min(z0t,1.0e-4)
+            z0t = max(z0t,2.0e-9)
+            z0q = z0t
+            psiq  = max(log((hs(i,j)+z0q)/z0q)-psih(i,j),  2.)
+            psit  = max(log((hs(i,j)+z0t)/z0t)-psih(i,j),  2.)
+            psiq2 = max(log((2.+z0q)/z0q)-psih2, 2.)
+            psit2 = max(log((2.+z0t)/z0t)-psih2, 2.)
+            end if
+        
+            ! 8.  Calculate 10m wind, 2m temperature and moisture
+        
+            u10(i,j) = us(i,j) * psiz / psiw
+            v10(i,j) = vs(i,j) * psiz / psiw
+            t2(i,j) = (thg + (ths - thg)*psit2/psit)*((psfc(i,j)/100.0)/1000.0)**rcp
+            q2(i,j) = qg + (qs(i,j) - qg)*psiq2/psiq 
+        
+            if ( present(has_lsm) ) then
+            if ( has_lsm ) then
+                !cqs2: 2m surface exchange coefficient for moisture
+                !chs2: 2m surface exchange coefficient for heat
+                cqs2 = ust*k_kar/psiq2
+                if (xland(i,j) .ge. 1.5) then
+                    !water
+                    chs2 = ust*k_kar/psit2
+                else
+                    !land
+                    chs2 = cqs2 !as in subroutine lsm in phys/module_sf_noahdrv.F
+                end if
+
+                !re-calculate T2/Q2 as in module_sf_sfcdiags.F
+                rho  = psfc(i,j)/(gas_constant*tg(i,j))
+                if ( cqs2 < 1.e-5 ) then
+                    q2(i,j) = qg
+                else
+                    if ( present(qfx) ) then
+                        q2(i,j) = qg - qfx(i,j)/(rho*cqs2)
+                    end if
+                end if
+                if ( chs2 < 1.e-5 ) then
+                    t2(i,j) = tg(i,j)
+                else
+                    if ( present(hfx) ) then
+                        t2(i,j) = tg(i,j) - hfx(i,j)/(rho*cp*chs2)
+                    end if
+                end if
+            end if
+            end if
+
+    ! if (trace_use_dull) call da_trace_exit("da_sfc_wtq")
+        enddo
+    enddo
+    end subroutine da_sfc_wtq
+
+
+    ! !--------------------------------------------------------
+    ! !
+    ! ! from old ICAR model (v1) - currently notused
+    ! !
+    ! !--------------------------------------------------------
+
+    ! subroutine calc_surface_stuff
+    !             ! ----- start surface layer calculations usually done by surface layer scheme ----- !
+    !     write(*,*) "start surface layer calculations"
+    !     if (options%physics%boundarylayer==kPBL_SIMPLE) then
+    !         write(*,*) "calculate surface layer based on log wind profile"
+    !         ! ! temporary constant
+    !         ! ! use log-law of the wall to convert from first model level to surface
+    !         ! currw = karman / log((domain%z(2:nx-1,1,2:ny-1)-domain%terrain(2:nx-1,2:ny-1)) &
+    !         !         / domain%znt(2:nx-1,2:ny-1))
+    !         ! ! use log-law of the wall to convert from surface to 10m height
+    !         ! lastw = log(10.0 / domain%znt(2:nx-1,2:ny-1)) / karman
+    !         ! domain%ustar(2:nx-1,2:ny-1) = domain%Um(2:nx-1,1,2:ny-1) * currw
+    !         ! domain%u10(2:nx-1,2:ny-1) = domain%ustar(2:nx-1,2:ny-1) * lastw
+    !         ! domain%ustar(2:nx-1,2:ny-1) = domain%Vm(2:nx-1,1,2:ny-1) * currw
+    !         ! domain%v10(2:nx-1,2:ny-1) = domain%ustar(2:nx-1,2:ny-1) * lastw
+        
+    !         ! ! now calculate master ustar based on U and V combined in quadrature
+    !         ! domain%ustar(2:nx-1,2:ny-1) = sqrt(domain%Um(2:nx-1,1,2:ny-1)**2 & 
+    !         !                             + domain%Vm(2:nx-1,1,2:ny-1)**2) * currw
+    !         ! ! counter is just a variable helping me to detect how much rounds
+    !         ! ! this subroutine went through
+    !         ! write(*,*) "Counter: ", counter
+    !         ! counter = counter + 1
+    !         ! write(*,*) "Counter: ", counter
+    !     elseif (options%physics%boundarylayer==kPBL_YSU) then
+    !         ! start surface layer calculations introduced by Patrik Bohlinger
+    !         write(*,*) "calculate surface layer based on monin-obukhov similarity theory"
+
+    !         ! ----- start temporary solution ----- !
+    !         ! use log-law of the wall to convert from first model level to surface
+    !         currw = karman / log((domain%z(2:nx-1,1,2:ny-1)-domain%terrain(2:nx-1,2:ny-1)) &
+    !                / domain%znt(2:nx-1,2:ny-1))
+    !         ! use log-law of the wall to convert from surface to 10m height
+    !         lastw = log(10.0 / domain%znt(2:nx-1,2:ny-1)) / karman
+    !         ! calculate ustar = horizontal wind speed scale
+    !         if (counter==1) then
+    !             domain%ustar_new(2:nx-1,2:ny-1) = domain%ustar(2:nx-1,2:ny-1)
+    !         endif
+    !         ! preventing ustar from being smaller than 0.1 as it could be under
+    !         ! very stable conditions, Jiminez et al. 2012
+    !         where(domain%ustar_new(2:nx-1,2:ny-1) < 0.1)
+    !             domain%ustar_new(2:nx-1,2:ny-1) = 0.1
+    !         endwhere
+    !         !domain%ustar(2:nx-1,2:ny-1) = domain%Um(2:nx-1,1,2:ny-1) * currw
+    !         domain%u10(2:nx-1,2:ny-1) = domain%ustar_new(2:nx-1,2:ny-1) * lastw
+    !         domain%ustar(2:nx-1,2:ny-1) = domain%Vm(2:nx-1,1,2:ny-1) * currw
+    !         domain%v10(2:nx-1,2:ny-1) = domain%ustar_new(2:nx-1,2:ny-1) * lastw
+    !         !now calculate master ustar based on U and V combined in quadrature
+    !         domain%wspd3d(2:nx-1,1:nz,2:ny-1) = sqrt(domain%Um(2:nx-1,1:nz,2:ny-1)**2 & 
+    !                                             + domain%Vm(2:nx-1,1:nz,2:ny-1)**2) 
+    !         ! added by Patrik Bohlinger in case we need this later for YSU (some variables seem to 
+    !         ! be 3D in articles like the YSU paper Hong et al. 2006)
+    !         domain%wspd(2:nx-1,2:ny-1) = sqrt(domain%Um(2:nx-1,1,2:ny-1)**2 & 
+    !                                    + domain%Vm(2:nx-1,1,2:ny-1)**2) 
+    !         ! added by Patrik Bohlinger since we need this as input for YSU
+    !          domain%ustar(2:nx-1,2:ny-1) = domain%wspd(2:nx-1,2:ny-1) * currw
+    !         ! ----- end temporary solution ----- !
+
+    !         ! compute z above ground used for estimating indices for 
+    !         domain%z_agl(2:nx-1,2:ny-1) = (domain%z(2:nx-1,1,2:ny-1)-domain%terrain(2:nx-1,2:ny-1)) 
+    !         !added by Patrik in case we need this later for YSU
+    !         ! calculate the Bulk-Richardson number Rib
+    !         domain%thv(2:nx-1,2:ny-1) = domain%th(2:nx-1,1,2:ny-1) & 
+    !                                     *(1+0.608*domain%qv(2:nx-1,1,2:ny-1)*1000)    
+    !         ! should domain%qv be multiplied by 1000? Did it since domain%qv is in kg/kg and not in g/kg 
+    !         ! normally should be specific humidity and not mixing ratio domain%qv but for first order approach does not matter
+    !         domain%thv3d(2:nx-1,1:nz,2:ny-1) = domain%th(2:nx-1,1:nz,2:ny-1) & 
+    !                                            * (1+0.608*domain%qv(2:nx-1,1:nz,2:ny-1)*1000)   !thv 3D
+    !         domain%thvg(2:nx-1,2:ny-1) = (domain%t2m(2:nx-1,2:ny-1)/domain%pii(2:nx-1,1,2:ny-1)) &
+    !                                      *(1+0.608*domain%qv(2:nx-1,1,2:ny-1)*1000)
+    !         ! t2m should rather be used than skin_t
+    !         domain%thg(2:nx-1,2:ny-1) = domain%t2m(2:nx-1,2:ny-1)/domain%pii(2:nx-1,1,2:ny-1) 
+    !         ! t2m should rather be used than skin_t
+
+    !         ! variables described for YSU but probably not needed to be calculated outside of the scheme:
+    !         !domain%wstar(2:nx-1,2:ny-1) = domain%ustar(2:nx-1,2:ny-1) / domain%psim(2:nx-1,2:ny-1) ! wstar = vertical wind speed scale
+    !         !domain%thT(2:nx-1,2:ny-1) = propfact * (virtual heat flux)/ domain%wstar ! virtual temperature excess
+    !         !domain%thvg(2:nx-1,2:ny-1) = domain%thv(2:nx-1,2:ny-1) ! for init thvg=thv since thT = 0, 
+    !         !t2m should rather be used than skin_t, b=proportionality factor=7.8, Hong et al, 2006
+
+    !         ! find value of pbl heights for wspd3d
+    !         !domain%PBLh(2:nx-1,2:ny-1) = Rib_cr * domain%thv(2:nx-1,2:ny-1) * domain%wspd(2:nx-1,2:ny-1)**2 & 
+    !         !                             / gravity * (domain%thv(2:nx-1,2:ny-1) - domain%thvg(2:nx-1,2:ny-1)) !U^2 and thv are from height PBLh in equation
+
+    !         !write(*,*) "max min domain%pbl_height: ", maxval(domain%pbl_height), minval(domain%pbl_height)
+    !         !write(*,*) "max min domain%PBLh: ", maxval(domain%PBLh), minval(domain%PBLh) ! introduced the 
+    !         !PBLh variabel to not overwrite pbl_height and compare new with old calculations as the pbl 
+    !         !height is one of the most crucial factors of the non-local surface layer calculations needed by the YSU-scheme
+
+    !         ! Constraint to prevent Rib from becoming too high a lower limit of 0.1 is
+    !         ! applied in for the original surface layer formulation Jiminez et al 2012
+    !         where(domain%wspd(2:nx-1,2:ny-1) < 0.1)
+    !             domain%wspd(2:nx-1,2:ny-1) = 0.1
+    !         endwhere
+
+    !         domain%Rib(2:nx-1,2:ny-1) = gravity/domain%th(2:nx-1,1,2:ny-1) * domain%z_agl(2:nx-1,2:ny-1) &
+    !                                     * (domain%thv(2:nx-1,2:ny-1) - domain%thvg(2:nx-1,2:ny-1)) &
+    !                                     / domain%wspd(2:nx-1,2:ny-1)**2
+    !         ! From Jiminez et al. 2012, from what height should the theta variables really be, Rib is a function of height? To my understanding the appropriate height is the lower most level.
+
+    !         ! calculate the integrated similarity functions
+    !         where(domain%Rib(2:nx-1,2:ny-1) >= 0.2)
+    !             !regime = 1, very stable night time conditions
+    !             domain%psim(2:nx-1,2:ny-1) = -10*log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !             domain%psim10(2:nx-1,2:ny-1) = -10*log(10/domain%znt(2:nx-1,2:ny-1))
+    !             domain%psim2m(2:nx-1,2:ny-1) = -10*log(2/domain%znt(2:nx-1,2:ny-1))
+    !             domain%psih(2:nx-1,2:ny-1) = domain%psim(2:nx-1,2:ny-1)
+    !             domain%psih2m(2:nx-1,2:ny-1) = domain%psim2m(2:nx-1,2:ny-1)
+    !             !impose constraints
+    !             where (domain%Rib(2:nx-1,2:ny-1) >= 0.2 .and. domain%psim(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) >= 0.2 .and. domain%psih(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psih(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) >= 0.2 .and. domain%psim10(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim10(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) >= 0.2 .and. domain%psih2m(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psih2m(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) >= 0.2 .and. domain%psim2m(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim2m(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !         elsewhere (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. domain%Rib(2:nx-1,2:ny-1) > 0.0)
+    !             !regime = 2, damped mechanical turbulence
+    !             domain%psim(2:nx-1,2:ny-1) = -5*domain%Rib(2:nx-1,2:ny-1)*log(domain%z_agl(2:nx-1,2:ny-1) & 
+    !                                          /domain%znt(2:nx-1,2:ny-1))/(1.1-5*domain%Rib(2:nx-1,2:ny-1))
+    !             domain%psim10(2:nx-1,2:ny-1) = -5*domain%Rib(2:nx-1,2:ny-1)*log(10/domain%znt(2:nx-1,2:ny-1)) &
+    !                                          /(1.1-5*domain%Rib(2:nx-1,2:ny-1)) ! Should maybe compute Rib at 10m as well?
+    !             domain%psim2m(2:nx-1,2:ny-1) = -5*domain%Rib(2:nx-1,2:ny-1)*log(2/domain%znt(2:nx-1,2:ny-1)) &
+    !                                          /(1.1-5*domain%Rib(2:nx-1,2:ny-1)) ! Should maybe compute Rib at 2m as well?
+    !             domain%psih(2:nx-1,2:ny-1) = domain%psim(2:nx-1,2:ny-1)
+    !             domain%psih2m(2:nx-1,2:ny-1) = domain%psim2m(2:nx-1,2:ny-1)
+    !             !impose constraints
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. &
+    !                     domain%Rib(2:nx-1,2:ny-1) > 0.0 .and. &
+    !                     domain%psim(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. &
+    !                     domain%Rib(2:nx-1,2:ny-1) > 0.0 .and. &
+    !                     domain%psih(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psih(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. &
+    !                     domain%Rib(2:nx-1,2:ny-1) > 0.0 .and. &
+    !                     domain%psim10(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim10(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. &
+    !                     domain%Rib(2:nx-1,2:ny-1) > 0.0 .and. &
+    !                     domain%psih2m(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psih2m(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0.2 .and. &
+    !                     domain%Rib(2:nx-1,2:ny-1) > 0.0 .and. &
+    !                     domain%psim2m(2:nx-1,2:ny-1) < -10.)
+    !                 domain%psim2m(2:nx-1,2:ny-1) = -10.
+    !             endwhere
+    !         elsewhere (domain%Rib(2:nx-1,2:ny-1).eq.0.0)
+    !             !regime = 3, forced convection
+    !             domain%psim(2:nx-1,2:ny-1) = 0.0
+    !             domain%psim10(2:nx-1,2:ny-1) = 0.0
+    !             domain%psih(2:nx-1,2:ny-1) = 0.0
+    !             domain%psih2m(2:nx-1,2:ny-1) = 0.0
+    !         elsewhere (domain%Rib(2:nx-1,2:ny-1) < 0)
+    !             !regime = 4, free convection
+    !             ! constraints
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol(2:nx-1,2:ny-1) < -9.9999)
+    !                 domain%zol(2:nx-1,2:ny-1) = -9.9999
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol(2:nx-1,2:ny-1) > 0.)
+    !                 domain%zol(2:nx-1,2:ny-1) = 0.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol10(2:nx-1,2:ny-1) < -9.9999)
+    !                 domain%zol10(2:nx-1,2:ny-1) = -9.9999
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol10(2:nx-1,2:ny-1) > 0.)
+    !                 domain%zol10(2:nx-1,2:ny-1) = 0.
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol2m(2:nx-1,2:ny-1) < -9.9999)
+    !                 domain%zol2m(2:nx-1,2:ny-1) = -9.9999              
+    !             endwhere
+    !             where (domain%Rib(2:nx-1,2:ny-1) < 0. .and. domain%zol2m(2:nx-1,2:ny-1) > 0.)
+    !                 domain%zol2m(2:nx-1,2:ny-1) = 0.
+    !             endwhere
+    !             domain%psix(2:nx-1,2:ny-1) = (1.-16.*(domain%zol(2:nx-1,2:ny-1)))**0.25
+    !             domain%psix10(2:nx-1,2:ny-1) = (1.-16.*(domain%zol10(2:nx-1,2:ny-1)))**0.25
+    !             domain%psix2m(2:nx-1,2:ny-1) = (1.-16.*(domain%zol2m(2:nx-1,2:ny-1)))**0.25
+    !             domain%psim(2:nx-1,2:ny-1) = 2.*log((1.+domain%psix(2:nx-1,2:ny-1))/2.) & 
+    !                                          + log((1.+domain%psix(2:nx-1,2:ny-1)**2.)/2.) &
+    !                                          - 2.*atan(domain%psix(2:nx-1,2:ny-1))+pi/2.
+    !             domain%psim10(2:nx-1,2:ny-1) = 2.*log((1.+domain%psix10(2:nx-1,2:ny-1))/2.) &
+    !                                          + log((1.+domain%psix10(2:nx-1,2:ny-1)**2.)/2.) &
+    !                                          - 2.*atan(domain%psix10(2:nx-1,2:ny-1))+pi/2.
+    !             domain%psih(2:nx-1,2:ny-1) = 2.*log((1.+domain%psix(2:nx-1,2:ny-1)**2.)/2.)
+    !             domain%psih2m(2:nx-1,2:ny-1) = 2.*log((1.+domain%psix2m(2:nx-1,2:ny-1)**2.)/2.)
+    !         endwhere
+    !         ! constrain psim and psih also for 2m and 10m
+    !         where (domain%psim(2:nx-1,2:ny-1) > 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)))
+    !             domain%psim(2:nx-1,2:ny-1) = 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         endwhere
+    !         where (domain%psim2m(2:nx-1,2:ny-1) > 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)))
+    !             domain%psim2m(2:nx-1,2:ny-1) = 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         endwhere
+    !         where (domain%psim10(2:nx-1,2:ny-1) > 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)))
+    !             domain%psim10(2:nx-1,2:ny-1) = 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         endwhere
+    !         where (domain%psih(2:nx-1,2:ny-1) > 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)))
+    !             domain%psih(2:nx-1,2:ny-1) = 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         endwhere
+    !         where (domain%psih2m(2:nx-1,2:ny-1) > 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)))
+    !             domain%psih2m(2:nx-1,2:ny-1) = 0.9 * log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         endwhere
+
+    !         ! calculate thstar = temperature scale
+    !         domain%thstar(2:nx-1,2:ny-1) = karman*(domain%th(2:nx-1,1,2:ny-1)-domain%thg) &
+    !                                        / log(domain%z_agl(2:nx-1,2:ny-1) & 
+    !                                        / domain%znt(2:nx-1,2:ny-1))-domain%psih(2:nx-1,2:ny-1)
+    !         ! Averaging ustar with ustar from previous time step to suppress
+    !         ! large oscillations
+    !         domain%ustar_tmp(2:nx-1,2:ny-1) = karman*domain%wspd(2:nx-1,2:ny-1)/(log(domain%z_agl(2:nx-1,2:ny-1) & 
+    !                                           / domain%znt(2:nx-1,2:ny-1))-domain%psim(2:nx-1,2:ny-1))
+    !         domain%ustar_new(2:nx-1,2:ny-1) = (domain%ustar_tmp(2:nx-1,2:ny-1) + domain%ustar_new(2:nx-1,2:ny-1))/2.0
+    !         ! preventing ustar from being smaller than 0.1 as it could be under
+    !         ! very stable conditions, Jiminez et al. 2012
+    !         where(domain%ustar_new(2:nx-1,2:ny-1) < 0.1)
+    !             domain%ustar_new(2:nx-1,2:ny-1) = 0.1
+    !         endwhere
+    !         ! calculate the Monin-Obukhov  stability parameter zol (z over l)
+    !         ! using ustar from the similarity theory
+    !         domain%zol(2:nx-1,2:ny-1) = (karman*gravity*domain%z_agl(2:nx-1,2:ny-1))/domain%th(2:nx-1,1,2:ny-1) &
+    !                                     * domain%thstar(2:nx-1,2:ny-1)/(domain%ustar_new(2:nx-1,2:ny-1) &
+    !                                     * domain%ustar_new(2:nx-1,2:ny-1))
+    !         domain%zol10(2:nx-1,2:ny-1) = (karman*gravity*10)/domain%th(2:nx-1,1,2:ny-1) * domain%thstar(2:nx-1,2:ny-1) &
+    !                                     / (domain%ustar_new(2:nx-1,2:ny-1)*domain%ustar_new(2:nx-1,2:ny-1))
+    !         domain%zol2m(2:nx-1,2:ny-1) = (karman*gravity*2)/domain%th(2:nx-1,1,2:ny-1) * domain%thstar(2:nx-1,2:ny-1) &
+    !                                     / (domain%ustar_new(2:nx-1,2:ny-1)*domain%ustar_new(2:nx-1,2:ny-1))
+    !         ! calculate pblh over l using ustar and thstar from the similarity theory
+    !         domain%hol(2:nx-1,2:ny-1) = (karman*gravity*domain%PBLh(2:nx-1,2:ny-1))/domain%th(2:nx-1,1,2:ny-1) &
+    !                                     * domain%thstar(2:nx-1,2:ny-1)/(domain%ustar_new(2:nx-1,2:ny-1) &
+    !                                     * domain%ustar_new(2:nx-1,2:ny-1))
+    !         ! arbitrary variables
+    !         domain%gz1oz0(2:nx-1,2:ny-1)=log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))
+    !         ! calculating dtmin
+    !         domain%dtmin = domain%dt / 60.0
+    !         ! p_top as a scalar, choosing just minimum from ptop as a start
+    !         p_top = minval(domain%ptop)
+    !         ! compute the dimensionless bulk coefficent for momentum, heat and
+    !         ! moisture
+    !         !domain%exch_m(2:nx-1,2:ny-1) = (karman**2)/(log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)) &
+    !         !- domain%psim(2:nx-1,2:ny-1))**2
+    !         !domain%exch_h(2:nx-1,2:ny-1) = (karman**2)/((log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))&
+    !         !- domain%psim(2:nx-1,2:ny-1))*(log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1))-domain%psih(2:nx-1,2:ny-1)))
+    !         !domain%exch_q(2:nx-1,2:ny-1) = (karman**2)/((log(domain%z_agl(2:nx-1,2:ny-1)/domain%znt(2:nx-1,2:ny-1)) &
+    !         !- domain%psim(2:nx-1,2:ny-1)) * (log(domain%rho(2:nx-1,1,2:ny-1)*cp*karman*domain%ustar_new(2:nx-1,2:ny-1) &
+    !         !*domain%z_agl(2:nx-1,2:ny-1)/cs)-psih(2:nx-1,2:ny-1)))
+
+    !         ! counter is just a variable helping me to detect how much rounds this subroutine went through
+    !         write(*,*) "Counter: ", counter
+    !         counter = counter + 1
+    !         write(*,*) "Counter: ", counter
+    !         ! end surface layer calculations introduced by Patrik Bohlinger
+    !     endif        
+    !     write(*,*) "end surface layer calculations"
+    !     ! ----- end sfc layer calculations ----- !
+    ! end subroutine
+
+
+end module mod_pbl_utilities


### PR DESCRIPTION

TYPE: enhancement, new feature

KEYWORDS: boundary layer, pbl, ysu, yonsei 

SOURCE: Bert Kruyt, NCAR

DESCRIPTION OF CHANGES: Incorporated the ysu boundary layer physics scheme into ICAR. This included a new utilities/pbl_utlities.f90 to calculate two input terms for ysu. The routines in pbl_utlities were copied from WRF, I am not a 100% sure that is the best way to tackle this problem, but it seems to work. Feedback and critical review appreciated!
As ysu calculates tendency terms for (amongst others) wind , the winds are re-balanced and dt is calculated after each pbl call in time_step.f90. 

TESTS CONDUCTED: run on severeal cores/nodes and appears to be stable. Results indicate significant effects on 2m air T, surface winds, etc. 

NOTES: As discussed with ethan, this also includes a modification to the noahMP call, were instead of dz_interface, dz_interface / 2. is now fed into the dz argument there. I am unsure of the physical interpretation of this, and if this is consistent with f.e. the apply_fluxes routine in lsm_driver, where the moisture flux calculation also includes a dz_i term that is left unchanged. 
Also, I noticed that in the recent version of WRF, the ysu code has been slightly modified. These modifications have not yet been incorporated here in ICAR. 


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [ ] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [x] Fully documented
