### PR TITLE
Bugfix: negative precip

### DIFF
--- a/helpers/aggregate_parallel_files.py
+++ b/helpers/aggregate_parallel_files.py
@@ -159,6 +159,23 @@ def agg_file(first_file, verbose=True):
     print(outputfile)
     data_set.to_netcdf(outputfile)
 
+# removing the last aggregated file to fix negative precip
+def remove_last_two_aggregated_files(file_search):
+    # switch from looking for every ranks output to every aggregated file
+    aggregated_file_search = file_search.replace("_*", "-*")
+    last_file_search = aggregated_file_search.format(ens="[1-2][0-9][0-9][0-9]")
+    sorted_aggregated_files = sorted(glob.glob(last_file_search))
+
+    # if list is not empty, remove last two files
+    if sorted_aggregated_files:
+        last_aggregated_file = sorted_aggregated_files.pop()
+        os.remove(last_aggregated_file)
+        print("removed last aggregated file", last_aggregated_file)
+        if sorted_aggregated_files:
+            last_aggregated_file = sorted_aggregated_files.pop()
+            os.remove(last_aggregated_file)
+            print("removed second to last aggregated file", last_aggregated_file)
+
 def main(file_search = "icar_out_{ens}_*"):
     first_files = glob.glob(file_search.format(ens="000001"))
     first_files.sort()
@@ -166,6 +183,8 @@ def main(file_search = "icar_out_{ens}_*"):
     # For some reason running the parallelization this far out seems to have far worse performance...
     #  would map_async be faster for some reason?  I assume map is still parallel.
     # pool.map(agg_file, first_files)
+
+    remove_last_two_aggregated_files(file_search)
 
     for f in first_files:
         agg_file(f)

--- a/src/io/output_obj.f90
+++ b/src/io/output_obj.f90
@@ -48,14 +48,14 @@ contains
         if (.not.this%is_initialized) call this%init()
 
         err = 0
+        ! open file
         this%filename = filename
-        ! if hour of the day is 0 file will never be opened but clobbered if
-        ! it exists, otherwise open file
+        ! if hour of the day is 0 file will never be opened but clobbered if it exists, otherwise open file
         if (time%hour /= 0) then
            err = nf90_open(filename, NF90_WRITE, this%ncfile_id)
         end if
 
-        ! create new file if first output of the day or error opening
+        ! create new file if error opening or first output of the day
         if (err /= NF90_NOERR .or. (time%hour == 0)) then
             call check( nf90_create(filename, NF90_CLOBBER, this%ncfile_id), "Opening:"//trim(filename))
             this%creating=.True.

--- a/src/io/output_obj.f90
+++ b/src/io/output_obj.f90
@@ -47,10 +47,16 @@ contains
 
         if (.not.this%is_initialized) call this%init()
 
-        ! open file
+        err = 0
         this%filename = filename
-        err = nf90_open(filename, NF90_WRITE, this%ncfile_id)
-        if (err /= NF90_NOERR) then
+        ! if hour of the day is 0 file will never be opened but clobbered if
+        ! it exists, otherwise open file
+        if (time%hour /= 0) then
+           err = nf90_open(filename, NF90_WRITE, this%ncfile_id)
+        end if
+
+        ! create new file if first output of the day or error opening
+        if (err /= NF90_NOERR .or. (time%hour == 0)) then
             call check( nf90_create(filename, NF90_CLOBBER, this%ncfile_id), "Opening:"//trim(filename))
             this%creating=.True.
         else


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: restart, post-processing, negative precipitation

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 

**PROBLEM**: When restarting the end of an interrupted run, there would be sometimes be negative precipitation between consecutive timesteps. This occurred for two reasons:
- Output files: if an existing NetCDF output file was from an interrupted run, negative precip would happen during a restarted run to one of these existing files during it's next open and modify.
- Aggregated files: the aggregated script will only write if there isn't an aggregated file at a date. During an interrupted run this could lead to partial results, e.g. an aggregated file only having 18 hours of a day. Also, during testing it was found that negative precip occurs if the partial aggregated file **or** the _previous_ date's aggregated file exist. So the presence of either of the last two aggregated files would cause negative precip.
- See NOTES section for further discussion of the previous two points.

**FIX**: 
- Output files: if a file exists and it is hour 0 of the day, clobber the file to completely rewrite it, rather than trying to open and modify.
- Aggregated files: removes that last two aggregated files, if they exist, before recreating them and any new ones within an output directory.

TESTS CONDUCTED: Lots of tests restarting from interrupted files and/or different start dates and then comparing results.

NOTES: Unique things about the negative precipitation error:
- Negative precipitation in most cases would occur 24 hours after the restart, sometimes it would occur sooner.
<img width="350" alt="image" src="https://github.com/NCAR/icar/assets/5750642/19b77428-eb1b-45f1-973c-d41ad285dae6">

- Shifted restart dates led to differing results, e.g. comparing output from overlapping timestamps from day `x` restarts to day `x+1` restarts. It is important and relieving to note that restarts from the same date will lead to identical results. The reason for the differing shifted restart results is uncertain at this point.
    - There also seems to be a 24 hour component to this difference. In the current tests, the day `x` restart and day `x+1` restart were restarted from files produced in the same origin run. Day `x` was the same for the first 24 hours as the origin run, but then starts to differ at day `x+1` from the `x+1` restart run. Will do a restart at day `x-1` to compare between all.
- Negative precip occurred only once from interrupted files, rerunning the same case would fix the issue. This indicates that the outputted NetCDF files caused that issue, hence clobbering them provided a fix.
- It is possible removing all the aggregated files from the restart point on will need to be done. Looking at some existing tests seem to point to this not being needed though.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The
   issue describes and documents the problem and general solution, the PR
   describes the technical details of the solution.)
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
