### PR TITLE
bugfix: unititialized todays_date_time variable used

### DIFF
--- a/src/io/output_obj.f90
+++ b/src/io/output_obj.f90
@@ -303,6 +303,10 @@ contains
         call check( nf90_put_att(ncid,NF90_GLOBAL,"Conventions","CF-1.6"), trim(err))
         call check( nf90_put_att(ncid,NF90_GLOBAL,"title","Intermediate Complexity Atmospheric Research (ICAR) model output"), trim(err))
         call check( nf90_put_att(ncid,NF90_GLOBAL,"institution","National Center for Atmospheric Research"), trim(err))
+        ! initialize todays_date_time variable before use as attribute
+        call date_and_time(values=date_time,zone=UTCoffset)
+        date_format='(I4,"/",I2.2,"/",I2.2," ",I2.2,":",I2.2,":",I2.2)'
+        write(todays_date_time,date_format) date_time(1:3),date_time(5:7)
         call check( nf90_put_att(ncid,NF90_GLOBAL,"history","Created:"//todays_date_time//UTCoffset), trim(err))
         call check( nf90_put_att(ncid,NF90_GLOBAL,"references", &
                     "Gutmann et al. 2016: The Intermediate Complexity Atmospheric Model (ICAR). J.Hydrometeor. doi:10.1175/JHM-D-15-0155.1, 2016."), trim(err))
@@ -319,11 +323,6 @@ contains
             enddo
         endif
 
-        call date_and_time(values=date_time,zone=UTCoffset)
-        date_format='(I4,"/",I2.2,"/",I2.2," ",I2.2,":",I2.2,":",I2.2)'
-        write(todays_date_time,date_format) date_time(1:3),date_time(5:7)
-
-        call check(nf90_put_att(this%ncfile_id, NF90_GLOBAL,"history","Created:"//todays_date_time//UTCoffset), "global attr")
         call check(nf90_put_att(this%ncfile_id, NF90_GLOBAL, "image", this_image()))
 
     end subroutine add_global_attributes


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: NetCDF, Valgrind

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Valgrind was producing warnings of an uninitialized variable being used. The executable was outputting correct behavior because it would output `todays_date_time` with a bad value, then rewrite it later in the subroutine. Presumably this was originally done so that `todays_date_time` variable showed up in the NetCDF output in a specific order. Moving the `todays_date_time` initialization before the `nf90_put_att` call fixes the init issue and allows for removal of the repeat `nf90_put_att` call.

TESTS CONDUCTED: Builds and runs with correct looking output

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
