### PR TITLE
Issue 146 bugfix: costheta and sintheta calculations

### DIFF
--- a/src/objects/domain_h.f90
+++ b/src/objects/domain_h.f90
@@ -257,6 +257,8 @@ module domain_interface
     integer,allocatable :: land_mask(:,:)
     type(variable_t) :: latitude
     type(variable_t) :: longitude
+    real, allocatable :: latitude_global(:,:)
+    real, allocatable :: longitude_global(:,:)
     type(variable_t) :: u_latitude
     type(variable_t) :: u_longitude
     type(variable_t) :: v_latitude

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -569,6 +569,7 @@ contains
 
         call make_2d_y(temporary_data, this%grid%ims, this%grid%ime)
         this%latitude%data_2d = temporary_data(this%grid%ims:this%grid%ime, this%grid%jms:this%grid%jme)
+        allocate(this%latitude_global, source=temporary_data)
 
         ! Read the longitude data
         call load_data(options%parameters%init_conditions_file,   &
@@ -576,7 +577,7 @@ contains
                        temporary_data, this%grid)
         call make_2d_x(temporary_data, this%grid%jms, this%grid%jme)
         this%longitude%data_2d = temporary_data(this%grid%ims:this%grid%ime, this%grid%jms:this%grid%jme)
-
+        allocate(this%longitude_global, source=temporary_data)
 
         !-----------------------------------------
         !

--- a/src/physics/wind.f90
+++ b/src/physics/wind.f90
@@ -552,19 +552,17 @@ contains
             deallocate(temporary_2d)
         else
 
-            associate(lat => domain%latitude%data_2d,  &
-                      lon => domain%longitude%data_2d  )
+            associate(lat => domain%latitude_global,  &
+                      lon => domain%longitude_global,  &
+                      grid => domain%grid)
 
-            ims = lbound(lat,1)
-            ime = ubound(lat,1)
-            jms = lbound(lat,2)
-            jme = ubound(lat,2)
             if (this_image()==1) print*, "Computing sin/cos alpha"
-            do j = jms, jme
-                do i = ims, ime
+
+            do j = grid%jms, grid%jme
+                do i = grid%ims, grid%ime
                     ! in case we are in the first or last grid, reset boundaries
-                    starti = max(ims, i-2)
-                    endi   = min(ime, i+2)
+                    starti = max(grid%ids, i-2)
+                    endi   = min(grid%ide, i+2)
 
                     ! change in latitude
                     dlat = DBLE(lat(endi,j)) - lat(starti,j)
@@ -576,12 +574,17 @@ contains
                     ! sin/cos of angles for use in rotating fields later
                     domain%costheta(i, j) = abs(dlon / dist)
                     domain%sintheta(i, j) = (-1) * dlat / dist
-
                 enddo
             enddo
 
             end associate
         endif
+
+        if (allocated(domain%latitude_global)) &
+            deallocate(domain%latitude_global)
+        if (allocated(domain%longitude_global)) &
+            deallocate(domain%longitude_global)
+
         if (options%parameters%debug .and.(this_image()==1)) then
             print*, ""
             print*, "Domain Geometry"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wind fields, latitude, longitude, boundary conditions

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Costheta and sintheta calculations were different when using one vs. multiple processes. To fix this lat and long fields are copied to global variables until costheta and sintheta are calculated. Slight changes to the bounds of certain calculations have been made

ISSUE: Fixes #146 

TESTS CONDUCTED: Comparing results from original code, 1 vs. 36 images  to the PR.
 - Original: 1 vs 36 images
<img width="535" alt="image" src="https://user-images.githubusercontent.com/5750642/191393384-bd44a202-5e12-4972-9420-c1e4ea2ad137.png">

 - 1 image (original) vs. 36 of PR Fix (note the orders of magnitude difference in the error color-bar needed to see any difference)
 
<img width="535" alt="image" src="https://user-images.githubusercontent.com/5750642/191393595-086aaaae-5ba5-4789-a74e-e4e6e2b32c37.png">


### Checklist

 - [X] Closes issue #146 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Fully documented
