### PR TITLE
enhancement: better performance for wind 3 u,v exchange 

### DIFF
--- a/src/objects/exchangeable_h.f90
+++ b/src/objects/exchangeable_h.f90
@@ -48,7 +48,6 @@ module exchangeable_interface
   end type
 
   integer, parameter :: space_dim=3
-  integer, parameter :: uv_comm_n_times=2
 
   interface
 

--- a/src/objects/exchangeable_obj.f90
+++ b/src/objects/exchangeable_obj.f90
@@ -163,83 +163,83 @@ contains
 
   module subroutine exchange_v(this)
     class(exchangeable_t), intent(inout) :: this
-    integer :: n, nx, start, comm_n_times, i
+    integer :: n, nx, start
     !When exchanging for the v-field, we want a full exchange in the y-direction,
     ! and an exchange in the x-direction of just the outer-most values
+    !Performing north/south communication before east/west so corner halo
+    !  region from diagonal neighbor is communicated
 
-    ! second communication makes sure that diagonal corners are communicated
-    comm_n_times = uv_comm_n_times
+    if (.not. this%north_boundary) then
+        n = ubound(this%data_3d,3)
+        nx = size(this%data_3d,1)
+        this%halo_south_in(1:nx,:,1:(halo_size+1))[north_neighbor] = this%data_3d(:,:,n-(halo_size)*2:n-(halo_size))
+    endif
+    if (.not. this%south_boundary) then
+        start = lbound(this%data_3d,3)
+        nx = size(this%data_3d,1)
+        this%halo_north_in(1:nx,:,1:halo_size)[south_neighbor] = this%data_3d(:,:,start+halo_size+1:start+halo_size*2)
+    endif
 
-    do i=1,comm_n_times
-        if (.not. this%north_boundary) then
-            n = ubound(this%data_3d,3)
-            nx = size(this%data_3d,1)
-            this%halo_south_in(1:nx,:,1:(halo_size+1))[north_neighbor] = this%data_3d(:,:,n-(halo_size)*2:n-(halo_size))
-        endif
-        if (.not. this%south_boundary) then
-            start = lbound(this%data_3d,3)
-            nx = size(this%data_3d,1)
-            this%halo_north_in(1:nx,:,1:halo_size)[south_neighbor] = this%data_3d(:,:,start+halo_size+1:start+halo_size*2)
-        endif
-        if (.not. this%east_boundary)  call this%put_east
-        if (.not. this%west_boundary)  call this%put_west
+    sync images( neighbors )
 
-        sync images( neighbors )
+    if (.not. this%north_boundary) call this%retrieve_north_halo
+    if (.not. this%south_boundary) then
+        start = lbound(this%data_3d,3)
+        nx = size(this%data_3d,1)
+        this%data_3d(:,:,start:start+halo_size) = this%halo_south_in(:nx,:,1:halo_size+1)
+    endif
 
-        if (.not. this%north_boundary) call this%retrieve_north_halo
+    sync images( neighbors )
 
-        if (.not. this%south_boundary) then
-            start = lbound(this%data_3d,3)
-            nx = size(this%data_3d,1)
-            this%data_3d(:,:,start:start+halo_size) = this%halo_south_in(:nx,:,1:halo_size+1)
-        endif
+    if (.not. this%east_boundary)  call this%put_east
+    if (.not. this%west_boundary)  call this%put_west
 
-        if (.not. this%east_boundary) call this%retrieve_east_halo
-        if (.not. this%west_boundary) call this%retrieve_west_halo
-        sync images( neighbors )
-    end do
+    sync images( neighbors )
 
+    if (.not. this%east_boundary) call this%retrieve_east_halo
+    if (.not. this%west_boundary) call this%retrieve_west_halo
+    sync images( neighbors )
   end subroutine
 
   module subroutine exchange_u(this)
     class(exchangeable_t), intent(inout) :: this
-    integer :: n, ny, start, comm_n_times, i
+    integer :: n, ny, start
     !When exchanging for the u-field, we want a full exchange in the x-direction,
     ! and an exchange in the y-direction of just the outer-most values
+    !Performing north/south communication before east/west so corner halo
+    !  region from diagonal neighbor is communicated
 
-    ! second communication makes sure that diagonal corners are communicated
-    comm_n_times = uv_comm_n_times
+    if (.not. this%north_boundary)  call this%put_north
+    if (.not. this%south_boundary)  call this%put_south
 
-    do i=1,comm_n_times
-        if (.not. this%north_boundary)  call this%put_north
-        if (.not. this%south_boundary)  call this%put_south
+    sync images( neighbors )
 
-        if (.not. this%east_boundary) then
-            n = ubound(this%data_3d,1)
-            ny = size(this%data_3d,3)
-            this%halo_west_in(1:halo_size+1,:,1:ny)[east_neighbor] = this%data_3d(n-(halo_size)*2:n-(halo_size),:,:)
-        endif
+    if (.not. this%north_boundary) call this%retrieve_north_halo
+    if (.not. this%south_boundary) call this%retrieve_south_halo
 
-        if (.not. this%west_boundary) then
-            start = lbound(this%data_3d,1)
-            ny = size(this%data_3d,3)
-            this%halo_east_in(1:halo_size,:,1:ny)[west_neighbor] = this%data_3d(start+halo_size+1:start+halo_size*2,:,:)
-        endif
+    sync images( neighbors )
 
-        sync images( neighbors )
+    if (.not. this%east_boundary) then
+        n = ubound(this%data_3d,1)
+        ny = size(this%data_3d,3)
+        this%halo_west_in(1:halo_size+1,:,1:ny)[east_neighbor] = this%data_3d(n-(halo_size)*2:n-(halo_size),:,:)
+    endif
+    if (.not. this%west_boundary) then
+        start = lbound(this%data_3d,1)
+        ny = size(this%data_3d,3)
+        this%halo_east_in(1:halo_size,:,1:ny)[west_neighbor] = this%data_3d(start+halo_size+1:start+halo_size*2,:,:)
+    endif
 
-        if (.not. this%north_boundary) call this%retrieve_north_halo
-        if (.not. this%south_boundary) call this%retrieve_south_halo
-        if (.not. this%east_boundary) call this%retrieve_east_halo
+    sync images( neighbors )
 
-        if (.not. this%west_boundary)  then
-            start = lbound(this%data_3d,1)
-            ny = size(this%data_3d,3)
-            this%data_3d(start:start+halo_size,:,:) = this%halo_west_in(1:halo_size+1,:,1:ny)
-         endif
+    if (.not. this%east_boundary) call this%retrieve_east_halo
+    if (.not. this%west_boundary)  then
+        start = lbound(this%data_3d,1)
+        ny = size(this%data_3d,3)
+        this%data_3d(start:start+halo_size,:,:) = this%halo_west_in(1:halo_size+1,:,1:ny)
+    endif
 
-         sync images( neighbors )
-    end do
+    sync images( neighbors )
   end subroutine
 
   module subroutine exchange(this)


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: halo exchange, wind 3 option

SOURCE: Soren Rasmussen's implementation and testing, Ethan's idea

DESCRIPTION OF CHANGES: More efficient halo communication for the u,v exchange. North/south communication and then east/west communication is performed instead of doing all u,v halo communication twice. The last PR #163 switched to performaing u,v halo communication twice to fix a bug. This had a hit on performance, while for the new PR the performance difference in negligible. 

TESTS CONDUCTED: Changes tested on the wind 3 option. When the two "smooth_array" lines are commented out the output of 32 vs 36 num processors is the same. I took a closer look at outputs at one of the corners and it looked correct. 

The "second PR" in the table is #163, the "original 1" is the develop branch before #163 was applied. The "new PR" is this PR. This shows that the new u,v enhancement fixes the bug and is a lot quicker than the old commit since the amount of data movement done is greatly reduced.

<img width="786" alt="uv_exchange_improvement" src="https://user-images.githubusercontent.com/5750642/235369645-f61ceb48-75ff-48c5-82be-02d011ce40ed.png">


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Fully documented
