### PR TITLE
hotfix: restrict CI to upstream

### DIFF
--- a/.github/workflows/icar-develop-commit.yml
+++ b/.github/workflows/icar-develop-commit.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build_and_test_ICAR:
+    if: github.repository == 'NCAR/icar'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/icar-main-commit.yml
+++ b/.github/workflows/icar-main-commit.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build_and_test_ICAR:
+    if: github.repository == 'NCAR/icar'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/icar-pull-request.yml
+++ b/.github/workflows/icar-pull-request.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_and_test_ICAR:
+    if: github.repository == 'NCAR/icar'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
TYPE: hotfix

KEYWORDS: CI, Github Actions

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Run CI only on upstream `NCAR/icar` repo, not forks. This is to prevent [charges to users](https://github.com/settings/billing).
