### PR TITLE
GCC 13.2.0 ICE Bugfix: expanding out associate statements

### DIFF
--- a/src/main/time_step.f90
+++ b/src/main/time_step.f90
@@ -98,8 +98,8 @@ contains
         temperature_i(:, kms, :) = temperature(:, kms, :) + (temperature(:, kms, :) - temperature(:, kms+1, :)) / 2
 
         if (associated(domain%density%data_3d)) then
-            density =  pressure / &
-                        (Rd * temperature) ! kg/m^3
+            domain%density%data_3d =  domain%pressure%data_3d / &
+                        (Rd * domain%temperature%data_3d) ! kg/m^3
         endif
         if (associated(domain%u_mass%data_3d)) then
             u_mass = (u(ims+1:ime+1,:,:) + u(ims:ime,:,:)) / 2

--- a/src/objects/domain_obj.f90
+++ b/src/objects/domain_obj.f90
@@ -1016,7 +1016,7 @@ contains
             ! ( Although an argument could be made to calculate this on the offset (u/v) grid b/c that is most
             !   relevant for advection? In reality this is probably a sufficient approximation, as long as we
             !   aren't pushing the gamma factor too close to zero )
-            allocate(gamma_n(this%kms : max_level))  
+            allocate(gamma_n(this%kms : max_level))
 
 
             i=kms
@@ -1027,7 +1027,7 @@ contains
                 * COSH((smooth_height/s2)**n) / SINH((smooth_height/s2)**n)
             if (options%parameters%debug .and. this_image()==1) write(*,*) " k, gamma: ", i, gamma_n(i)
 
-            ! do i = this%grid%kds, this%grid%kde 
+            ! do i = this%grid%kds, this%grid%kde
             do i = this%grid%kms, max_level-1 ! account for flat z < 0, otherwise gamma can blow up if flat z < 0.
                 gamma_n(i+1)  =  1                                    &    ! # for i != kds !!
                 - MAXVAL(h1) * n/(s1**n) * sum(dz_scl(1:i))**(n-1)                                             &
@@ -1530,7 +1530,7 @@ contains
 
 
         ! create a separate variable that will be smoothed later on:
-        h1 =  global_terrain(this%grid2d%ids:this%grid2d%ide, this%grid2d%jds:this%grid2d%jde)
+        h1 =  this%global_terrain(this%grid2d%ids:this%grid2d%ide, this%grid2d%jds:this%grid2d%jde)
 
         ! offset the global terrain for the h_(u/v) calculations:
         call array_offset_x(global_terrain, temp_offset)

--- a/src/physics/lsm_driver.f90
+++ b/src/physics/lsm_driver.f90
@@ -358,7 +358,7 @@ contains
         !$omp end parallel
     end subroutine surface_diagnostics
 
-        subroutine apply_fluxes(domain,dt)
+    subroutine apply_fluxes(domain,dt)
         ! add sensible and latent heat fluxes to the first atm level
         implicit none
         type(domain_t), intent(inout) :: domain
@@ -407,7 +407,7 @@ contains
             lhdQV(i,j) = (lh_feedback_fraction * latent_heat(i,j) / LH_vaporization * dt) &
                     / (density(i,k,j) * sfc_layer_thickness)
             ! add water vapor in kg/kg
-            qv(i,k,j) = qv(i,k,j) + lhdQV(i,j) * layer_fraction
+            domain%water_vapor%data_3d(i,k,j) = domain%water_vapor%data_3d(i,k,j) + lhdQV(i,j) * layer_fraction
 
         end do ! i
         end do ! k


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: GNU 13, compiler

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Expanding out statements that use `associate` to fix ICE errors caused by compiling with GNU 13.2.0. There doesn't seem to be any unifying reason why it causes an ICE, other similar `associate` statements work correctly. This ICE error should eventually be fixed in the compiler and then this commit could be removed.

NOTES: The source code will compile now but the runtime is still broken on Derecho. Somehow the executable is loading an old version of the NetCDF library. This is odd because
- `ldd icar` shows the correct library is being loaded
- that library is not symlinked so it isn't pointing to the old library
- the path where the old library is is not in the compiler flags
- the old path is not if `LD_LIBRARY_PATH`