### PR TITLE
Check if output and restart file path is writeable

### DIFF
--- a/src/io/io_routines.f90
+++ b/src/io/io_routines.f90
@@ -1619,4 +1619,28 @@ contains
         if (present(unit)) unit=io_newunit
     end function io_newunit
 
+    !>------------------------------------------------------------
+    !! Checks if path exists from filename string
+    !!
+    !! If directory does not exist print error message and stop program
+    !!
+    !! @param filename string of path to write output/restart files to
+    !!
+    !!------------------------------------------------------------
+    subroutine check_writeable_path(filename)
+        use icar_constants, only : kMAX_FILE_LENGTH
+        implicit none
+        character(len=kMAX_FILE_LENGTH), intent(in) :: filename
+        character(len=kMAX_FILE_LENGTH) :: dir_path
+        integer :: dir_separator
+        logical :: dir_exists
+        dir_separator = index(filename, '/', back=.true.)
+        if (dir_separator > 0) then
+            dir_path = filename(1:dir_separator)
+            inquire(file=dir_path, exist=dir_exists)
+            if (dir_exists .eqv. .false.) then
+               stop "Following directory does not exist to write to: " // dir_path
+            end if
+         end if
+    end subroutine check_writeable_path
 end module io_routines

--- a/src/makefile
+++ b/src/makefile
@@ -745,7 +745,7 @@ $(BUILD)pbl_utilities.o:$(UTIL)pbl_utilities.f90 $(BUILD)icar_constants.o 	\
 #	I/O routines
 ###################################################################
 
-$(BUILD)io_routines.o:$(IO)io_routines.f90 $(BUILD)data_structures.o
+$(BUILD)io_routines.o:$(IO)io_routines.f90 $(BUILD)data_structures.o $(BUILD)icar_constants.o
 
 $(BUILD)lt_lut_io.o: $(IO)lt_lut_io.f90 $(BUILD)data_structures.o $(BUILD)io_routines.o \
 				$(BUILD)string.o $(BUILD)opt_types.o $(BUILD)icar_constants.o

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -4,7 +4,7 @@ submodule(options_interface) options_implementation
                                            kNO_STOCHASTIC, kVERSION_STRING, kMAX_FILE_LENGTH, kMAX_NAME_LENGTH, pi, &
                                            kWATER_LAKE, &
                                            kWIND_LINEAR, kLINEAR_ITERATIVE_WINDS, kITERATIVE_WINDS, kCONSERVE_MASS
-    use io_routines,                only : io_newunit
+    use io_routines,                only : io_newunit, check_writeable_path
     use time_io,                    only : find_timestep_in_file
     use time_delta_object,          only : time_delta_t
     use time_object,                only : Time_type
@@ -510,7 +510,7 @@ contains
         restart_file = get_image_filename(this_image(), restart_file, restart_time)
         restart_step = find_timestep_in_file(restart_file, 'time', restart_time, time_at_step)
 
-        ! check to see if we actually udpated the restart date and print if in a more verbose mode
+        ! check to see if we actually updated the restart date and print if in a more verbose mode
         if (options%debug) then
             if (restart_time /= time_at_step) then
                 if (this_image()==1) write(*,*) " updated restart date: ", trim(time_at_step%as_string())
@@ -702,9 +702,12 @@ contains
             options%restart_count = max(24, nint(restartinterval))
         endif
 
+        ! check if directory paths to output and restart file strings exist
+        ! stop and report error if they do not rather than failing at write step
+        call check_writeable_path(output_file)
+        call check_writeable_path(restart_file)
         options%output_file = output_file
         options%restart_file = restart_file
-
 
     end subroutine output_namelist
 


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: IO Files, Namelist Validation

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: New subroutine checks if output and restart file paths are writeable. When the namelist is read, the existence of the directories where the output and restart files are being written to is checked. If they do not exist the routine will report error then, rather than throwing an error later when the NetCDF library tries to write to the file.

TESTS CONDUCTED: Checked that the subroutine functioned correctly for the following input file strings
``` Fortran
output_file = "output/foo/icar_out_"
output_file = "output/icar_out_"
output_file = "output//icar_out_"
output_file = "./icar_out_"
output_file = "icar_out_"
```

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
