### PR TITLE
New feature: non-coarray LUT

### DIFF
--- a/src/io/io_routines.f90
+++ b/src/io/io_routines.f90
@@ -186,7 +186,7 @@ contains
         implicit none
         ! This is the name of the data_in file and variable we will read.
         character(len=*),  intent(in)  :: filename, varname
-        real, allocatable, intent(inout) :: data_in(:,:,:,:,:,:)[:]
+        real, allocatable, intent(inout) :: data_in(:,:,:,:,:,:)
         integer, optional, intent(in)  :: extradim
 
         integer, dimension(io_maxDims)  :: diminfo !will hold dimension lengths
@@ -205,7 +205,7 @@ contains
         call io_getdims(filename,varname,diminfo)
 
         if (allocated(data_in)) deallocate(data_in)
-        allocate(data_in(diminfo(2),diminfo(3),diminfo(4),diminfo(5),diminfo(6),diminfo(7))[*])
+        allocate(data_in(diminfo(2),diminfo(3),diminfo(4),diminfo(5),diminfo(6),diminfo(7)))
 
         ! Open the file. NF90_NOWRITE tells netCDF we want read-only access to the file.
         call check(nf90_open(filename, NF90_NOWRITE, ncid),filename)

--- a/src/io/lt_lut_io.f90
+++ b/src/io/lt_lut_io.f90
@@ -59,7 +59,7 @@ contains
     function write_lut(filename, uLUT, vLUT, dz, options) result(error)
         implicit none
         character(len=*), intent(in) :: filename
-        real, dimension(:,:,:,:,:,:), intent(in) :: uLUT[*], vLUT[*]
+        real, dimension(:,:,:,:,:,:), intent(in) :: uLUT, vLUT
         real, dimension(:),           intent(in) :: dz
         type(lt_options_type),        intent(in) :: options
         integer :: error
@@ -134,7 +134,7 @@ contains
     function read_LUT(filename, uLUT, vLUT, dz, dims, options) result(error)
         implicit none
         character(len=*), intent(in) :: filename
-        real, allocatable, dimension(:,:,:,:,:,:), intent(inout) :: uLUT[:], vLUT[:]
+        real, allocatable, dimension(:,:,:,:,:,:), intent(inout) :: uLUT, vLUT
         real, dimension(:), intent(in) :: dz
         integer, dimension(3,2), intent(in) :: dims
         type(lt_options_type), intent(in) :: options

--- a/src/makefile
+++ b/src/makefile
@@ -195,7 +195,7 @@ endif
 ifeq ($(COMPILER), cray)
 	COMP= -h omp vector2 -O2 -c -eI -hfp0
 	LINK= -fopenmp
-	PREPROC= -eZ
+	PREPROC= -eT
 	MODOUTPUT= -J $(BUILD) -em
 endif
 
@@ -213,7 +213,7 @@ ifeq ($(MODE), debugslow)
 	ifeq ($(COMPILER), cray)
 		COMP=-h noomp -c -g -h develop -m 0 -R csp -M 399 -hfp0
 		LINK=-h noomp
-		PREPROC=-eZ
+		PREPROC=-eT
 		MODOUTPUT=-e m -J $(BUILD)
 	endif
 endif
@@ -229,7 +229,7 @@ ifeq ($(MODE), debug)
 	ifeq ($(COMPILER), cray)
 		COMP=-O2 -h noomp -c -g -hfp0
 		LINK=-h noomp
-		PREPROC=-eZ
+		PREPROC=-eT
 		MODOUTPUT=-e m -J $(BUILD)
 	endif
 endif
@@ -246,7 +246,7 @@ ifeq ($(MODE), debugompslow)
 	ifeq ($(COMPILER), cray)
 		COMP=-c -g -m 0 -h develop -R csp -M 399 -hfp0
 		LINK=
-		PREPROC=-eZ
+		PREPROC=-eT
 		MODOUTPUT=-e m -J $(BUILD)
 	endif
 endif
@@ -263,7 +263,7 @@ ifeq ($(MODE), debugomp)
 	ifeq ($(COMPILER), cray)
 		COMP=-O1 -c -g -hfp0
 		LINK=
-		PREPROC=-eZ
+		PREPROC=-eT
 		MODOUTPUT=-e m -J $(BUILD)
 	endif
 endif
@@ -454,7 +454,6 @@ TEST_EXECUTABLES= 	fftshift_test			\
 
 icar:${OBJS} $(BUILD)driver.o
 	${LINKER} $^ -o icar ${LFLAGS}
-	make move_i
 
 all:icar test
 
@@ -462,18 +461,15 @@ install:icar
 	mkdir -p ${INSTALLDIR}
 	${CP} icar ${INSTALLDIR}
 
-move_i:
-	$(ECHO_MOVE) *.i ${BUILD} 2>/dev/null || true
-
 clean:
-	${RM} $(BUILD)*.o $(BUILD)*.mod $(BUILD)*.smod *.i *.lst docs/doxygen_sqlite3.db 2>/dev/null ||:
+	${RM} $(BUILD)*.o $(BUILD)*.mod $(BUILD)*.smod *.lst docs/doxygen_sqlite3.db 2>/dev/null ||:
 
 allclean:cleanall
 
 cleanall:clean
 	${RM} icar $(TEST_EXECUTABLES) 2>/dev/null ||:
 
-test: $(TEST_EXECUTABLES) move_i
+test: $(TEST_EXECUTABLES)
 
 caf_tests:	$(CAF_TEST_EXECUTABLES)
 

--- a/src/objects/options_obj.f90
+++ b/src/objects/options_obj.f90
@@ -1554,6 +1554,9 @@ contains
                 endif
             endif
 
+            ! check if directory paths to LUT file strings exist, if not fails before write step
+            call check_writeable_path(u_LUT_Filename)
+            call check_writeable_path(v_LUT_Filename)
             opt%u_LUT_Filename = u_LUT_Filename
             opt%v_LUT_Filename = v_LUT_Filename
             opt%overwrite_lt_lut = overwrite_lt_lut


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: LUT, look-up table, coarrays

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: 
- The large LUT coarray has been changed to a regular array and two new smaller coarrays are used to communicate the data. This change has been done so the Cray compiler on Derecho can handle large LUT files.
- added check if to see if LUT file paths are writeable when reading namelist options
- there were issues with Crays debugslow mode causing issues with the the namelist being read incorrectly. Seems to be from the `-eZ` preprocessor option creating `.i` files mixed with some other compile options. The new preprocessor option is now `-eT`. The following shows the different preprocessor options and their descriptions
- Preprocessing flags: 
   - `-eT` Control  preprocessing of Fortran source files. When enabled, source  preprocessing is performed. Macro expansion within Fortran source lines  is enabled but can be controlled by the -e/d F command line option. When disabled (-dT), preprocessing of the Fortran source file is not performed, even for files with upper case suffixes such as file.F90.
   - `-eZ`  Perform source preprocessing and compilation on Fortran source files. When specified, source code is included by both #include directives and Fortran INCLUDE lines. Generates file file.i, which contains the source code after the preprocessing has been performed and the effects applied to the source program.
   - `-eP` Perform source preprocessing on Fortran source files but do not compile. When specified, source code is included by #include directives but not by Fortran INCLUDE lines. Generates file.i, which contains the source code after the preprocessing has been performed and the effects applied to the source program. If the -o out_fileargument is also specified, the preprocessed source is written to out_file instead of file.i.
   - `-eF` Control preprocessor expansion of macros in Fortran source lines.



TESTS CONDUCTED: 
 - A Cray `6km_conus_west.nc` testcase that broke on Derecho from lack of memory now runs. 
 - Ran the PR executable and the upstream executable with 1,2,4,8 cores. I then compared the resulting look-up table files and they were always identical between the PR and upstream output. Note, this set of comparisons was done with the idealized test case and the following lt_parameters
```
&lt_parameters
n_dir_values=2,
n_spd_values=2,
n_nsq_values=2,
buffer = 2,               
stability_window_size = 1,    
vert_smooth = 1,
variable_N = False,
read_LUT  = True,  
write_LUT = True,  
LUT_filename = "Lineary_Theory_LUT.nc"
/
```


### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Fully documented
