### PR TITLE
Bugfix: Fix 'node.js 12 deprecated' Message

### DIFF
--- a/.github/workflows/icar-develop-commit.yml
+++ b/.github/workflows/icar-develop-commit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Create Processing Badges
       # - name: Create Processing Build Badge

--- a/.github/workflows/icar-main-commit.yml
+++ b/.github/workflows/icar-main-commit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Create Processing Badges
       # - name: Create Processing Build Badge

--- a/.github/workflows/icar-pull-request.yml
+++ b/.github/workflows/icar-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Build Dependencies then ICAR
       - name: Dependencies


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Github Actions, CI, Node.js

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Github actions are returning a "Node.js 12 actions are deprecated." warning. This should fix the issue.

TESTS CONDUCTED: none, changes only affect Github Actions so the CI tests will let us know if it was successful. 

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
