### PR TITLE
documentation: mkdocs broken links and Intel info

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,25 +1,25 @@
 # FAQ
-* [Are you planning on add the Cumulus, PBL or/and land surface schemes to the ICAR?](#Has-ICAR-include-Cumulus,-PBL-and-land-surface-schemes)
-* [Can I say that ICAR is an Hydrostatic model or a quasi-geostrophic approximated model?](#Is-ICAR-an-Hydrostatic-model-or-a-quasi-geostrophic-approximated-model)
-* [What are the limitations on using the 1st order approximation to solve the advection term?](#What-are-the-limitations-on-using-the-1st-order-approximation-to-solve-the-advection-term?)
-* [Is the LUT (Look Up Table) for the dry N^2 or both dry and moist N^2?](#Is-the-LUT-(Look-Up-Table)-for-the-dry-N^2-or-both-dry-and-moist-N^2)
-* [How do you include the soundings as an input?](#How-do-you-include-the-soundings-as-an-input?)
+* [Are you planning to add the Cumulus, PBL, or land surface schemes to ICAR?](#has-icar-included-cumulus-pbl-and-land-surface-schemes)
+* [Can I say that ICAR is an Hydrostatic model or a quasi-geostrophic approximated model?](#is-icar-an-hydrostatic-model-or-a-quasi-geostrophic-approximated-model)
+* [What are the limitations on using the 1st order approximation to solve the advection term?](#what-are-the-limitations-on-using-the-1st-order-approximation-to-solve-the-advection-term)
+* [Is the LUT (Look Up Table) for the dry N^2 or both dry and moist N^2?](#is-the-lut-look-up-table-for-the-dry-n2-or-both-dry-and-moist-n2)
+* [How do you include the soundings as an input?](#how-do-you-include-the-soundings-as-an-input)
 
-## Has ICAR include Cumulus, PBL and land surface schemes?
+## Has ICAR included Cumulus, PBL and land surface schemes?
 
-There is already a cumulus (Tiedtke), PBL (greatly simplified form of YSU), and LSM (Noah) in ICAR. 
+There is already a cumulus (Tiedtke), PBL (greatly simplified form of YSU), and LSM (Noah) in ICAR.
 
 ## Is ICAR an Hydrostatic model or a quasi-geostrophic approximated model?
 
-Not really. It isn’t a hydrostatic model, or a non-hydrostatic model.  
-That assumption doesn’t really come into the modeling framework. (ditto quasi-geostrophic).  
-To some extend it inherits those features from whatever model you use to force it though.  
+Not really. It isn’t a hydrostatic model, or a non-hydrostatic model.
+That assumption doesn’t really come into the modeling framework. (ditto quasi-geostrophic).
+To some extend it inherits those features from whatever model you use to force it though.
 
 ## What are the limitations on using the 1st order approximation to solve the advection term?
 
 Mostly that it ends up creating far too much diffusion, so fields such as water vapor get blurred out a little.
-If you look up the “upwind” scheme, or read one of the MP-DATA papers they will describe this effect.  
-Actually most papers that deal with advection will probably talk about this effect.  
+If you look up the “upwind” scheme, or read one of the MP-DATA papers they will describe this effect.
+Actually most papers that deal with advection will probably talk about this effect.
 
 ## Is the LUT (Look Up Table) for the dry N^2 or both dry and moist N^2?
 Both (and neither).  The atmosphere behaves (sort of) the same for a given N^2 whether it is dry or moist. So the LUT itself knows nothing about dry or moist; however, when ICAR runs it calculates the dry or moist N^2 depending on the atmospheric conditions, and uses that to get the correct perturbation from the LUT.

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -45,10 +45,13 @@ make -j 4
 
 #### GNU Compiler
 ``` bash
-module load gcc ncarenv/23.09 cray-mpich netcdf fftw opencoarrays
+module load ncarenv gcc cray-mpich netcdf fftw opencoarrays
 COMPILER=gnu make -j 4
 ```
 
+#### Intel Compiler
+<span style="color: red;">Warning</span>: ICAR will compile with `ifx` but not on Derecho.
+The Intel coarray implementation requires the Intel MPI library, which Derecho does not have.
 
 ### Derecho Debugging
 When running ICAR on larger domains there is a chance the program will run out of memory available for coarrays.


### PR DESCRIPTION
TYPE: fix


KEYWORDS: Derecho, Intel, ifx, broken links

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Fixed broken FAQ links and added a warning about ifx/intel not working on Derecho because the coarray implementation needs `impi`, which Derecho doesn't have.


TESTS CONDUCTED: Built locally with mkdocs
