### PR TITLE
Fix/cmip stability v2.1.1

### DIFF
--- a/src/physics/mp_wsm3.f90
+++ b/src/physics/mp_wsm3.f90
@@ -595,7 +595,7 @@ CONTAINS
         kwork1(i) = mstep(i)
         if(mstep(i).ne.0) then
           if (w(i,mstep(i)).gt.0.) then
-            kwork1(i) = min(kme, mstep(i) + 1)
+            kwork1(i) = min(kte, mstep(i) + 1)
           endif
         endif
       enddo

--- a/src/physics/mp_wsm3.f90
+++ b/src/physics/mp_wsm3.f90
@@ -595,7 +595,7 @@ CONTAINS
         kwork1(i) = mstep(i)
         if(mstep(i).ne.0) then
           if (w(i,mstep(i)).gt.0.) then
-            kwork1(i) = mstep(i) + 1
+            kwork1(i) = min(kme, mstep(i) + 1)
           endif
         endif
       enddo


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: wsm3, array bounds, bug fix

SOURCE: Ethan Gutmann, NCAR

DESCRIPTION OF CHANGES: WSM3 was not checking for the array bounds when setting an array index, this fixes that. 

TESTS CONDUCTED: 
Ran an identical test that was crashing previously, and model now runs smoothly. 


### Checklist
 - [x] Backwards compatible
