### PR TITLE
Compile with ifx on Derecho

### DIFF
--- a/src/io/io_routines.f90
+++ b/src/io/io_routines.f90
@@ -1637,9 +1637,16 @@ contains
         dir_separator = index(filename, '/', back=.true.)
         if (dir_separator > 0) then
             dir_path = filename(1:dir_separator)
+
+! Intel compiler has non-standard conforming 'directory' argument
+#ifdef __INTEL_COMPILER
+            inquire(directory=dir_path, exist=dir_exists)
+#else
             inquire(file=dir_path, exist=dir_exists)
+#endif
             if (dir_exists .eqv. .false.) then
-               stop "Following directory does not exist to write to: " // dir_path
+               print *, "Following directory does not exist to write to: ", dir_path
+               stop "Error: unwritable file path"
             end if
          end if
     end subroutine check_writeable_path

--- a/src/io/output_obj.f90
+++ b/src/io/output_obj.f90
@@ -2,6 +2,7 @@ submodule(output_interface) output_implementation
     ! use icar_constants,     only : kREAL, kDOUBLE ! these are included in output_interface already
     use output_metadata,    only : get_metadata
     use time_io,            only : get_output_time
+    use time_object,        only : Time_type
     implicit none
 
 contains

--- a/src/makefile
+++ b/src/makefile
@@ -136,6 +136,9 @@ ifndef COMPILER
 	ifeq ($(F90),ifort)
 		COMPILER=intel
 	endif
+	ifeq ($(F90),ifx)
+		COMPILER=intel
+	endif
 	ifeq ($(F90),ftn)
 		COMPILER=cray
 	endif
@@ -203,7 +206,7 @@ endif
 # Various compiling options.  Set the MODE variable with "make MODE=debugslow" etc.
 ifeq ($(MODE), debugslow)
 	ifeq ($(COMPILER), intel)
-		COMP= -debug -debug-parameters all -traceback -ftrapuv -g -fpe0 -c -u -check all -check noarg_temp_created -CB
+		COMP= -debug -O0 -debug-parameters all -traceback -ftrapuv -g -fpe0 -c -u -check all -check noarg_temp_created -CB
 		LINK=
 	endif
 	ifeq ($(COMPILER), gnu)
@@ -334,6 +337,7 @@ $(info $$FFTW_PATH   = ${FFTW_PATH})
 $(info $$NCDF_PATH   = ${NCDF_PATH})
 $(info $$GIT_VERSION = ${GIT_VERSION})
 $(info $$COMP        = ${COMP})
+$(info $$CAF_FLAG    = ${CAF_FLAG})
 $(info $$LINK        = ${LINK})
 $(info $$MODE        = ${MODE})
 

--- a/src/objects/boundary_obj.f90
+++ b/src/objects/boundary_obj.f90
@@ -15,7 +15,8 @@ submodule(boundary_interface) boundary_implementation
     use mod_atm_utilities,      only : rh_to_mr, relative_humidity, compute_3d_p, compute_3d_z, exner_function
     use geo,                    only : standardize_coordinates
     use vertical_interpolation, only : vLUT, vinterp
-
+    use time_object,            only : Time_type
+    use variable_interface,     only : variable_t
     implicit none
 contains
 

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -16,7 +16,8 @@ submodule(domain_interface) domain_implementation
     use io_routines,          only : io_read, io_write
     use geo,                  only : geo_lut, geo_interp, geo_interp2d, standardize_coordinates
     use array_utilities,      only : array_offset_x, array_offset_y, smooth_array, make_2d_x, make_2d_y
-    use vertical_interpolation,only : vinterp, vLUT
+    use vertical_interpolation,only: vinterp, vLUT
+    use variable_interface,   only : variable_t
 
     implicit none
 
@@ -1016,7 +1017,7 @@ contains
             ! ( Although an argument could be made to calculate this on the offset (u/v) grid b/c that is most
             !   relevant for advection? In reality this is probably a sufficient approximation, as long as we
             !   aren't pushing the gamma factor too close to zero )
-            allocate(gamma_n(this%kms : max_level))  
+            allocate(gamma_n(this%kms : max_level))
 
 
             i=kms
@@ -1027,7 +1028,7 @@ contains
                 * COSH((smooth_height/s2)**n) / SINH((smooth_height/s2)**n)
             if (options%parameters%debug .and. this_image()==1) write(*,*) " k, gamma: ", i, gamma_n(i)
 
-            ! do i = this%grid%kds, this%grid%kde 
+            ! do i = this%grid%kds, this%grid%kde
             do i = this%grid%kms, max_level-1 ! account for flat z < 0, otherwise gamma can blow up if flat z < 0.
                 gamma_n(i+1)  =  1                                    &    ! # for i != kds !!
                 - MAXVAL(h1) * n/(s1**n) * sum(dz_scl(1:i))**(n-1)                                             &

--- a/src/physics/water_simple.f90
+++ b/src/physics/water_simple.f90
@@ -80,10 +80,10 @@ contains
         z0 = 8e-6 / max(ustar,1e-7)
     end function ocean_roughness
 
-    module subroutine water_simple(options, sst, psfc, wind, ustar, qv, temperature,  &
+    subroutine water_simple(options, sst, psfc, wind, ustar, qv, temperature, &
                             sensible_heat, latent_heat, &
                             z_atm, Z0, landmask, &
-                            qv_surf, evap_flux, tskin, vegtype ) 
+                            qv_surf, evap_flux, tskin, vegtype )
         implicit none
         type(options_t),intent(in)    :: options
         real,    dimension(:,:,:),intent(in)    :: qv, temperature

--- a/src/utilities/co_utilities.f90
+++ b/src/utilities/co_utilities.f90
@@ -431,9 +431,13 @@ contains
         integer,          intent(in)    :: source_image, first_image, last_image
         logical,          intent(in)    :: create_co_array
 
+! ifx currently breaks when accessing allocatable character coarrays
+#ifdef __INTEL_LLVM_COMPILER
+        character(len=kMAX_STRING_LENGTH), save :: coscalar[*]
+#else
         character(len=kMAX_STRING_LENGTH), allocatable :: coscalar[:]
-
         allocate(coscalar[*])
+#endif
         coscalar = scalar
 
         !call co_broadcast(coscalar, source_image)
@@ -442,7 +446,9 @@ contains
         call broadcast(coscalar, source_image, first_image, last_image)
 
         scalar = coscalar
+#ifndef __INTEL_LLVM_COMPILER
         deallocate(coscalar)
+#endif
     end subroutine
 
     subroutine print_in_image_order(input)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ifx, compiler, Derecho

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: 

- Intel compilers use non-standard argument `inquire(directory=dir,...)` to check if a directory exists.
- ifx needed additional use statement for certain functions. 
- coscalar allocatable character array causes ICE in ifx.
- 'module subroutine water_simple' needed to be 'subroutine water_simple', seemingly so 'module module_water_simple' doesn't clash in compiler symbol table 
- Added `-O0` to Intel's debugslow so the following message won't be shown everytime a file is compiled: `ifx: remark #10440: Note that use of a debug option without any optimization-level option will turnoff most compiler optimizations similar to use of '-O0'`


TESTS CONDUCTED: built and ran test case on Derecho with ifx (distributed and shared arguments), GNU, and Cray compilers

NOTE: Results from testcase with the different compilers on 1 Derecho node:


| compiler          | num_images | total (s) |  init | input | output | physics | 
| -------------- | ------------ | ---------- | ---- | ----- | ------ | ------- | 
| ifx distributed |        128 |      100.1 | 65.3 |  6.6 |    0.1 |    28.1 | 
| ifx shared        |        128 |      99.7 |  65.7 |  6.4   |  0.2 |  27.5 |  
| gnu                  |        128 |      117.2 | 71.7 |  6.7 |    0.2 |    38.5 |  
| cray                 |        128 |       81.8 |  65.9   |   7.0  |    0.2 |    9.0 |  


<!-- - Cray 256 image error: `LIBSMA ERROR: "fi_domain(smat_ofi_global.fabric, _smati_selected_prov, &smat_ofi_global.domain, NULL)" failed with -22: "Invalid argument"` -->

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
