### PR TITLE
bugfix: CAMtr_volume_mixing_ratio read issue

### DIFF
--- a/src/physics/ra_clWRF_support.f90
+++ b/src/physics/ra_clWRF_support.f90
@@ -11,6 +11,7 @@
 !-----------------------------------------------------------------------
 MODULE module_ra_clWRF_support
 
+  use iso_fortran_env, only: iostat_end
   !USE module_wrf_error
 
   IMPLICIT NONE
@@ -113,6 +114,7 @@ CONTAINS
     !INTEGER, EXTERNAL                                :: get_unused_unit
 
     INTEGER                                          :: istatus, iunit, idata
+    CHARACTER(LEN=1024)                              :: imessage
 !ccc VARCAM_in_years is a module variable, needs something else here!
     INTEGER, SAVE                             :: max_years
     integer                                          :: nyrm, nyrp, njulm, njulp
@@ -151,7 +153,7 @@ CONTAINS
              istatus = 0
              idata = 1
              DO WHILE (istatus == 0)
-                READ(UNIT=iunit, FMT='(I4, 1x, F8.3,1x, 4(F10.3,1x))', IOSTAT=istatus)    &
+                READ(UNIT=iunit, FMT='(I4, 1x, F8.3,1x, 4(F10.3,1x))', IOSTAT=istatus, IOMSG=imessage) &
                      yrdata(idata), co2r(idata), n2or(idata), ch4r(idata), cfc11r(idata), &
                      cfc12r(idata)
                 if (istatus==0) then
@@ -171,10 +173,10 @@ CONTAINS
              END DO
              if (this_image()==1) print*,"CLWRF read:",idata-1, " lines"
 
-             IF (istatus /= -1) THEN
+             IF (istatus /= iostat_end) THEN
                 PRINT *,'CLWRF -- clwrf -- CLWRF ALERT!'
                 PRINT *,"   Not normal ending of 'CAMtr_volume_mixing_ratio' file"
-                PRINT *,"   Lecture ends with 'IOSTAT'=",istatus
+                PRINT *,"   Lecture ends with 'IOSTAT'=",istatus, "and IOMSG=", trim(imessage)
              END IF
              max_years = idata - 1
              CLOSE(iunit)


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: read file, iso_fortran_env

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: The iso_fortran_env constant `iostat_end` has replaced the traditional, but not defined by the Fortran standard, `-1` to mean the end-of-file has been reached. This fix reflects that change that is starting to appear in some compilers.

TESTS CONDUCTED: The `CLWRF -- clwrf -- CLWRF ALERT!` [statement](https://github.com/scrasmussen/icar/blob/f295303f7eb19f6971714e4c3ff8e103c9026ef1/src/physics/ra_clWRF_support.f90#L177-L179) had started appearing with the Cray compiler 15.0.1, without any change to the "CAMtr_volume_mixing_ratio.SSP245" input file. This warning message is not showing up anymore.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between
  each of the square brackets if they are completed in the PR itself. If a
  bullet is not relevant to you, please comment on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
