### PR TITLE
minor changes to make icar compile with cray and run 

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -193,7 +193,7 @@ endif
 
 # Cray fortran
 ifeq ($(COMPILER), cray)
-	COMP= -h omp vector2 -O2 -c -eI
+	COMP= -h omp vector2 -O2 -c -eI -hfp1
 	LINK= -fopenmp
 	PREPROC= -eZ
 	MODOUTPUT= -J $(BUILD) -em

--- a/src/makefile
+++ b/src/makefile
@@ -193,7 +193,7 @@ endif
 
 # Cray fortran
 ifeq ($(COMPILER), cray)
-	COMP= -h omp vector2 -O2 -c -eI -hfp1
+	COMP= -h omp vector2 -O2 -c -eI -hfp0
 	LINK= -fopenmp
 	PREPROC= -eZ
 	MODOUTPUT= -J $(BUILD) -em
@@ -211,7 +211,7 @@ ifeq ($(MODE), debugslow)
 		LINK=
 	endif
 	ifeq ($(COMPILER), cray)
-		COMP=-h noomp -c -g -h develop -m 0 -R bcsp -M 399
+		COMP=-h noomp -c -g -h develop -m 0 -R bcsp -M 399 -hfp0
 		LINK=-h noomp
 		PREPROC=-eZ
 		MODOUTPUT=-e m -J $(BUILD)
@@ -227,7 +227,7 @@ ifeq ($(MODE), debug)
 		LINK=
 	endif
 	ifeq ($(COMPILER), cray)
-		COMP=-O2 -h noomp -c -g
+		COMP=-O2 -h noomp -c -g -hfp0
 		LINK=-h noomp
 		PREPROC=-eZ
 		MODOUTPUT=-e m -J $(BUILD)
@@ -244,7 +244,7 @@ ifeq ($(MODE), debugompslow)
 		LINK= -fopenmp -lgomp
 	endif
 	ifeq ($(COMPILER), cray)
-		COMP=-c -g -m 0 -h develop -R bcsp -M 399
+		COMP=-c -g -m 0 -h develop -R bcsp -M 399 -hfp0
 		LINK=
 		PREPROC=-eZ
 		MODOUTPUT=-e m -J $(BUILD)
@@ -261,7 +261,7 @@ ifeq ($(MODE), debugomp)
 		 # -Wall -Wno-unused-variable -Wno-unused-dummy-argument
 	endif
 	ifeq ($(COMPILER), cray)
-		COMP=-O1 -c -g
+		COMP=-O1 -c -g -hfp0
 		LINK=
 		PREPROC=-eZ
 		MODOUTPUT=-e m -J $(BUILD)

--- a/src/makefile
+++ b/src/makefile
@@ -820,7 +820,7 @@ $(BUILD)lsm_driver.o: $(PHYS)lsm_driver.f90 $(BUILD)data_structures.o	\
 
 # $(BUILD)lsm_basic.o $(BUILD)lsm_simple.o
 
-$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)data_structures.o
+$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)options_h.o	$(BUILD)data_structures.o
 
 $(BUILD)water_lake.o: $(PHYS)water_lake.f90 $(BUILD)data_structures.o
 

--- a/src/physics/lsm_noahmplsm.f90
+++ b/src/physics/lsm_noahmplsm.f90
@@ -1602,8 +1602,12 @@ ENDIF   ! CROPTYPE == 0
 !jref:start
    ERRSW   = SWDOWN - (FSA + FSR)
 !   ERRSW   = SWDOWN - (SAV+SAG + FSRV+FSRG)
-!   WRITE(*,*) "ERRSW =",ERRSW
-   IF (ABS(ERRSW) > 0.01) THEN            ! w/m2
+   IF (ABS(ERRSW) > 0.1) THEN            ! w/m2  ! BK 2022/10/14: modified to prevent error when running with cray-compiled icar
+    WRITE(*,*) "ERRSW =",ERRSW
+    ! write(*,*) "SWDOWN=", SWDOWN 
+    ! write(*,*) "(FSA + FSR)=", (FSA + FSR)
+    ! write(*,*) "FSA =", (FSA)
+    ! write(*,*) "FSR=", FSR
    WRITE(*,*) "VEGETATION!"
    WRITE(*,*) "SWDOWN*FVEG =",SWDOWN*FVEG
    WRITE(*,*) "FVEG*(SAV+SAG) =",FVEG*SAV + SAG

--- a/src/physics/water_simple.f90
+++ b/src/physics/water_simple.f90
@@ -6,7 +6,7 @@
 !!
 !!----------------------------------------------------------
 module module_water_simple
-    use data_structures,
+    use data_structures
     use options_interface,   only : options_t
     use icar_constants
     implicit none


### PR DESCRIPTION

TYPE: bug fix

KEYWORDS: Cray, NoahMP, precision, compiler

SOURCE: Bert Kruyt, NCAR, RAL

DESCRIPTION OF CHANGES: makefile: water_simple now depends on options_h. Apparently gnu was ok without it, but cray is not. 
NoahMP: an error check in NoahMP that compares SWDOWN (downward solar filtered by sun angle [w/m2]) to the sum of FSA ( total absorbed solar radiation (w/m2)) and  FSR (total reflected solar radiation (w/m2)) gives an error if the difference is more than 0.01 W/m2. When compiled with cray, this condition is too stringent and the error is triggered. I increased the threshold to 0.1 W/m2.


TESTS CONDUCTED: runs - havent checked results but unlikely that <0.1 W/m2 makes a difference. Compiles with gfortran as well as cray (on Perlmutter)




### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
