### PR TITLE
bugfixes: halo_size and wind=1 smoothing

### DIFF
--- a/src/objects/domain_h.f90
+++ b/src/objects/domain_h.f90
@@ -24,6 +24,7 @@ module domain_interface
     type(grid_t)         :: grid_snow, grid_snowsoil
     type(grid_t)         :: grid_soilcomp, grid_gecros, grid_croptype
     type(grid_t)         :: grid_lake , grid_lake_soisno, grid_lake_soi, grid_lake_soisno_1
+    type(grid_t)         :: grid_smooth_nsquared
 
     type(Time_type) :: model_time
 
@@ -60,6 +61,7 @@ module domain_interface
     type(variable_t) :: z_interface
     type(variable_t) :: dz_mass
     type(variable_t) :: nsquared
+    type(exchangeable_t) :: smooth_nsquared
     type(variable_t) :: graupel
     type(variable_t) :: accumulated_precipitation
     integer,allocatable :: precipitation_bucket(:,:)

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -182,6 +182,7 @@ contains
         if (0<opt%vars_to_allocate( kVARS%w) )                          call setup(this%w,                        this%grid )
         if (0<opt%vars_to_allocate( kVARS%w) )                          call setup(this%w_real,                   this%grid )
         if (0<opt%vars_to_allocate( kVARS%nsquared) )                   call setup(this%nsquared,                 this%grid )
+        if (0<opt%vars_to_allocate( kVARS%nsquared) )                   call setup(this%smooth_nsquared,          this%grid_smooth_nsquared)
         if (0<opt%vars_to_allocate( kVARS%water_vapor) )                call setup(this%water_vapor,              this%grid,     forcing_var=opt%parameters%qvvar,      list=this%variables_to_force, force_boundaries=.True.)
         if (0<opt%vars_to_allocate( kVARS%potential_temperature) )      call setup(this%potential_temperature,    this%grid,     forcing_var=opt%parameters%tvar,       list=this%variables_to_force, force_boundaries=.True.)
         if (0<opt%vars_to_allocate( kVARS%cloud_water) )                call setup(this%cloud_water_mass,         this%grid,     forcing_var=opt%parameters%qcvar,      list=this%variables_to_force, force_boundaries=.True.)
@@ -2157,6 +2158,9 @@ contains
 
         call this%u_grid%set_grid_dimensions(       nx_global, ny_global, nz_global, nx_extra = 1)
         call this%v_grid%set_grid_dimensions(       nx_global, ny_global, nz_global, ny_extra = 1)
+
+        call this%grid_smooth_nsquared%set_grid_dimensions(nx_global, ny_global, nz_global, &
+             halo_width = (nsmooth+2)*2)
 
         ! for 2D mass variables
         call this%grid2d%set_grid_dimensions(       nx_global, ny_global, 0)

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -2160,7 +2160,7 @@ contains
         call this%v_grid%set_grid_dimensions(       nx_global, ny_global, nz_global, ny_extra = 1)
 
         call this%grid_smooth_nsquared%set_grid_dimensions(nx_global, ny_global, nz_global, &
-             halo_width = (nsmooth+2)*2)
+             halo_width = options%lt_options%stability_window_size )
 
         ! for 2D mass variables
         call this%grid2d%set_grid_dimensions(       nx_global, ny_global, 0)

--- a/src/objects/exchangeable_h.f90
+++ b/src/objects/exchangeable_h.f90
@@ -24,6 +24,7 @@ module exchangeable_interface
     logical :: east_boundary=.false.
     logical :: west_boundary=.false.
     integer :: dtype=kREAL
+    integer :: halo_size
 
   contains
     private
@@ -34,6 +35,7 @@ module exchangeable_interface
     procedure, public :: exchange
     procedure, public :: exchange_u
     procedure, public :: exchange_v
+    procedure, public :: exchange_directional_sync
     procedure, public :: set_outputdata
     generic,   public :: initialize=>const
 
@@ -96,6 +98,11 @@ module exchangeable_interface
     module subroutine exchange_v(this)
       implicit none
       class(exchangeable_t), intent(inout) :: this
+    end subroutine
+
+    module subroutine exchange_directional_sync(this)
+        implicit none
+        class(exchangeable_t), intent(inout) :: this
     end subroutine
 
     module subroutine put_north(this)

--- a/src/objects/exchangeable_obj.f90
+++ b/src/objects/exchangeable_obj.f90
@@ -3,7 +3,6 @@ submodule(exchangeable_interface) exchangeable_implementation
   implicit none
 
   ! these are all global for a given image, so we save them in the module instead of in the individual objects
-  integer, save :: halo_size
   integer, save :: north_neighbor, south_neighbor
   integer, save :: east_neighbor, west_neighbor
   integer, save, allocatable :: neighbors(:)
@@ -16,10 +15,10 @@ contains
     type(variable_t),                intent(in),    optional :: metadata
     character(len=kMAX_NAME_LENGTH), intent(in),    optional :: forcing_var
 
-    integer :: err
+    integer :: err, halo_size
 
-    halo_size = grid%halo_size
-
+    this%halo_size = grid%halo_size
+    halo_size = this%halo_size
 
     this%north_boundary = (grid%yimg == grid%yimages)
     this%south_boundary = (grid%yimg == 1)
@@ -163,7 +162,9 @@ contains
 
   module subroutine exchange_v(this)
     class(exchangeable_t), intent(inout) :: this
-    integer :: n, nx, start
+
+    integer :: n, nx, start, halo_size
+    halo_size = this%halo_size
     !When exchanging for the v-field, we want a full exchange in the y-direction,
     ! and an exchange in the x-direction of just the outer-most values
     !Performing north/south communication before east/west so corner halo
@@ -203,7 +204,9 @@ contains
 
   module subroutine exchange_u(this)
     class(exchangeable_t), intent(inout) :: this
-    integer :: n, ny, start
+
+    integer :: n, ny, start, halo_size
+    halo_size = this%halo_size
     !When exchanging for the u-field, we want a full exchange in the x-direction,
     ! and an exchange in the y-direction of just the outer-most values
     !Performing north/south communication before east/west so corner halo
@@ -257,12 +260,32 @@ contains
     if (.not. this%west_boundary)  call this%retrieve_west_halo
   end subroutine
 
+  ! exchange north/south boundaries before exchanging east/west
+  module subroutine exchange_directional_sync(this)
+    class(exchangeable_t), intent(inout) :: this
+    if (.not. this%north_boundary) call this%put_north
+    if (.not. this%south_boundary) call this%put_south
+    sync images( neighbors )
+    if (.not. this%north_boundary) call this%retrieve_north_halo
+    if (.not. this%south_boundary) call this%retrieve_south_halo
+
+    sync images( neighbors ) ! north/south complete, perform east/west
+
+    if (.not. this%east_boundary)  call this%put_east
+    if (.not. this%west_boundary)  call this%put_west
+    sync images( neighbors )
+    if (.not. this%east_boundary)  call this%retrieve_east_halo
+    if (.not. this%west_boundary)  call this%retrieve_west_halo
+
+  end subroutine
+
   module subroutine put_north(this)
       class(exchangeable_t), intent(inout) :: this
-      integer :: n, nx
+
+      integer :: n, nx, halo_size
       n = ubound(this%data_3d,3)
       nx = size(this%data_3d,1)
-
+      halo_size = this%halo_size
       ! if (assertions) then
       !   !! gfortran 6.3.0 doesn't check coarray shape conformity with -fcheck=all so we verify with an assertion
       !   call assert( shape(this%halo_south_in(:nx,:,1:halo_size)[north_neighbor]) &
@@ -277,10 +300,10 @@ contains
   module subroutine put_south(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: start, nx
+      integer :: start, nx, halo_size
       start = lbound(this%data_3d,3)
       nx = size(this%data_3d,1)
-
+      halo_size = this%halo_size
       ! if (assertions) then
       !   ! gfortran 6.3.0 doesn't check coarray shape conformity with -fcheck=all so we verify with an assertion
       !   call assert( shape(this%halo_north_in(:nx,:,1:halo_size)[south_neighbor]) &
@@ -294,9 +317,10 @@ contains
   module subroutine retrieve_north_halo(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: n, nx
+      integer :: n, nx, halo_size
       n = ubound(this%data_3d,3)
       nx = size(this%data_3d,1)
+      halo_size = this%halo_size
 
       this%data_3d(:,:,n-halo_size+1:n) = this%halo_north_in(:nx,:,1:halo_size)
   end subroutine
@@ -304,19 +328,21 @@ contains
   module subroutine retrieve_south_halo(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: start, nx
+      integer :: start, nx, halo_size
       start = lbound(this%data_3d,3)
       nx = size(this%data_3d,1)
+      halo_size = this%halo_size
 
       this%data_3d(:,:,start:start+halo_size-1) = this%halo_south_in(:nx,:,1:halo_size)
   end subroutine
 
   module subroutine put_east(this)
       class(exchangeable_t), intent(inout) :: this
-      integer :: n, ny
+
+      integer :: n, ny, halo_size
       n = ubound(this%data_3d,1)
       ny = size(this%data_3d,3)
-
+      halo_size = this%halo_size
       ! if (assertions) then
       !   !! gfortran 6.3.0 doesn't check coarray shape conformity with -fcheck=all so we verify with an assertion
       !   call assert( shape(this%halo_west_in(1:halo_size,:,:ny)[east_neighbor])       &
@@ -331,10 +357,10 @@ contains
   module subroutine put_west(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: start, ny
+      integer :: start, ny, halo_size
       start = lbound(this%data_3d,1)
       ny = size(this%data_3d,3)
-
+      halo_size = this%halo_size
       ! if (assertions) then
       !   !! gfortran 6.3.0 doesn't check coarray shape conformity with -fcheck=all so we verify with an assertion
       !   call assert( shape(this%halo_east_in(1:halo_size,:,:ny)[west_neighbor])               &
@@ -349,9 +375,10 @@ contains
   module subroutine retrieve_east_halo(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: n, ny
+      integer :: n, ny, halo_size
       n = ubound(this%data_3d,1)
       ny = size(this%data_3d,3)
+      halo_size = this%halo_size
 
       this%data_3d(n-halo_size+1:n,:,:) = this%halo_east_in(1:halo_size,:,1:ny)
   end subroutine
@@ -359,9 +386,10 @@ contains
   module subroutine retrieve_west_halo(this)
       class(exchangeable_t), intent(inout) :: this
 
-      integer :: start, ny
+      integer :: start, ny, halo_size
       start = lbound(this%data_3d,1)
       ny = size(this%data_3d,3)
+      halo_size = this%halo_size
 
       this%data_3d(start:start+halo_size-1,:,:) = this%halo_west_in(1:halo_size,:,1:ny)
   end subroutine

--- a/src/physics/linear_winds.f90
+++ b/src/physics/linear_winds.f90
@@ -978,7 +978,10 @@ contains
 
         ! smooth array has it's own parallelization, so this probably can't go in a critical section
         if (smooth_nsq) then
-            call smooth_array(nsquared, winsz, ydim=3)
+            domain%smooth_nsquared%data_3d(ims:ime,:,jms:jme) = nsquared(:,:,:)
+            call domain%smooth_nsquared%exchange_directional_sync()
+            call smooth_array(domain%smooth_nsquared%data_3d, winsz, ydim=3)
+            nsquared(:,:,:) = domain%smooth_nsquared%data_3d(ims:ime,:,jms:jme)
         endif
 
         !$omp parallel firstprivate(ims, ime, jms, jme, ims_u, ime_u, jms_v, jme_v, kms, kme, nx,nxu,ny,nyv,nz), &


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: halo exchange, smoothing, linear winds

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES:  bugfixes: 
1. `halo_size` changed from module variable to exchangeable_t type variable. Previous behavior meant the value used by the last grid to set halo_size was used for every exchangeable object going forward. Procedures that had used `halo_size` now have the additional line `halo_size = this%halo_size`, which fixes behavior without `this%` word "pollution".
2. wind=1 physics option was failing n-cores test due to smoothing behavior [here](https://github.com/NCAR/icar/blob/1bc194b245bb9115331e14ccaec3f29d472e3258/src/physics/linear_winds.f90#L981). New larger exchange_obj variable used to cover the extra area needed for the smooth function to pass n-cores tests. This smoothing exxchange object can possibly can be reused other places if smoothing is causing issues. A new exchange subroutine has been added to perform north-south halo exchanges before performing east-west ones. This is to ensure halo regions from diagonal images are exchanged. The function is called `exchange_directional_sync`, this can be called something else if a different name is preferable. 

TESTS CONDUCTED: Performed 32 and 36 image runs to plot the difference of the u-variable. The difference is shown in the following plot.
<img width="555" alt="pr-fix-16hr" src="https://github.com/NCAR/icar/assets/5750642/0aeec2cd-edfc-45cb-8339-b764281b0763">


This is the difference after 16 hours for the `develop` branch. Thus this PR improves the n-core output.
<img width="534" alt="develop-16hr" src="https://github.com/NCAR/icar/assets/5750642/dd36755a-f771-4c45-88f5-0cb76d7a7e65">



Performance runs where done using `debugslow` mode. The impact of the data movement and extra smooth calculations from using a larger array is shown in the following table comparing develop branch to pr-fix:
<img width="811" alt="performance" src="https://github.com/NCAR/icar/assets/5750642/156244d3-d877-434d-91cc-331fc7eb9147">



NOTES: This PR fix does not produce n-core equality without two additional steps. The following two changes discussed would produce near equality after an hour run (there were two grid cells that would differed by `-1.1920929e-07` and `-5.9604645e-08` on the lowest 5 of 25 levels). The following two changes were only for testing.
1. Comment out the `smooth_array` lines from [here](https://github.com/NCAR/icar/blob/14c226235db364ed05daffb038400c320fdd297f/src/objects/domain_obj.f90#L2771) and [here](https://github.com/NCAR/icar/blob/14c226235db364ed05daffb038400c320fdd297f/src/objects/domain_obj.f90#L2792).
2. This causes differences shown in the following plot. This is due to differing timesteps between images. Adding `seconds = 45.0` to [time_step.f90](https://github.com/NCAR/icar/blob/1bc194b245bb9115331e14ccaec3f29d472e3258/src/main/time_step.f90#L418). This will now remove the following differences so the user can pass the n-core test.
<img width="555" alt="nosmooth-fix-ncore-difference-1hr" src="https://github.com/NCAR/icar/assets/5750642/10ef8f0f-3fa7-4b10-b335-6967b228cb35">





### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
