### PR TITLE
Bugfix: wind boundary

### DIFF
--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -308,7 +308,8 @@ module icar_constants
 !>------------------------------------------------
 !!  Default width of coarray halos, ideally might be physics dependant (e.g. based on advection spatial order)
 !! ------------------------------------------------
-    integer,parameter :: kDEFAULT_HALO_SIZE = 1
+    integer,parameter :: kDEFAULT_HALO_SIZE = 3
+
 
 !>------------------------------------------------
 !! Value to accept for difference between real numbers should be as a fraction but then have to test for non-zero...

--- a/src/constants/icar_constants.f90
+++ b/src/constants/icar_constants.f90
@@ -308,8 +308,7 @@ module icar_constants
 !>------------------------------------------------
 !!  Default width of coarray halos, ideally might be physics dependant (e.g. based on advection spatial order)
 !! ------------------------------------------------
-    integer,parameter :: kDEFAULT_HALO_SIZE = 3
-
+    integer,parameter :: kDEFAULT_HALO_SIZE = 1
 
 !>------------------------------------------------
 !! Value to accept for difference between real numbers should be as a fraction but then have to test for non-zero...

--- a/src/objects/exchangeable_obj.f90
+++ b/src/objects/exchangeable_obj.f90
@@ -191,8 +191,6 @@ contains
     if (.not. this%east_boundary) call this%retrieve_east_halo
     if (.not. this%west_boundary) call this%retrieve_west_halo
 
-
-
   end subroutine
 
   module subroutine exchange_u(this)

--- a/src/objects/exchangeable_obj.f90
+++ b/src/objects/exchangeable_obj.f90
@@ -173,8 +173,7 @@ contains
     if (.not. this%south_boundary) then
         start = lbound(this%data_3d,3)
         nx = size(this%data_3d,1)
-
-        this%halo_north_in(1:nx,:,1:halo_size)[south_neighbor] = this%data_3d(:,:,start+halo_size*2:start+halo_size*2)
+        this%halo_north_in(1:nx,:,1:halo_size)[south_neighbor] = this%data_3d(:,:,start+halo_size+1:start+halo_size*2)
     endif
     if (.not. this%east_boundary)  call this%put_east
     if (.not. this%west_boundary)  call this%put_west
@@ -186,12 +185,13 @@ contains
     if (.not. this%south_boundary) then
         start = lbound(this%data_3d,3)
         nx = size(this%data_3d,1)
-
         this%data_3d(:,:,start:start+halo_size) = this%halo_south_in(:nx,:,1:halo_size+1)
     endif
 
     if (.not. this%east_boundary) call this%retrieve_east_halo
     if (.not. this%west_boundary) call this%retrieve_west_halo
+
+
 
   end subroutine
 
@@ -213,7 +213,7 @@ contains
     if (.not. this%west_boundary) then
         start = lbound(this%data_3d,1)
         ny = size(this%data_3d,3)
-        this%halo_east_in(1:halo_size,:,1:ny)[west_neighbor] = this%data_3d(start+halo_size*2:start+halo_size*2,:,:)
+        this%halo_east_in(1:halo_size,:,1:ny)[west_neighbor] = this%data_3d(start+halo_size+1:start+halo_size*2,:,:)
     endif
 
     sync images( neighbors )

--- a/src/physics/wind.f90
+++ b/src/physics/wind.f90
@@ -433,10 +433,10 @@ contains
         U_cor = ABS(domain%u%data_3d(ims:ime,:,jms:jme))/ &
                 (ABS(domain%u%data_3d(ims:ime,:,jms:jme))+ABS(domain%v%data_3d(ims:ime,:,jms:jme)))
 
-        do k = kms,kme
-            do i = ims,ime
-                do j = jms,jme
-                    domain%smooth_height = sum(domain%advection_dz(i,:,j))
+        do i = ims,ime
+            do j = jms,jme
+                domain%smooth_height = sum(domain%advection_dz(i,:,j)) !
+                do k = kms,kme
                     corr_factor = ((sum(domain%advection_dz(i,1:k,j)))/domain%smooth_height)
                     corr_factor = min(corr_factor,1.0)
                     domain%w%data_3d(i,k,j) = domain%w%data_3d(i,k,j) - corr_factor * (domain%w%data_3d(i,wind_k,j))
@@ -444,6 +444,9 @@ contains
                     !if ( (domain%u%data_3d(i,k,j)+domain%v%data_3d(i,k,j)) == 0) U_cor(i,k,j) = 0.5
                 enddo
             enddo
+        enddo
+
+        do k = kms,kme
             ! Compute this now, since it wont change in the loop
             ADJ_coef(:,k,:) = -2/domain%dx
         enddo

--- a/src/physics/wind.f90
+++ b/src/physics/wind.f90
@@ -428,17 +428,17 @@ contains
         !         exit
         !     endif
         ! enddo
-        domain%smooth_height = sum(domain%advection_dz(ims,:,jms))
+        ! domain%smooth_height = sum(domain%advection_dz(ims,:,jms))
         !Compute relative correction factors for U and V based on input speeds
         U_cor = ABS(domain%u%data_3d(ims:ime,:,jms:jme))/ &
                 (ABS(domain%u%data_3d(ims:ime,:,jms:jme))+ABS(domain%v%data_3d(ims:ime,:,jms:jme)))
 
         do k = kms,kme
-            corr_factor = ((sum(domain%advection_dz(ims,1:k,jms)))/domain%smooth_height)
-            !corr_factor = (k*1.0)/wind_k
-            corr_factor = min(corr_factor,1.0)
             do i = ims,ime
                 do j = jms,jme
+                    domain%smooth_height = sum(domain%advection_dz(i,:,j))
+                    corr_factor = ((sum(domain%advection_dz(i,1:k,j)))/domain%smooth_height)
+                    corr_factor = min(corr_factor,1.0)
                     domain%w%data_3d(i,k,j) = domain%w%data_3d(i,k,j) - corr_factor * (domain%w%data_3d(i,wind_k,j))
 
                     !if ( (domain%u%data_3d(i,k,j)+domain%v%data_3d(i,k,j)) == 0) U_cor(i,k,j) = 0.5


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wind field, boundary conditions

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Boundary conditions of the wind fields causes significant answer changes. The calculation of the the halo region bounds was slightly off for the wind fields.

ISSUE: The GitHub Issue that this PR addresses. For issue number 123, it would
  be `Fixes #123`

### Checklist

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
