### PR TITLE
bugfix: makefile parallel build

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -820,7 +820,7 @@ $(BUILD)lsm_driver.o: $(PHYS)lsm_driver.f90 $(BUILD)data_structures.o	\
 
 # $(BUILD)lsm_basic.o $(BUILD)lsm_simple.o
 
-$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)data_structures.o
+$(BUILD)water_simple.o: $(PHYS)water_simple.f90 $(BUILD)data_structures.o $(BUILD)options_h.o
 
 $(BUILD)water_lake.o: $(PHYS)water_lake.f90 $(BUILD)data_structures.o
 


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: Makefile, build system

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: water_simple requires `makefile` dependency change for parallel build.

TESTS CONDUCTED: built in parallel, tested up to `make -j 8`

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
