### PR TITLE
Issue 182 Fix: Xarray Future Warning

### DIFF
--- a/helpers/aggregate_parallel_files.py
+++ b/helpers/aggregate_parallel_files.py
@@ -64,15 +64,15 @@ def set_up_dataset(d):
         x_off, y_off = get_dim_offset(dims)
 
         if len(dims) == 1:
-            nt = d.dims[dims[0]]
+            nt = d.sizes[dims[0]]
             data = np.zeros((nt))
         if len(dims) == 2:
             data = np.zeros((ny + y_off, nx + x_off))
         if len(dims) == 3:
-            data = np.zeros((d.dims[dims[0]], ny + y_off, nx + x_off))
+            data = np.zeros((d.sizes[dims[0]], ny + y_off, nx + x_off))
         if len(dims) == 4:
-            nt = d.dims[dims[0]]
-            nz = d.dims[dims[1]]
+            nt = d.sizes[dims[0]]
+            nz = d.sizes[dims[1]]
             data = np.zeros((nt, nz, ny + y_off, nx + x_off))
 
         # print(name, data.shape, dims, attrs)


### PR DESCRIPTION
TYPE: ~~bug~~ issue fix

KEYWORDS: Xarray, Python, Aggregation

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Fix for warning of a future switch in xarray. Just switched from `Dataset.dims` to `Dataset.sizes` in `aggregate_parallel_files.py` script to fix it. 

ISSUE: Fixes #182 

TESTS CONDUCTED: Compared results of new and previous aggregation script, they were identical.
```
$ nccmp -ds icar_out_2010-09-01_00-00-00.nc icar_out_2010-09-01_00-00-00.nc.orig
Files "icar_out_2010-09-01_00-00-00.nc" and "icar_out_2010-09-01_00-00-00.nc.orig" are identical.
```

### Checklist
 - [X] Closes issue #182 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
