### PR TITLE
bugfix: wind 3 physics n-cores differences

### DIFF
--- a/src/objects/exchangeable_h.f90
+++ b/src/objects/exchangeable_h.f90
@@ -48,6 +48,7 @@ module exchangeable_interface
   end type
 
   integer, parameter :: space_dim=3
+  integer, parameter :: uv_comm_n_times=2
 
   interface
 


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: windfields, halo exchange, boundary conditions

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: The halo exchange of the `u` and `v` variables doesn't communicate the diagonal values. These are needed for the windfield calculations to be performed correctly. Attempts were made to do a second halo exchange with just the single corner column but there is a bug in either Gfortran 12.1.0 or OpenCoarrays 2.10.1 that causes the `A(n,:,:)[neighbor]` assignment to occur incorrectly. 


TESTS CONDUCTED: Commented out `smooth_array` calls [here](https://github.com/NCAR/icar/blob/453dc64e508f549982724e93d73d6ed45da1bdf5/src/objects/domain_obj.f90#L2771) and [here](https://github.com/NCAR/icar/blob/453dc64e508f549982724e93d73d6ed45da1bdf5/src/objects/domain_obj.f90#L2792) and then performed runs with physics `mp=5` and `wind=3`. The output of runs with 32 cores and 36 were compared. Without `smooth_array` the output of `u` and `v` are identical after init and after running the model for an hour.

Here is the effect of the two `smooth_array` lines:
<img width="525" alt="effect_of_smoothing-dev" src="https://user-images.githubusercontent.com/5750642/234724618-2c692d42-6a47-4472-9e10-494299a4fd39.png">

Here is the effect that the `uv_exchange` commit fixes:
<img width="525" alt="upstream_t0l4_nosmooth_withSINCOSALPHAnml" src="https://user-images.githubusercontent.com/5750642/234724746-42fafa52-65f6-4a82-8590-41cd985f3973.png">

Here are the effects on performance, the `num iterations` column is the number of wind iterations. `1x` is with one halo exchange and `2x` is with the two halo exchanges that fixes the results. `total` have the timings fro the `2x` halo exchange runs:
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/5750642/234728805-28980055-6556-4269-88f0-3b0483bed482.png">





NOTES: These tests were done with 100 wind iterations which increases the effects of the bug. Also there are **issues** that will show up in `wind=3` on the `main` branch since it doesn't have the sintheta and costheta fix that is in the `develop` branch. Also github isn't showing the changes well, I added a do-loop and indented the code but github doesn't show those differences succinctly.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Fully documented
