### PR TITLE
Fix/cmip stability v2.1.1

### DIFF
--- a/run/complete_icar_options.nml
+++ b/run/complete_icar_options.nml
@@ -217,6 +217,16 @@
     !   t_offset will be added to the forcing temperature data.  Defaults to 0
     ! t_offset = 300, ! [K]
 
+    ! limit to impose on relative humidity in the forcing data in case some weird values (e.g. 200% RH) are present
+    rh_limit = 1.2    ! [ fractional ]
+
+    ! limit to impose on externally supplied convective precipitation in the forcing data in case bad values (e.g. 1e10 mm) are present
+    cp_limit = 500    ! [ mm/hr ]
+
+    ! limit to impose on minimum SST in the forcing data in case any non-sensical values (e.g. 200 K) are present
+    sst_min_limit = 273    ! [ k ]
+
+
     !   If the temperature field in the forcing data is not potential temperature, then set this flag to False
     ! t_is_potential = .True.
 

--- a/src/objects/boundary_h.f90
+++ b/src/objects/boundary_h.f90
@@ -34,7 +34,8 @@ module boundary_interface
 
         ! boundary data coordinate system
         real, dimension(:,:),   allocatable :: lat, lon
-        real, dimension(:,:,:), allocatable :: z
+        real, dimension(:,:,:), allocatable :: z            ! 3D z elevation data on the forcing grid
+        real, dimension(:,:,:), allocatable :: interpolated_z ! 3D z interpolated to the model grid (horizontally and vertically)
 
         type(interpolable_type) :: geo
         type(interpolable_type) :: geo_u

--- a/src/objects/boundary_obj.f90
+++ b/src/objects/boundary_obj.f90
@@ -12,7 +12,7 @@ submodule(boundary_interface) boundary_implementation
     use time_io,                only : read_times, find_timestep_in_file
     use co_util,                only : broadcast
     use string,                 only : str
-    use mod_atm_utilities,      only : rh_to_mr, compute_3d_p, compute_3d_z, exner_function
+    use mod_atm_utilities,      only : rh_to_mr, relative_humidity, compute_3d_p, compute_3d_z, exner_function
     use geo,                    only : standardize_coordinates
     use vertical_interpolation, only : vLUT, vinterp
 
@@ -175,7 +175,7 @@ contains
         ! else
             ! print *, "  ext var = 2D"
             if ( (size(this%lat,2)==1) .and. (size(this%lon,2)==1) ) then
-                if (this_image()==1) print*, "  external conditions provided on regular 1D grid"
+                if (this_image()==1) write(*,*) "  external conditions provided on regular 1D grid"
                 nx = size(this%lon,1)
                 ny = size(this%lat,1)
                 nz = 0
@@ -192,7 +192,6 @@ contains
         do i=1, size(var_list)
 
             call add_var_to_dict(this%variables, file_list(this%curfile), var_list(i), dim_list(i), this%curstep, [nx, nz, ny])
-            ! if (this_image()==1)  print*, i," var_list(i): ",trim(var_list(i)), " dim_list(i): ", dim_list(i), " this%curstep ", this%curstep
 
         end do
 
@@ -328,13 +327,12 @@ contains
 
         if (ndims==2) then
             call io_read(file_name, var_name, temp_2d_data, timestep)
-            ! print*, "    file_name, var_name ", file_name, trim(var_name)
 
             call new_variable%initialize( shape( temp_2d_data ) )
             new_variable%data_2d = temp_2d_data
 
             call var_dict%add_var(var_name, new_variable)
-            ! print*, "    added boundary variable ", trim(var_name), " to dict with shape ", shape( temp_2d_data )
+
             ! do not deallocate data arrays because they are pointed to inside the var_dict now
             ! deallocate(new_variable%data_2d)
 
@@ -549,6 +547,8 @@ contains
             tvar%data_3d = tvar%data_3d / exner_function(pvar%data_3d)
         endif
 
+        call limit_rh(list, options)
+
         end associate
 
     end subroutine update_computed_vars
@@ -578,6 +578,42 @@ contains
 
 
     end subroutine compute_mixing_ratio_from_rh
+
+
+    subroutine limit_rh(list, options)
+        implicit none
+        type(var_dict_t),   intent(inout)   :: list
+        type(options_t),    intent(in)      :: options
+
+        integer           :: err
+        type(variable_t)  :: pvar, tvar, qvar
+        real :: rh, t
+        integer :: i,j,k
+
+        if (options%parameters%rh_limit<0) return
+
+        tvar = list%get_var(options%parameters%tvar)
+        pvar = list%get_var(options%parameters%pvar)
+        qvar = list%get_var(options%parameters%qvvar)
+
+
+        do j = lbound(tvar%data_3d, 3), ubound(tvar%data_3d, 3)
+            do k = lbound(tvar%data_3d, 2), ubound(tvar%data_3d, 2)
+                do i = lbound(tvar%data_3d, 1), ubound(tvar%data_3d, 1)
+
+                    t = tvar%data_3d(i,k,j) * exner_function(pvar%data_3d(i,k,j))
+
+                    rh = relative_humidity(t, qvar%data_3d(i,k,j), pvar%data_3d(i,k,j))
+
+                    if (rh > options%parameters%rh_limit) then
+                        qvar%data_3d = rh_to_mr(options%parameters%rh_limit, t, pvar%data_3d(i,k,j))
+                    endif
+
+                enddo
+            enddo
+        enddo
+
+    end subroutine limit_rh
 
 
     subroutine compute_mixing_ratio_from_sh(list, options)

--- a/src/objects/boundary_obj.f90
+++ b/src/objects/boundary_obj.f90
@@ -548,6 +548,8 @@ contains
         endif
 
         call limit_rh(list, options)
+        call limit_2d_var(list, options%parameters%sst_var, min_val=options%parameters%sst_min_limit)
+        call limit_2d_var(list, options%parameters%rain_var, max_val=options%parameters%cp_limit)
 
         end associate
 
@@ -596,7 +598,6 @@ contains
         pvar = list%get_var(options%parameters%pvar)
         qvar = list%get_var(options%parameters%qvvar)
 
-
         do j = lbound(tvar%data_3d, 3), ubound(tvar%data_3d, 3)
             do k = lbound(tvar%data_3d, 2), ubound(tvar%data_3d, 2)
                 do i = lbound(tvar%data_3d, 1), ubound(tvar%data_3d, 1)
@@ -615,6 +616,29 @@ contains
 
     end subroutine limit_rh
 
+    ! set minimum and/or maximum values on any 2D forcing variable (e.g. sst_var, rain_var)
+    subroutine limit_2d_var(list, varname, min_val, max_val)
+        implicit none
+        type(var_dict_t),   intent(inout)   :: list
+        character(len=*),   intent(in)      :: varname
+        real, optional,     intent(in)      :: min_val
+        real, optional,     intent(in)      :: max_val
+
+        type(variable_t)  :: var
+
+        if (trim(varname) == "") return
+
+        var = list%get_var(varname)
+
+        if (present(min_val)) then
+            where(var%data_2d < min_val) var%data_2d = min_val
+        endif
+
+        if (present(max_val)) then
+            where(var%data_2d > max_val) var%data_2d = max_val
+        endif
+
+    end subroutine limit_2d_var
 
     subroutine compute_mixing_ratio_from_sh(list, options)
         implicit none

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -90,7 +90,7 @@ contains
 
         ! interpolate external variables to the hi-res grid
         call this%interpolate_external( external_conditions, options)
-        ! if (this_image()==1) print*, " interpolating exteral conditions"
+        ! if (this_image()==1) write(*,*) " interpolating exteral conditions"
       endif
 
       ! - - - - - - - - - - - - - - - - - - -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -993,14 +993,6 @@ contains
 
             ! Still not 100% convinced this works well in cases other than flat_z_height = 0 (w sleve). So for now best to keep at 0 when using sleve?
             max_level = find_flat_model_level(options, nz, dz)
-            ! if(max_level /= nz) then
-            !     if (this_image()==1) then
-            !         print*, "    flat z height ", options%parameters%flat_z_height
-            !         print*, "    flat z height set to 0 to comply with SLEVE coordinate calculation "
-            !         print*, "    flat z height now", nz
-            !     end if
-            !     max_level = nz
-            ! end if
 
             smooth_height = sum(dz(1:max_level)) !sum(global_terrain) / size(global_terrain) + sum(dz(1:max_level))
 
@@ -1049,14 +1041,14 @@ contains
             !    Decay Rate for Large-Scale Topography: svc1 = 10000.0000
             !    Decay Rate for Small-Scale Topography: svc2 =  3300.0000
             if ((this_image()==1)) then
-                print*, "    Using a SLEVE coordinate with a Decay height for Large-Scale Topography: (s1) of ", s1, " m."
-                print*, "    Using a SLEVE coordinate with a Decay height for Small-Scale Topography: (s2) of ", s2, " m."
-                print*, "    Using a sleve_n of ", options%parameters%sleve_n
+                write(*,*) "    Using a SLEVE coordinate with a Decay height for Large-Scale Topography: (s1) of ", s1, " m."
+                write(*,*) "    Using a SLEVE coordinate with a Decay height for Small-Scale Topography: (s2) of ", s2, " m."
+                write(*,*) "    Using a sleve_n of ", options%parameters%sleve_n
                 write(*,*) "    Smooth height is ", smooth_height, "m.a.s.l     (model top ", sum(dz(1:nz)), "m.a.s.l.)"
                 write(*,*) "    invertibility parameter gamma is: ", gamma_min
-                if(gamma_min <= 0) print*, " CAUTION: coordinate transformation is not invertible (gamma <= 0 ) !!! reduce decay rate(s), and/or increase flat_z_height!"
+                if(gamma_min <= 0) write(*,*) " CAUTION: coordinate transformation is not invertible (gamma <= 0 ) !!! reduce decay rate(s), and/or increase flat_z_height!"
                 ! if(options%parameters%debug)  write(*,*) "   (for (debugging) reference: 'gamma(n=1)'= ", gamma,")"
-                print*, ""
+                write(*,*) ""
             endif
 
             ! - - - - -   Mass grid calculations for lowest level (i=kms)  - - - - -
@@ -1133,10 +1125,8 @@ contains
                     if ( ANY(dz_interface(:,i,:)<0) ) then   ! Eror catching. Probably good to engage.
                     if (this_image()==1) then
                         write(*,*) "Error: dz_interface below zero (for level  ",i,")"
-                        print*, "min max dz_interface: ",MINVAL(dz_interface(:,i,:)),MAXVAL(dz_interface(:,i,:))
+                        write(*,*)  "min max dz_interface: ",MINVAL(dz_interface(:,i,:)),MAXVAL(dz_interface(:,i,:))
                         error stop
-                        print*, dz_interface(:,i,:)
-                        print*,""
                     endif
                     else if ( ANY(global_dz_interface(:,i,:)<=0.01) ) then
                     if (this_image()==1)  write(*,*) "WARNING: dz_interface very low (at level ",i,")"
@@ -1525,8 +1515,8 @@ contains
         endif
 
         if ((this_image()==1)) then
-          print*, "  Setting up the SLEVE vertical coordinate:"
-          print*, "    Smoothing large-scale terrain (h1) with a windowsize of ", &
+          write(*,*) "  Setting up the SLEVE vertical coordinate:"
+          write(*,*) "    Smoothing large-scale terrain (h1) with a windowsize of ", &
                   options%parameters%terrain_smooth_windowsize, " for ",        &
                   options%parameters%terrain_smooth_cycles, " smoothing cylces."
         endif
@@ -1566,9 +1556,9 @@ contains
         ! endif
 
         if (this_image()==1) then
-           print*, "       Max of full topography", MAXVAL(global_terrain )
-           print*, "       Max of large-scale topography (h1)  ", MAXVAL(h1)
-           print*, "       Max of small-scale topography (h2)  ", MAXVAL(h2)
+           write(*,*) "       Max of full topography", MAXVAL(global_terrain )
+           write(*,*) "       Max of large-scale topography (h1)  ", MAXVAL(h1)
+           write(*,*) "       Max of small-scale topography (h2)  ", MAXVAL(h2)
         end if
 
         end associate
@@ -1732,8 +1722,8 @@ contains
                 this%soil_deep_temperature%data_2d = temporary_data(this%grid%ims:this%grid%ime, this%grid%jms:this%grid%jme)
 
                 if (minval(temporary_data)< 200) then
-                    if (this_image()==1) print*, "WARNING, VERY COLD SOIL TEMPERATURES SPECIFIED:", minval(temporary_data)
-                    if (this_image()==1) print*, trim(options%parameters%init_conditions_file),"  ",trim(options%parameters%soil_deept_var)
+                    if (this_image()==1) write(*,*) "WARNING, VERY COLD SOIL TEMPERATURES SPECIFIED:", minval(temporary_data)
+                    if (this_image()==1) write(*,*) trim(options%parameters%init_conditions_file),"  ",trim(options%parameters%soil_deept_var)
                 endif
                 if (minval(this%soil_deep_temperature%data_2d)< 200) then
                     where(this%soil_deep_temperature%data_2d<200) this%soil_deep_temperature%data_2d=280 ! <200 is just broken, set to mean annual air temperature at mid-latidudes
@@ -1836,7 +1826,7 @@ contains
                     enddo
 
                     if (maxval(temporary_data_3d) > 1) then
-                        if (this_image()==1) print*, "Changing input ALBEDO % to fraction"
+                        if (this_image()==1) write(*,*) "Changing input ALBEDO % to fraction"
                         this%albedo%data_3d = this%albedo%data_3d / 100
                     endif
                 endif
@@ -1850,7 +1840,7 @@ contains
                     enddo
 
                     if (maxval(temporary_data) > 1) then
-                        if (this_image()==1) print*, "Changing input ALBEDO % to fraction"
+                        if (this_image()==1) write(*,*) "Changing input ALBEDO % to fraction"
                         this%albedo%data_3d = this%albedo%data_3d / 100
                     endif
                 endif
@@ -2324,6 +2314,8 @@ contains
             call geo_interp(forcing%geo%z, forcing%z, forcing%geo%geolut)
             call vLUT(this%geo,   forcing%geo)
 
+            allocate(forcing%interpolated_z(nx, size(this%geo%z,2), ny))
+            call vinterp(forcing%interpolated_z, forcing%geo%z, forcing%geo%vert_lut)
         end if
 
     end subroutine
@@ -2462,17 +2454,13 @@ contains
         type(variable_t) :: external_var, external_var2
         ! real, allocatable :: ext_snowheight_int(:,:)
 
-        ! do i = 1, external_conditions%variables%n_vars
-        !     print*, "    interpolating external_conditions for ", trim(external_conditions%variables%var_list(i)%name)
-        ! end do
-        ! nsoil=4
         if(options%parameters%external_files/="MISSING") then
           ! -------  repeat this code block for other external variables?   -----------------
           if(options%parameters%swe_ext/="") then
 
             varname = options%parameters%swe_ext   !   options%ext_var_list(j)
 
-            if (this_image()==1) print*, "    interpolating external var ", trim(varname) , " for initial conditions"
+            if (this_image()==1) write(*,*) "    interpolating external var ", trim(varname) , " for initial conditions"
             external_var =external_conditions%variables%get_var(trim(varname))  ! the external variable
 
             if (associated(this%snow_water_equivalent%data_2d)) then
@@ -2488,7 +2476,7 @@ contains
 
             varname = options%parameters%hsnow_ext   !   options%ext_var_list(j)
 
-            if (this_image()==1) print*, "    interpolating external var ", trim(varname) , " for initial conditions"
+            if (this_image()==1) write(*,*) "    interpolating external var ", trim(varname) , " for initial conditions"
             external_var =external_conditions%variables%get_var(trim(varname))  ! the external variable
 
             if (associated(this%snow_height%data_2d)) then
@@ -2501,7 +2489,7 @@ contains
 
             varname = options%parameters%rho_snow_ext   !   options%ext_var_list(j)
 
-            if (this_image()==1) print*, "    interpolating external var ", trim(varname) , " to calculate initial snow height"
+            if (this_image()==1) write(*,*) "    interpolating external var ", trim(varname) , " to calculate initial snow height"
             external_var =external_conditions%variables%get_var(trim(varname))  ! the external variable
             external_var2 =external_conditions%variables%get_var(trim(options%parameters%swe_ext))  ! the external swe
             if (associated(this%snow_height%data_2d)) then
@@ -2516,7 +2504,7 @@ contains
 
             varname = options%parameters%tsoil2D_ext   !   options%ext_var_list(j)
 
-            if (this_image()==1) print*, "    interpolating external var ", trim(varname) , " for initial conditions"
+            if (this_image()==1) write(*,*) "    interpolating external var ", trim(varname) , " for initial conditions"
             external_var =external_conditions%variables%get_var(trim(varname))  ! the external variable
 
             if (associated(this%soil_deep_temperature%data_2d)) then
@@ -2535,7 +2523,7 @@ contains
 
             varname = options%parameters%tsoil3D_ext
 
-            if (this_image()==1) print*, "    interpolating external var ", trim(varname) , " for initial conditions"
+            if (this_image()==1) write(*,*) "    interpolating external var ", trim(varname) , " for initial conditions"
             external_var =external_conditions%variables%get_var(trim(varname))  ! the external variable
 
             if (associated(this%soil_deep_temperature%data_2d)) then
@@ -2564,14 +2552,14 @@ contains
 
         ! internal field always present for value of optional "update"
         logical :: update_only
-        logical :: var_is_not_pressure
+        logical :: var_is_pressure
         ! temporary to hold the variable to be interpolated to
         type(variable_t) :: var_to_interpolate
         ! temporary to hold the forcing variable to be interpolated from
         type(variable_t) :: input_data, forcing_temperature
         real, allocatable, dimension(:,:,:) :: potential_temperature
         ! number of layers has to be used when subsetting for update_pressure (for now)
-        integer :: nz
+        integer :: i, nz
         logical :: var_is_u, var_is_v
 
         update_only = .False.
@@ -2600,8 +2588,8 @@ contains
                 endif
 
             else
-                ! if this is the pressure variable, then don't perform vertical interpolation, adjust the pressure directly
-                var_is_not_pressure = (trim(var_to_interpolate%forcing_var) /= trim(this%pressure%forcing_var))
+                ! if this is the pressure variable, then adjust the pressure directly
+                var_is_pressure = (trim(var_to_interpolate%forcing_var) == trim(this%pressure%forcing_var))
 
                 var_is_u = (trim(var_to_interpolate%forcing_var) == trim(this%u%meta_data%forcing_var))
                 var_is_v = (trim(var_to_interpolate%forcing_var) == trim(this%v%meta_data%forcing_var))
@@ -2610,30 +2598,31 @@ contains
                 if (update_only) then
 
                     call interpolate_variable(var_to_interpolate%dqdt_3d, input_data, forcing, this, &
-                                    vert_interp=var_is_not_pressure, var_is_u=var_is_u, var_is_v=var_is_v, nsmooth=this%nsmooth)
+                                    vert_interp=.True., var_is_u=var_is_u, var_is_v=var_is_v, nsmooth=this%nsmooth)
 
                     ! because pressure needs to be adjusted for grid points that fall below the forcing lowest level, we adjust it separately.
-                    if (.not.var_is_not_pressure) then
+                    if (var_is_pressure) then
                         allocate(potential_temperature, mold=var_to_interpolate%dqdt_3d)
-                        ! to improve the pressure adjustment, we need to get forcing potential temperature on the ICAR grid WITHOUT vertical interpolation
+                        ! to improve the pressure adjustment, we need to get forcing potential temperature on the ICAR grid
                         call interpolate_variable(potential_temperature, forcing_temperature, forcing, this, &
-                                        vert_interp=.False., var_is_u=.False., var_is_v=.False., nsmooth=this%nsmooth)
+                                        vert_interp=.True., var_is_u=.False., var_is_v=.False., nsmooth=this%nsmooth)
 
-                        call adjust_pressure(var_to_interpolate%dqdt_3d, forcing%geo%z, this%geo%z, potential_temperature)
+                        call adjust_pressure(var_to_interpolate%dqdt_3d, forcing%interpolated_z, this%geo%z, potential_temperature)
+
                     endif
 
                 else
                     call interpolate_variable(var_to_interpolate%data_3d, input_data, forcing, this, &
-                                    vert_interp=var_is_not_pressure, var_is_u=var_is_u, var_is_v=var_is_v, nsmooth=this%nsmooth)
+                                    vert_interp=.True., var_is_u=var_is_u, var_is_v=var_is_v, nsmooth=this%nsmooth)
 
                     ! because pressure needs to be adjusted for grid points that fall below the forcing lowest level, we adjust it separately.
-                    if (.not.var_is_not_pressure) then
+                    if (var_is_pressure) then
                         allocate(potential_temperature, mold=var_to_interpolate%dqdt_3d)
-                        ! to improve the pressure adjustment, we need to get forcing potential temperature on the ICAR grid WITHOUT vertical interpolation
+                        ! to improve the pressure adjustment, we need to get forcing potential temperature on the ICAR grid
                         call interpolate_variable(potential_temperature, forcing_temperature, forcing, this, &
-                                        vert_interp=.False., var_is_u=.False., var_is_v=.False., nsmooth=this%nsmooth)
+                                        vert_interp=.True., var_is_u=.False., var_is_v=.False., nsmooth=this%nsmooth)
 
-                        call adjust_pressure(var_to_interpolate%data_3d, forcing%geo%z, this%geo%z, potential_temperature)
+                        call adjust_pressure(var_to_interpolate%data_3d, forcing%interpolated_z, this%geo%z, potential_temperature)
                     endif
                 endif
 
@@ -2881,12 +2870,12 @@ contains
         e = 1.2  ! <- first guess
         if (MAXVAL(global_terrain) *e < s1 ) then
             wind_top = s1
-            if (this_image()==1) print*, "  horizontally accelerating winds below:", wind_top, "m. " !,"(Factor H/s:", H/s ,")"
+            if (this_image()==1) write(*,*) "  horizontally accelerating winds below:", wind_top, "m. " !,"(Factor H/s:", H/s ,")"
         else
             wind_top = MAXVAL(global_terrain) * e !**2
-            if (this_image()==1 )   print*, "  adjusting wind top upward from ",s1 ," to ", wind_top  ,"m. Horizontally accelerating winds below this level."
+            if (this_image()==1 )   write(*,*) "  adjusting wind top upward from ",s1 ," to ", wind_top  ,"m. Horizontally accelerating winds below this level."
         endif
-        ! if (this_image()==1) print*, "  s_accel max: ", wind_top, "  - h max:", MAXVAL(global_terrain)
+        ! if (this_image()==1) write(*,*) "  s_accel max: ", wind_top, "  - h max:", MAXVAL(global_terrain)
 
 
         !_________ 1. Calculate delta_dzdx for w_real calculation - CURRENTLY NOT USED- reconsider  _________

--- a/src/objects/opt_types.f90
+++ b/src/objects/opt_types.f90
@@ -282,6 +282,9 @@ module options_types
 
         real :: t_offset                ! offset to temperature because WRF outputs potential temperature-300
         real :: rh_limit                ! limit to impose on relative humidity in the forcing data
+        real :: cp_limit      ! [ mm/hr ] limit to impose on externally supplied convective precipitation in the forcing data in case bad values (e.g. 1e10 mm) are present
+        real :: sst_min_limit   ! [ K ]   limit to impose on minimum SST in the forcing data in case any non-sensical values (e.g. 200 K) are present
+
 
         ! note this can't be allocatable because gfortran does not support allocatable components inside derived type coarrays...
         real, dimension(MAXLEVELS)::dz_levels ! model layer thicknesses to be read from namelist

--- a/src/objects/opt_types.f90
+++ b/src/objects/opt_types.f90
@@ -281,6 +281,7 @@ module options_types
         type(Time_type) :: end_time     ! End point for the model simulation
 
         real :: t_offset                ! offset to temperature because WRF outputs potential temperature-300
+        real :: rh_limit                ! limit to impose on relative humidity in the forcing data
 
         ! note this can't be allocatable because gfortran does not support allocatable components inside derived type coarrays...
         real, dimension(MAXLEVELS)::dz_levels ! model layer thicknesses to be read from namelist

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -974,7 +974,7 @@ contains
         ! parameters to read
 
         real    :: dx, dxlow, outputinterval, restartinterval, inputinterval, t_offset, smooth_wind_distance, frames_per_outfile, agl_cap
-        real    :: cfl_reduction_factor
+        real    :: cfl_reduction_factor, rh_limit
         integer :: ntimesteps, wind_iterations
         integer :: longitude_system
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
@@ -994,7 +994,7 @@ contains
 
 
         namelist /parameters/ ntimesteps, wind_iterations, outputinterval, frames_per_outfile, inputinterval, surface_io_only,                &
-                              dx, dxlow, ideal, readz, readdz, nz, t_offset,                             &
+                              dx, dxlow, ideal, readz, readdz, nz, t_offset, rh_limit,                   &
                               debug, warning_level, interactive, restart,                                &
                               external_winds, buffer, n_ext_winds, advect_density, smooth_wind_distance, &
                               mean_winds, mean_fields, z_is_geopotential, z_is_on_interface,             &
@@ -1019,6 +1019,7 @@ contains
         external_winds      = .False.
         n_ext_winds         = 1
         t_offset            = (-9999)
+        rh_limit            = -1
         buffer              = 0
         advect_density      = .False.
         t_is_potential      = .True.
@@ -1111,6 +1112,12 @@ contains
         endif
 
         options%t_offset=t_offset
+
+        if (rh_limit > 5) then
+            write(*,*) "RH limit >5 specified, assuming it is in %"
+            rh_limit = rh_limit/100
+        endif
+        options%rh_limit=rh_limit
         if (smooth_wind_distance<0) then
             write(*,*) " Wind smoothing must be a positive number"
             write(*,*) " smooth_wind_distance = ",smooth_wind_distance
@@ -2002,12 +2009,6 @@ contains
         options%decay_rate_S_topo = decay_rate_S_topo ! decay_rate_small_scale_topography !
         options%sleve_n = sleve_n
         options%use_terrain_difference = use_terrain_difference
-
-        !if (fixed_dz_advection) then
-        !    print*, "WARNING: setting fixed_dz_advection to true is not recommended, use wind = 2 instead"
-        !    print*, "if you want to continue and enable this, you will need to change this code in the options_obj"
-        !    error stop
-        !endif
 
 
         if (dz_modifies_wind) then

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -974,7 +974,7 @@ contains
         ! parameters to read
 
         real    :: dx, dxlow, outputinterval, restartinterval, inputinterval, t_offset, smooth_wind_distance, frames_per_outfile, agl_cap
-        real    :: cfl_reduction_factor, rh_limit
+        real    :: cfl_reduction_factor, rh_limit, sst_min_limit, cp_limit
         integer :: ntimesteps, wind_iterations
         integer :: longitude_system
         integer :: nz, n_ext_winds,buffer, warning_level, cfl_strictness
@@ -994,7 +994,7 @@ contains
 
 
         namelist /parameters/ ntimesteps, wind_iterations, outputinterval, frames_per_outfile, inputinterval, surface_io_only,                &
-                              dx, dxlow, ideal, readz, readdz, nz, t_offset, rh_limit,                   &
+                              dx, dxlow, ideal, readz, readdz, nz, t_offset, rh_limit, sst_min_limit, cp_limit, &
                               debug, warning_level, interactive, restart,                                &
                               external_winds, buffer, n_ext_winds, advect_density, smooth_wind_distance, &
                               mean_winds, mean_fields, z_is_geopotential, z_is_on_interface,             &
@@ -1020,6 +1020,8 @@ contains
         n_ext_winds         = 1
         t_offset            = (-9999)
         rh_limit            = -1
+        sst_min_limit       = 273.15
+        cp_limit            = 500
         buffer              = 0
         advect_density      = .False.
         t_is_potential      = .True.
@@ -1118,6 +1120,11 @@ contains
             rh_limit = rh_limit/100
         endif
         options%rh_limit=rh_limit
+
+        options%sst_min_limit = sst_min_limit
+
+        options%cp_limit = cp_limit / 3600.0 ! convert from mm/hr to mm/s
+
         if (smooth_wind_distance<0) then
             write(*,*) " Wind smoothing must be a positive number"
             write(*,*) " smooth_wind_distance = ",smooth_wind_distance


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: pressure interpolation, forcing, sst, external precipitation, relative humidity

SOURCE: Ethan Gutmann, NCAR

DESCRIPTION OF CHANGES: 
This PR fixed a possible pressure interpolation bug and generally improved pressure vertical interpolation process significantly (**note** this can change precipitation, so far it seems to be an improvement)
This also adds namelist options to limit the relative humidity in the forcing data to, e.g. 120%, the minimum SST in the forcing to, e.g. 273.15K, and the maximum prescribed convective precipitation. All limit values are namelist options.

TESTS CONDUCTED: 
Ran multiple western US tests.  Tested model simulations that used to break as a result of bad pressure interpolation.  Tested that setting the SST, RH, or CP limits to very restrictive settings changed the simulations correctly. 

### Checklist
 - [X] Backwards compatible
 - [X] Fully documented (options described in namelist)
