### PR TITLE
Bugfix: Cray logical derived type member values

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -328,6 +328,14 @@ ASSERT=-DUSE_ASSERTIONS=$(USE_ASSERTIONS)
 LFLAGS=$(LINK) $(PROF) $(CAF_FLAG) $(CAF_LINK) $(LIBNETCDF) $(LIBFFT)
 FFLAGS=$(COMP) $(PROF) $(CAF_FLAG) $(PREPROC) -DVERSION=\"$(GIT_VERSION)\" $(INCNETCDF) $(INCFFT) $(MODOUTPUT) $(ASSERT)
 
+# this line is to handle the fact the Cray compiler does optimizations that
+# make setting logical values in derived types unrealiable in options_obs.F90
+ifeq ($(COMPILER), cray)
+	OPTIONS_FLAGS=${FFLAGS} -O0
+else
+	OPTIONS_FLAGS=${FFLAGS}
+endif
+
 $(info $$NODENAME    = ${NODENAME})
 $(info $$FC          = ${F90})
 $(info $$FFTW_PATH   = ${FFTW_PATH})
@@ -591,6 +599,9 @@ caf_threads_test: $(BUILD)test_caf_threads.o
 ###################################################################
 #	Generic compilation rules
 ###################################################################
+
+$(BUILD)options_obj.o: $(OBJECTS)options_obj.f90
+	${F90} ${OPTIONS_FLAGS} $< -o $@
 
 $(BUILD)%.o: $(UTIL)%.f90
 	${F90} ${FFLAGS} $< -o $@


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: derived types, logical types, hack

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: If using the Cray compiler, turn off optimization when compiling the `options_obj.f90` file.

TESTS CONDUCTED: Add the following lines to line 1930 of `options_obj.f90`.
```
        print*, "use_simple_sw, options%rad_options%use_simple_sw, rad_options%use_simple_sw"
        print*, use_simple_sw, options%rad_options%use_simple_sw, rad_options%use_simple_sw
stop "debugging"
```

NOTE: The `-eo` compiler option lists all the optimization flags. Since `-O0` works and `-O1` does not, I could test each flag that is different individually to find which one is breaking this test. Might be worth it in case the optimization would break things somewhere else. I had previously tried to create a simple reproducer but have been unsuccessful since this issue probably has to do with the complexity of derived types/modules/submodules being used. But it might be worth it to try to create one to add to the CTests (this is a branch that has CTests but is waiting for good ones before it becomes a PR).

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
