### PR TITLE
Bugfix: parallel build

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -820,7 +820,7 @@ $(BUILD)lsm_driver.o: $(PHYS)lsm_driver.f90 $(BUILD)data_structures.o	\
 
 # $(BUILD)lsm_basic.o $(BUILD)lsm_simple.o
 
-$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)data_structures.o
+$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)data_structures.o $(BUILD)options_h.o
 
 $(BUILD)water_lake.o: $(PHYS)water_lake.f90 $(BUILD)data_structures.o
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: parallel build, Makefile

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Running `make -j 4` was causing the following error
```
physics/water_simple.f90:10:9:

   10 |     use options_interface,   only : options_t
      |         1
Fatal Error: Cannot open module file ‘options_interface.mod’ for reading at (1): No such file or directory
compilation terminated.
```
Changed the Makefile to fix the compile dependencies. 

NOTE: This fix should also be applied to the `main` branch as well

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
